### PR TITLE
Aristotle golfing: scripts and shorter proof annotations

### DIFF
--- a/Lean/Polychromatic/FourThree/Combi.lean
+++ b/Lean/Polychromatic/FourThree/Combi.lean
@@ -16,43 +16,54 @@ The proof works in the cyclic group $\mathbb{Z}_m$ where $m = c - a + b$.
 As shown in §4 of the paper, the polychromaticity of $S$ in $\mathbb{Z}$ follows from
 its polychromaticity in $\mathbb{Z}_m$.
 
-The analysis splits into two main cases based on the subgroup structure of $\mathbb{Z}_m$
-relative to the differences in $S$:
+## Main results
 
-- **Case 1: Single Cycle (§4.1)**
-  This case occurs when at least one of $\gcd(b, m)$ or $\gcd(b-a, m)$ is 1.
-  The set $S$ is shown to be equivalent (via an affine transformation $x \mapsto ux + v$)
-  to a set of the form $\{0, 1, g, g+1\}$. The proof then branches:
-  - **(1a) Small $g$:** $g \in \{2, 3, 4\}$. Handled by the "Table 1" block colorings.
-  - **(1b) Interval Coloring:** For larger $g$, we partition $\mathbb{Z}_m$ into $s$
-    intervals (where $s$ is a multiple of 3) and use a repeating color pattern.
-  - **(1c/1d) Specific Residues:** When the interval bound is tight, we use multiplication
-    by 3 (if $3 \nmid m$) or explicit periodic colorings (if $3 \mid m$).
+- `normal_bit` — **the main theorem**: every normalized 4-element set admits a
+  3-polychromatic coloring. This is the entry point used by `Main.lean`.
 
-- **Case 2: Multiple Cycles (§4.2)**
-  This case occurs when both $d_1 = \gcd(b, m) > 1$ and $d_2 = \gcd(b-a, m) > 1$.
-  The group $\mathbb{Z}_m$ is viewed via the isomorphism
-  $\mathbb{Z}_{d_1} \times \mathbb{Z}_{e_1} \cong \mathbb{Z}_m$
-  (where $e_1 = m/d_1$). The set $S$ then interacts with two adjacent cycles in this
-  decomposition. Colorings are constructed cycle-by-cycle:
-  - **(2a) Even cycle length ($e_1$ even):** Parity-based alternation.
-  - **(2b) Even cycle count ($d_1$ even, $e_1$ odd):** Parity-based alternation with
-    a "degenerate" position fixup.
-  - **(2c/2d) Both odd:** Rotating color patterns based on a partition $e_1 = u+v+w$.
+## Proof structure
 
-## Infrastructure
+Let $d_1 = \gcd(b, m)$ and $d_2 = \gcd(b{-}a, m)$. The proof dispatches on whether
+one of these GCDs equals 1 (so the corresponding element generates all of
+$\mathbb{Z}_m$) or both are greater than 1 (so $\mathbb{Z}_m$ decomposes into
+shorter cycles):
 
-The file provides `blockColor_polychrom`, a general tool for proving polychromaticity of
-cyclic colorings formed by concatenating two types of blocks (lengths $r$ and $r+1$).
-This reduces the proof of polychromaticity to checking a finite number of block-pair
-boundaries, which is done using `decide`.
+- `main_case_one` — **Case 1: Single Cycle (§4.1).**
+  Applies when $\min(d_1, d_2) = 1$. The set reduces to $\{0,1,g,g{+}1\}$ via an
+  affine transformation (`exists_g_of_coprime`). Subcases by the gap parameter $g$:
+  - `case_one_small_g` — **(1a)** $g \in \{2,3,4\}$, via Table 1 block colorings.
+  - `case_one_interval` — **(1b)** General $g$, via interval coloring.
+  - `case_one_residues` — **(1c)** $3 \nmid m$, via multiplication by 3.
+  - `case_one_divisible` — **(1d)** $3 \mid m$, via explicit periodic colorings.
 
-## Completion status
+- `main_case_two` — **Case 2: Multiple Cycles (§4.2).**
+  Applies when both $d_1, d_2 > 1$. Setting $e_1 = m/d_1$, we use the isomorphism
+  $\mathbb{Z}_{d_1} \times \mathbb{Z}_{e_1} \cong \mathbb{Z}_m$ to define colorings
+  cycle-by-cycle. Subcases by the parity of $d_1$ and $e_1$:
+  - `case_two_e1_even` — **(2a)** $e_1$ even: parity-based alternation.
+  - `case_two_d1_even_e1_odd` — **(2b)** $d_1$ even, $e_1$ odd: alternation with fixup.
+  - `case_two_odd_small` — **(2c)** Both odd, $e_1 \le 17$: shifted periodic colorings.
+  - `case2d_coloring_works` — **(2d)** Both odd, $e_1 \ge 19$: rotating interval patterns.
 
-Total: 9 sorries (5 Table 1 + 1 interval + 3 Case 2)
+## File organization
+
+The file is organized into Lean `section`s:
+
+- `BlockColorInfra` — General tool (`blockColor_polychrom`) for proving polychromaticity
+  of cyclic colorings formed by concatenating two block sizes.
+- `Table1` — Concrete block colorings for six specific 4-element sets.
+- `Case1_SingleCycle` — Case 1 subcases (1a)–(1d) and their aggregation.
+- `Case2_MultipleCycles` — Case 2 subcases (2a)–(2d) and their aggregation.
+- `Assembly` — Glue connecting the $\mathbb{Z}_m$ analysis back to $\mathbb{Z}$,
+  culminating in `normal_bit`.
+
+Most `private` lemmas are modular arithmetic helpers or case-analysis plumbing.
+
 -/
 
 open Finset Pointwise
+
+/-! ## Preliminaries: the normalized set in ZMod m -/
 
 /--
 A helper to define the transformed set in ZMod m.
@@ -61,6 +72,8 @@ Corresponds to S = {0, b-a, b, 2b-a} in the informal text.
 def zmod_set (m : ℕ) (a b : ℤ) : Finset (ZMod m) :=
   ({0, b - a, b, 2 * b - a} : Finset ℤ).image Int.cast
 
+/-- Auxiliary: the polychromatic number is invariant under the translation that
+    maps `{0, a, b, c}` to `zmod_set m a b`. -/
 /- Aristotle alternative for `polychromNumber_zmod` (10 lines vs 12 original, -2).
 
 lemma polychromNumber_zmod {a b c : ℤ} {m : ℕ} (hm : m = c - a + b) :
@@ -95,20 +108,20 @@ lemma polychromNumber_zmod {a b c : ℤ} {m : ℕ} (hm : m = c - a + b) :
 
 /-- The set {0, b-a, b, 2b-a} is symmetric in the two repeated differences b and b-a:
     swapping them (replacing a by -a, b by b-a) gives the same set. -/
-lemma zmod_set_swap (m : ℕ) (a b : ℤ) :
-    zmod_set m (-a) (b - a) = zmod_set m a b := by
+lemma zmod_set_swap (m : ℕ) (a b : ℤ) : zmod_set m (-a) (b - a) = zmod_set m a b := by
   grind [zmod_set]
 
-/-! ## Block coloring infrastructure for Table 1
+/-! ## Block coloring infrastructure
 
-For each set S in Table 1 (paper §4), we define a block-based coloring:
-given blocks A (length r) and B (length r+1), concatenate h copies of A
-followed by k copies of B to color Z_m where m = r·h + (r+1)·k.
+Given blocks A (length r) and B (length r+1), concatenate h copies of A followed
+by k copies of B to color ℤ_m where m = r·h + (r+1)·k. Polychromaticity reduces
+to checking 4 block-pair boundaries (AA, AB, BA, BB), which is decidable for
+concrete blocks. The key result is `blockColor_polychrom` at the end of this section.
 
-The polychromaticity reduces to checking 4 block-pair boundaries (AA, AB, BA, BB),
-which is decidable for concrete blocks. The general theorem `blockColor_polychrom`
-proves that passing these checks implies cyclic polychromaticity.
+The remaining lemmas in this section are technical plumbing.
 -/
+
+section BlockColorInfra
 
 /--
 Check that every starting position in the list `L` hits all three colors {0, 1, 2}
@@ -118,8 +131,7 @@ that is handled by checking all possible block-pair concatenations.
 -/
 def checkLinearPolychrom (offsets : List ℕ) (L : List (Fin 3)) : Bool :=
   let maxOff := offsets.foldr max 0
-  (List.range (L.length - maxOff)).all fun i =>
-    ([0, 1, 2] : List (Fin 3)).all fun c =>
+  (List.range (L.length - maxOff)).all fun i => ([0, 1, 2] : List (Fin 3)).all fun c =>
       offsets.any fun s => L[i + s]? == some c
 
 /--
@@ -141,10 +153,8 @@ followed by some copies of block `B`.
 The resulting pattern colors $\mathbb{Z}_m$ where $m = h|A| + k|B|$.
 -/
 def blockColorVal (A B : List (Fin 3)) (h : ℕ) (p : ℕ) : Fin 3 :=
-  if p < A.length * h then
-    (A[p % A.length]?).getD 0
-  else
-    (B[(p - A.length * h) % B.length]?).getD 0
+  if p < A.length * h then (A[p % A.length]?).getD 0
+  else (B[(p - A.length * h) % B.length]?).getD 0
 
 
 private lemma checkLinearPolychrom_spec {offsets : List ℕ} {L : List (Fin 3)}
@@ -157,28 +167,12 @@ private lemma checkLinearPolychrom_spec {offsets : List ℕ} {L : List (Fin 3)}
 
 /-- Frobenius representation for consecutive block sizes r, r+1:
     any m ≥ r(r-1) can be written as r·h + (r+1)·k. -/
-/- Aristotle alternative for `frobenius_consec` (10 lines vs 11 original, -1).
-
-private lemma frobenius_consec {rA m : ℕ} (hrA : 1 < rA) (hm : m ≥ rA * (rA - 1)) :
-    ∃ h k, rA * h + (rA + 1) * k = m ∧ 0 < h + k := by
-      -- By the properties of linear combinations, since $rA$ and $rA + 1$ are coprime, there exist non-negative integers $h$ and $k$ such that $rA * h + (rA + 1) * k = m$.
-      have h_comb : ∃ h k : ℤ, rA * h + (rA + 1) * k = m ∧ 0 ≤ h ∧ h < rA + 1 := by
-        have h_comb : ∃ h k : ℤ, rA * h + (rA + 1) * k = m := by
-          exact ⟨ m * rA, -m * ( rA - 1 ), by ring ⟩;
-        obtain ⟨ h, k, hk ⟩ := h_comb; exact ⟨ h % ( rA + 1 ), k + h / ( rA + 1 ) * rA, by nth_rw 1 [ ← hk ] ; nlinarith [ Int.emod_add_mul_ediv h ( rA + 1 ) ], Int.emod_nonneg _ ( by positivity ), Int.emod_lt_of_pos _ ( by positivity ) ⟩ ;
-      obtain ⟨ h, k, h₁, h₂, h₃ ⟩ := h_comb;
-      refine' ⟨ Int.toNat h, Int.toNat k, _, _ ⟩;
-      · nlinarith [ Int.toNat_of_nonneg h₂, Int.toNat_of_nonneg ( by nlinarith [ Nat.sub_add_cancel hrA.le ] : 0 ≤ k ) ];
-      · rcases rA with ( _ | _ | rA ) <;> simp_all +decide;
-        exact Classical.or_iff_not_imp_left.2 fun h => by nlinarith;
--/
 private lemma frobenius_consec {rA m : ℕ} (hrA : 1 < rA) (hm : m ≥ rA * (rA - 1)) :
     ∃ h k, rA * h + (rA + 1) * k = m ∧ 0 < h + k := by
   obtain ⟨a, b, hab⟩ := Nat.exists_add_mul_eq_of_gcd_dvd_of_mul_pred_le rA (rA + 1) m
     (by rw [(Nat.coprime_self_add_right.mpr (Nat.coprime_one_right _)).gcd_eq_one]; exact one_dvd _)
     (by grind [Nat.pred_eq_sub_one, mul_comm rA (rA - 1)])
   refine ⟨a, b, by grind [mul_comm a rA, mul_comm b (rA + 1)], ?_⟩
-  -- a + b = 0 → a = b = 0 → m = 0, but m ≥ rA * (rA - 1) > 0
   by_contra hle; push_neg at hle
   have ha0 : a = 0 := by omega
   have hb0 : b = 0 := by omega
@@ -191,18 +185,11 @@ private lemma hasPolychromColouring_of_cyclic {m : ℕ} [NeZero m] [Fact (1 < m)
     (c : ℕ → Fin 3) (S : Finset (ZMod m))
     (hpoly : ∀ n : ZMod m, ∀ k : Fin 3, ∃ a ∈ S, c (n + a).val = k) :
     HasPolychromColouring (Fin 3) S :=
-  ⟨fun x => c x.val, fun n k => by
-    obtain ⟨a, ha, heq⟩ := hpoly n k
-    exact ⟨a, ha, by change c (n + a).val = k; exact heq⟩⟩
+  ⟨fun x => c x.val, hpoly⟩
 
-/-- Key: offsets in a list are bounded by foldr max. -/
-private lemma le_foldr_max {offsets : List ℕ} {s : ℕ} (hs : s ∈ offsets) :
-    s ≤ offsets.foldr max 0 :=
-  List.le_max_of_le' 0 hs le_rfl
 
 /-- If `i % r + s < r`, then `(i + s) % r = i % r + s`. -/
-private lemma add_mod_of_lt {i s r : ℕ} (h : i % r + s < r) :
-    (i + s) % r = i % r + s := by
+private lemma add_mod_of_lt {i s r : ℕ} (h : i % r + s < r) : (i + s) % r = i % r + s := by
   have hs : s < r := by omega
   rw [Nat.add_mod, Nat.mod_eq_of_lt hs]
   exact Nat.mod_eq_of_lt h
@@ -220,8 +207,7 @@ private lemma add_mod_sub {i s r : ℕ} (hr : 0 < r) (hge : r ≤ i % r + s)
   exact Nat.mod_eq_of_lt (by omega)
 
 /-- If `M ≤ n` and `n - M < M`, then `n % M = n - M`. -/
-private lemma mod_eq_sub {n M : ℕ} (hge : M ≤ n) (hlt : n - M < M) :
-    n % M = n - M := by
+private lemma mod_eq_sub {n M : ℕ} (hge : M ≤ n) (hlt : n - M < M) : n % M = n - M := by
   conv_lhs => rw [← Nat.sub_add_cancel hge]
   rw [Nat.add_mod_right, Nat.mod_eq_of_lt hlt]
 
@@ -241,7 +227,8 @@ private lemma ge_mul_of_mod_add_ge {i s r n : ℕ} (hr : 0 < r) (hn : 0 < n)
     r * n ≤ i + s := by
   have := Nat.mod_add_div i r
   have := Nat.mod_lt i hr
-  have : n - 1 ≤ i / r := by rw [Nat.le_div_iff_mul_le hr]; grind [mul_comm r (n - 1)]
+  have : n - 1 ≤ i / r := by
+    rw [Nat.le_div_iff_mul_le hr]; grind
   have : n ≤ i / r + 1 := by omega
   grind [Nat.mul_le_mul_left r this]
 
@@ -280,42 +267,16 @@ private lemma sub_add_eq {i j s r q : ℕ} (hge : r ≤ j + s)
     (hi : j + q = i) :
     i + s - (q + r) = j + s - r := by grind
 
-/- Aristotle alternative for sub_region_eq (12 vs 13 lines, -1)
-
+/-- When i is in the last block before boundary `r*h`, and j = i%r: `i + s - r*h = j + s - r`. -/
 private lemma sub_region_eq {i s r h : ℕ} (hr : 0 < r)
     (hi_lo : r * (h - 1) ≤ i) (hi_hi : i < r * h)
     (hjs_ge : r ≤ i % r + s) :
     i + s - r * h = i % r + s - r := by
-      -- By definition of modulo, we can write $i = r * (h - 1) + (i % r)$.
-      have h_mod : i = r * (h - 1) + (i % r) := by
-        -- By the division algorithm, we can write $i$ as $r * (h - 1) + (i % r)$ because $i < r * h$ implies $i % r < r$.
-        have h_div_alg : i = r * (i / r) + (i % r) := by
-          rw [ Nat.div_add_mod ];
-        -- Since $i < r * h$, we have $i / r < h$. Also, since $r * (h - 1) \leq i$, we have $h - 1 \leq i / r$. Therefore, $i / r = h - 1$.
-        have h_div_eq : i / r < h ∧ h - 1 ≤ i / r := by
-          exact ⟨ Nat.div_lt_of_lt_mul <| by linarith, Nat.le_div_iff_mul_le hr |>.2 <| by linarith ⟩;
-        grind +ring;
-      -- Substitute $i = r * (h - 1) + (i % r)$ into the left-hand side.
-      rw [h_mod];
-      rcases h with ( _ | _ | h ) <;> norm_num [ Nat.add_mod, Nat.mul_succ ] at * ; omega;
--/
-/-- When i is in the last block before boundary `r*h`, and j = i%r:
-    `i + s - r*h = j + s - r`. -/
-private lemma sub_region_eq {i s r h : ℕ} (hr : 0 < r)
-    (hi_lo : r * (h - 1) ≤ i) (hi_hi : i < r * h)
-    (hjs_ge : r ≤ i % r + s) :
-    i + s - r * h = i % r + s - r := by
-  have hmod := Nat.mod_lt i hr
   have hdiv := Nat.mod_add_div i r
-  have hle : h - 1 ≤ i / r := by
-    rw [Nat.le_div_iff_mul_le hr]; grind [mul_comm r (h - 1)]
-  have hlt : i / r < h := Nat.div_lt_of_lt_mul (by grind [mul_comm r h])
-  have hq : i / r = h - 1 := by grind
-  set Q := r * (i / r) with hQ_def
-  have hQr : r * h = Q + r := by
-    rw [hQ_def, hq]
-    have : h = (h - 1) + 1 := by grind
-    conv_lhs => rw [this, Nat.mul_add, Nat.mul_one]
+  have hle : h - 1 ≤ i / r := by rw [Nat.le_div_iff_mul_le hr]; grind
+  have hlt : i / r < h := Nat.div_lt_of_lt_mul (by grind)
+  have hh : 1 ≤ h := by omega
+  have hQr : r * h = r * (i / r) + r := by grind [Nat.sub_add_cancel]
   rw [hQr]
   exact sub_add_eq hjs_ge hdiv
 
@@ -328,14 +289,11 @@ produces a `CaseGoal`, and the main theorem dispatches to them.
 -/
 
 /-- The common proof obligation for each case of `blockColor_polychrom`. -/
-private def CaseGoal (A B : List (Fin 3)) (offsets : List ℕ) (h m i : ℕ) :
-    Prop :=
+private def CaseGoal (A B : List (Fin 3)) (offsets : List ℕ) (h m i : ℕ) : Prop :=
   ∃ (XY : List (Fin 3)) (j : ℕ),
     checkLinearPolychrom offsets XY = true ∧
     j + offsets.foldr max 0 < XY.length ∧
-    ∀ s, s ≤ offsets.foldr max 0 →
-      (XY[j + s]? : Option (Fin 3)) =
-        some (blockColorVal A B h ((i + s) % m))
+    ∀ s, s ≤ offsets.foldr max 0 → XY[j + s]? = some (blockColorVal A B h ((i + s) % m))
 
 /-! ### Case 1: No wrap, AA interior -/
 private lemma case_no_wrap_AA (A B : List (Fin 3)) (offsets : List ℕ)
@@ -351,7 +309,7 @@ private lemma case_no_wrap_AA (A B : List (Fin 3)) (offsets : List ℕ)
   set j := i % A.length
   have hj_lt : j < A.length := Nat.mod_lt _ hA
   refine ⟨A ++ A, j, hAA, by grind, fun s hsle => ?_⟩
-  rw [Nat.mod_eq_of_lt (by grind : i + s < m)]
+  rw [Nat.mod_eq_of_lt (by grind)]
   have his_A : i + s < A.length * h := by grind
   by_cases hjs_lt : j + s < A.length
   · exact bcv_eq_A A B h _ _ _ _ his_A
@@ -361,7 +319,7 @@ private lemma case_no_wrap_AA (A B : List (Fin 3)) (offsets : List ℕ)
     have hjs_2r : i % A.length + s < 2 * A.length := by grind
     exact bcv_eq_A A B h _ _ _ _ his_A
       (add_mod_sub hA hjs_lt hjs_2r) hjs_sub
-      (by rw [List.getElem?_append_right (by grind : A.length ≤ j + s)])
+      (by rw [List.getElem?_append_right (by grind)])
 
 /-! ### Case 2: No wrap, AB boundary -/
 private lemma case_no_wrap_AB (A B : List (Fin 3)) (offsets : List ℕ)
@@ -378,10 +336,9 @@ private lemma case_no_wrap_AB (A B : List (Fin 3)) (offsets : List ℕ)
   set j := i % A.length
   have hj_lt : j < A.length := Nat.mod_lt _ hA
   have hh_pos : 0 < h := by grind
-  have hi_lo : A.length * (h - 1) ≤ i := by
-    grind [Nat.mul_sub]
+  have hi_lo : A.length * (h - 1) ≤ i := by grind [Nat.mul_sub]
   refine ⟨A ++ B, j, hAB, by grind, fun s hsle => ?_⟩
-  rw [Nat.mod_eq_of_lt (by grind : i + s < m)]
+  rw [Nat.mod_eq_of_lt (by grind)]
   by_cases hjs_lt : j + s < A.length
   · exact bcv_eq_A A B h _ _ _ _
       (add_lt_of_mod_add_lt hA hA_region hjs_lt)
@@ -389,13 +346,12 @@ private lemma case_no_wrap_AB (A B : List (Fin 3)) (offsets : List ℕ)
       (List.getElem?_append_left hjs_lt)
   · push_neg at hjs_lt
     have hjs_B : j + s - A.length < B.length := by grind
-    have his_ge : A.length * h ≤ i + s :=
-      ge_mul_of_mod_add_ge hA hh_pos hi_lo hjs_lt
+    have his_ge : A.length * h ≤ i + s := ge_mul_of_mod_add_ge hA hh_pos hi_lo hjs_lt
     have hnot_A : ¬(i + s < A.length * h) := by grind
     refine bcv_eq_B A B h _ _ _ _ hnot_A ?_ hjs_B ?_
     · rw [sub_region_eq hA hi_lo hA_region hjs_lt,
         Nat.mod_eq_of_lt (by grind)]
-    · rw [List.getElem?_append_right (by grind : A.length ≤ j + s)]
+    · rw [List.getElem?_append_right (by grind)]
 
 /-! ### Case 3: No wrap, BB -/
 private lemma case_no_wrap_BB (A B : List (Fin 3)) (offsets : List ℕ)
@@ -411,7 +367,7 @@ private lemma case_no_wrap_BB (A B : List (Fin 3)) (offsets : List ℕ)
   set j := (i - A.length * h) % B.length
   have hj_lt : j < B.length := Nat.mod_lt _ (by grind)
   refine ⟨B ++ B, j, hBB, by grind, fun s hsle => ?_⟩
-  rw [Nat.mod_eq_of_lt (by grind : i + s < m)]
+  rw [Nat.mod_eq_of_lt (by grind)]
   by_cases hjs_lt : j + s < B.length
   · exact bcv_eq_B A B h _ _ _ _ (by grind)
       (by rw [Nat.sub_add_comm hB_region]; exact add_mod_of_lt hjs_lt)
@@ -421,8 +377,7 @@ private lemma case_no_wrap_BB (A B : List (Fin 3)) (offsets : List ℕ)
     exact bcv_eq_B A B h _ _ _ _ (by grind)
       (by rw [Nat.sub_add_comm hB_region]; exact add_mod_sub (by grind) hjs_lt (by grind))
       hjs_sub
-      (by rw [List.getElem?_append_right
-            (by grind : B.length ≤ j + s)])
+      (by rw [List.getElem?_append_right (by grind)])
 
 /-! ### Case 4: Wrap, A region (k = 0) -/
 private lemma case_wrap_A (A B : List (Fin 3)) (offsets : List ℕ)
@@ -441,27 +396,22 @@ private lemma case_wrap_A (A B : List (Fin 3)) (offsets : List ℕ)
   have hj_lt : j < A.length := Nat.mod_lt _ hA
   have hh_pos : 0 < h := by grind
   have hi_lo : A.length * (h - 1) ≤ i := by grind [Nat.mul_sub]
-  have hAh : A.length ≤ A.length * h :=
-    Nat.le_mul_of_pos_right _ hh_pos
+  have hAh : A.length ≤ A.length * h := Nat.le_mul_of_pos_right _ hh_pos
   refine ⟨A ++ A, j, hAA, by grind, fun s hsle => ?_⟩
   by_cases hjs_lt : j + s < A.length
-  · have his_lt : i + s < A.length * h :=
-      add_lt_of_mod_add_lt hA (by grind) hjs_lt
+  · have his_lt : i + s < A.length * h := add_lt_of_mod_add_lt hA (by grind) hjs_lt
     rw [Nat.mod_eq_of_lt his_lt]
     exact bcv_eq_A A B h _ _ _ _ his_lt
       (add_mod_of_lt hjs_lt) hjs_lt (List.getElem?_append_left hjs_lt)
   · push_neg at hjs_lt
-    have his_ge : A.length * h ≤ i + s :=
-      ge_mul_of_mod_add_ge hA hh_pos hi_lo hjs_lt
-    have hmod : (i + s) % (A.length * h) = i + s - A.length * h :=
-      mod_eq_sub his_ge (by grind)
+    have his_ge : A.length * h ≤ i + s := ge_mul_of_mod_add_ge hA hh_pos hi_lo hjs_lt
+    have hmod : (i + s) % (A.length * h) = i + s - A.length * h := mod_eq_sub his_ge (by grind)
     have hsub_eq := sub_region_eq hA hi_lo (by grind) hjs_lt
     have hjs_idx : j + s - A.length < A.length := by grind
     refine bcv_eq_A A B h _ _ _ _ (by grind)
       (by rw [hmod, Nat.mod_eq_of_lt (by grind), hsub_eq])
       hjs_idx ?_
-    rw [List.getElem?_append_right
-      (by grind : A.length ≤ j + s)]
+    rw [List.getElem?_append_right (by grind)]
 
 /-! ### Case 5: Wrap, B region, h > 0 → BA -/
 private lemma case_wrap_BA (A B : List (Fin 3)) (offsets : List ℕ)
@@ -476,43 +426,38 @@ private lemma case_wrap_BA (A B : List (Fin 3)) (offsets : List ℕ)
     (hh_pos : 0 < h) (hk_pos : 0 < k) :
     CaseGoal A B offsets h m i := by
   set maxOff := offsets.foldr max 0
-  have hAh : A.length ≤ A.length * h :=
-    Nat.le_mul_of_pos_right _ hh_pos
-  have hBk : B.length ≤ B.length * k :=
-    Nat.le_mul_of_pos_right _ hk_pos
+  have hAh : A.length ≤ A.length * h := Nat.le_mul_of_pos_right _ hh_pos
+  have hBk : B.length ≤ B.length * k := Nat.le_mul_of_pos_right _ hk_pos
   set j := (i - A.length * h) % B.length
   have hj_lt : j < B.length := Nat.mod_lt _ (by grind)
   have hi_B : i - A.length * h < B.length * k := by grind
-  have hk_lo : B.length * (k - 1) ≤ i - A.length * h := by
-    grind [Nat.mul_sub]
+  have hk_lo : B.length * (k - 1) ≤ i - A.length * h := by grind [Nat.mul_sub]
   refine ⟨B ++ A, j, hBA, by grind, fun s hsle => ?_⟩
   by_cases hjs_lt : j + s < B.length
   · -- Still in B
     have his_lt : (i - A.length * h) + s < B.length * k :=
       add_lt_of_mod_add_lt (by grind) hi_B hjs_lt
-    rw [Nat.mod_eq_of_lt (by grind : i + s < m)]
+    rw [Nat.mod_eq_of_lt (by grind)]
     exact bcv_eq_B A B h _ _ _ _ (by grind)
       (by rw [Nat.sub_add_comm hB_region]; exact add_mod_of_lt hjs_lt)
       hjs_lt (List.getElem?_append_left hjs_lt)
   · -- Wrapped to A region
     push_neg at hjs_lt
     have his_ge : m ≤ i + s := by
-      have := ge_mul_of_mod_add_ge (by grind : 0 < B.length)
-        hk_pos hk_lo hjs_lt; grind
+      have := ge_mul_of_mod_add_ge (by grind) hk_pos hk_lo hjs_lt
+      grind
     have hmod : (i + s) % m = i + s - m := mod_eq_sub his_ge (by grind)
     have hsub_eq : i + s - m = j + s - B.length := by
-      have key : (i - A.length * h) + s - B.length * k =
-          j + s - B.length :=
-        sub_region_eq (by grind) hk_lo hi_B hjs_lt
+      have := sub_region_eq (by grind) hk_lo hi_B hjs_lt
       grind
     have hjs_idx : j + s - B.length < A.length := by grind
     refine bcv_eq_A A B h _ _ _ _ (by grind)
       (by rw [hmod, Nat.mod_eq_of_lt (by grind), hsub_eq])
       hjs_idx ?_
-    rw [List.getElem?_append_right
-      (by grind : B.length ≤ j + s)]
+    rw [List.getElem?_append_right (by grind)]
 
-/- Aristotle alternative for case_wrap_BB (20 vs 33 lines, -13)
+/-! ### Case 6: Wrap, B region, h = 0 → BB -/
+/- Aristotle alternative for `case_wrap_BB` (20 lines vs 27 original, -7).
 
 private lemma case_wrap_BB (A B : List (Fin 3)) (offsets : List ℕ)
     (k m i : ℕ)
@@ -545,7 +490,6 @@ private lemma case_wrap_BB (A B : List (Fin 3)) (offsets : List ℕ)
       simp_all +decide [ Nat.mod_lt ];
       linarith [ Nat.mod_lt i ( Nat.succ_pos A.length ) ]
 -/
-/-! ### Case 6: Wrap, B region, h = 0 → BB -/
 private lemma case_wrap_BB (A B : List (Fin 3)) (offsets : List ℕ)
     (k m i : ℕ)
     (hBlen : B.length = A.length + 1)
@@ -557,25 +501,22 @@ private lemma case_wrap_BB (A B : List (Fin 3)) (offsets : List ℕ)
     (hk_pos : 0 < k) :
     CaseGoal A B offsets 0 m i := by
   set maxOff := offsets.foldr max 0
-  have hBk : B.length ≤ B.length * k :=
-    Nat.le_mul_of_pos_right _ hk_pos
+  have hBk : B.length ≤ B.length * k := Nat.le_mul_of_pos_right _ hk_pos
   set j := i % B.length
   have hj_lt : j < B.length := Nat.mod_lt _ (by grind)
-  have hk_lo : B.length * (k - 1) ≤ i := by
-    grind [Nat.mul_sub]
+  have hk_lo : B.length * (k - 1) ≤ i := by grind [Nat.mul_sub]
   refine ⟨B ++ B, j, hBB, by grind, fun s hsle => ?_⟩
   by_cases hjs_lt : j + s < B.length
-  · have his_lt : i + s < B.length * k :=
-      add_lt_of_mod_add_lt (by grind) (by grind) hjs_lt
-    rw [Nat.mod_eq_of_lt (by grind : i + s < m)]
+  · have his_lt : i + s < B.length * k := add_lt_of_mod_add_lt (by grind) (by grind) hjs_lt
+    rw [Nat.mod_eq_of_lt (by grind)]
     exact bcv_eq_B A B 0 _ _ _ _
       (by omega)
-      (by simp only [mul_zero, tsub_zero]; exact add_mod_of_lt hjs_lt)
+      (by grind [add_mod_of_lt hjs_lt])
       hjs_lt (List.getElem?_append_left hjs_lt)
   · push_neg at hjs_lt
     have his_ge : m ≤ i + s := by
-      have := ge_mul_of_mod_add_ge (by grind : 0 < B.length)
-        hk_pos hk_lo hjs_lt; grind
+      have := ge_mul_of_mod_add_ge (by grind) hk_pos hk_lo hjs_lt
+      grind
     have hmod : (i + s) % m = i + s - m := mod_eq_sub his_ge (by grind)
     have hsub_eq : i + s - m = j + s - B.length := by
       rw [← hm]
@@ -583,62 +524,15 @@ private lemma case_wrap_BB (A B : List (Fin 3)) (offsets : List ℕ)
     have hjs_idx : j + s - B.length < B.length := by grind
     refine bcv_eq_B A B 0 _ _ _ _
       (by omega)
-      (by simp only [mul_zero, tsub_zero]
-          rw [hmod, Nat.mod_eq_of_lt
-            (by grind : i + s - m < B.length), hsub_eq])
+      (by rw [Nat.mul_zero, Nat.sub_zero, hmod, Nat.mod_eq_of_lt (by grind), hsub_eq])
       hjs_idx ?_
-    rw [List.getElem?_append_right
-      (by grind : B.length ≤ j + s)]
+    rw [List.getElem?_append_right (by grind)]
 
-/- Aristotle alternative for blockColor_polychrom (34 vs 46 lines, -12)
+/-! ### Main result of the block coloring infrastructure -/
 
-theorem blockColor_polychrom
-    (A B : List (Fin 3)) (offsets : List ℕ)
-    (hA : 0 < A.length) (hBlen : B.length = A.length + 1)
-    (hmaxOff : offsets.foldr max 0 ≤ A.length)
-    (hpairs : checkBlockPairs offsets A B = true)
-    {h k : ℕ} (hhk : 0 < h + k) {m : ℕ}
-    (hm : A.length * h + B.length * k = m)
-    {i : ℕ} (hi : i < m) (c : Fin 3) :
-    ∃ s ∈ offsets, blockColorVal A B h ((i + s) % m) = c := by
-      -- Apply the lemma `case_no_wrap_AA` to obtain a contradiction.
-      have h_case : CaseGoal A B offsets h m i := by
-        by_cases h_no_wrap : i + offsets.foldr Max.max 0 < m;
-        · by_cases hA_region : i < A.length * h;
-          · by_cases h_cross : A.length * h ≤ i + offsets.foldr Max.max 0;
-            · apply case_no_wrap_AB A B offsets h k m i hA hBlen hmaxOff (by
-              unfold checkBlockPairs at hpairs; aesop;) hm h_no_wrap hA_region h_cross;
-            · apply case_no_wrap_AA A B offsets h k m i hA hmaxOff (by
-              unfold checkBlockPairs at hpairs; aesop;) hm h_no_wrap (by
-              grind);
-          · apply case_no_wrap_BB A B offsets h k m i hBlen hmaxOff (by
-            unfold checkBlockPairs at hpairs; aesop;) hm h_no_wrap (by
-            grind);
-        · by_cases hB_region : A.length * h ≤ i;
-          · by_cases hk_pos : 0 < k;
-            · by_cases hh_pos : 0 < h;
-              · apply case_wrap_BA A B offsets h k m i hA hBlen hmaxOff (by
-                unfold checkBlockPairs at hpairs; aesop;) hm hi (by
-                linarith) hB_region hh_pos hk_pos;
-              · have h_case : CaseGoal A B offsets 0 m i := by
-                  have hBB : checkLinearPolychrom offsets (B ++ B) = true := by
-                    unfold checkBlockPairs at hpairs; aesop;
-                  apply case_wrap_BB A B offsets k m i hBlen hmaxOff hBB (by
-                  aesop) hi (by
-                  grind) hk_pos;
-                aesop;
-            · grind;
-          · apply case_wrap_A;
-            all_goals try linarith;
-            · unfold checkBlockPairs at hpairs; aesop;
-            · nlinarith [ show k = 0 by nlinarith ];
-      obtain ⟨ XY, j, hj₁, hj₂, hj₃ ⟩ := h_case;
-      have := checkLinearPolychrom_spec hj₁ hj₂ c; simp_all +decide ;
-      obtain ⟨ s, hs₁, hs₂ ⟩ := this; specialize hj₃ s ( le_foldr_max hs₁ ) ; aesop;
--/
-/-! ### Main theorem: combine all cases -/
-/-- The main theorem: if all block-pair checks pass, the block coloring is
-    polychromatic for any m expressible as rA·h + rB·k. -/
+/-- **Key infrastructure theorem.** If all block-pair checks pass, the block coloring is
+    polychromatic for any m expressible as rA·h + rB·k. This is the main interface
+    used by the Table 1 lemmas below. -/
 theorem blockColor_polychrom
     (A B : List (Fin 3)) (offsets : List ℕ)
     (hA : 0 < A.length) (hBlen : B.length = A.length + 1)
@@ -654,55 +548,51 @@ theorem blockColor_polychrom
   -- Reduce to CaseGoal
   suffices hg : CaseGoal A B offsets h m i by
     obtain ⟨XY, j, hXY_check, hj_bound, hcorr⟩ := hg
-    obtain ⟨s, hs_mem, hs_eq⟩ :=
-      checkLinearPolychrom_spec hXY_check hj_bound c
+    obtain ⟨s, hs_mem, hs_eq⟩ := checkLinearPolychrom_spec hXY_check hj_bound c
     refine ⟨s, hs_mem, ?_⟩
-    have := hcorr s (le_foldr_max hs_mem)
+    have := hcorr s (List.le_max_of_le' 0 hs_mem le_rfl)
     rw [hs_eq] at this; exact Option.some.inj this.symm
   -- Dispatch to case lemmas
   by_cases h_wrap : i + maxOff < m
   · by_cases hA_region : i < A.length * h
     · by_cases h_cross : i + maxOff < A.length * h
-      · exact case_no_wrap_AA A B offsets h k m i hA hmaxOff
-          hAA hm h_wrap h_cross
+      · exact case_no_wrap_AA A B offsets h k m i hA hmaxOff hAA hm h_wrap h_cross
       · push_neg at h_cross
         have hk_pos : 0 < k := by grind
-        exact case_no_wrap_AB A B offsets h k m i hA hBlen hmaxOff
-          hAB hm h_wrap hA_region h_cross
+        exact case_no_wrap_AB A B offsets h k m i hA hBlen hmaxOff hAB hm h_wrap hA_region h_cross
     · push_neg at hA_region
-      exact case_no_wrap_BB A B offsets h k m i hBlen hmaxOff
-        hBB hm h_wrap hA_region
+      exact case_no_wrap_BB A B offsets h k m i hBlen hmaxOff hBB hm h_wrap hA_region
   · push_neg at h_wrap
     by_cases hA_region : i < A.length * h
-    · have hk0 : k = 0 := by
-        by_contra hle; push_neg at hle
-        have : 0 < k := by grind
-        have : B.length ≤ B.length * k :=
-          Nat.le_mul_of_pos_right _ this; grind
+    · have hk0 : k = 0 := by rw [hBlen] at hm; nlinarith [hmaxOff]
       subst hk0; simp only [mul_zero, add_zero] at hm
-      exact case_wrap_A A B offsets h m i hA hmaxOff hAA hm
-        hi h_wrap hA_region
+      exact case_wrap_A A B offsets h m i hA hmaxOff hAA hm hi h_wrap hA_region
     · push_neg at hA_region
-      have hk_pos : 0 < k := by
-        by_contra hle; push_neg at hle; have : k = 0 := by grind
-        subst this; simp [mul_zero] at hm; grind
+      have hk_pos : 0 < k := by nlinarith [hm, hA_region, hi]
       by_cases hh_pos : 0 < h
       · exact case_wrap_BA A B offsets h k m i hA hBlen hmaxOff
           hBA hm hi h_wrap hA_region hh_pos hk_pos
       · have hh0 : h = 0 := by grind
         subst hh0
         simp only [mul_zero, zero_add] at hm
-        exact case_wrap_BB A B offsets k m i hBlen hmaxOff
-          hBB hm hi h_wrap hk_pos
+        exact case_wrap_BB A B offsets k m i hBlen hmaxOff hBB hm hi h_wrap hk_pos
+
+end BlockColorInfra
 
 /-! ## Table 1: Block concatenation colorings (paper §4, Table 1)
 
-For each set S below, blocks of length r and r+1 are concatenated to produce
-an S-polychromatic 3-coloring of ℤ_m. The Frobenius coin problem ensures
-m can be so expressed when m ≥ r². Polychromaticity follows from
-`blockColor_polychrom` after checking block-pair boundaries by `decide`.
+Each `table1_*` lemma constructs a concrete 3-polychromatic coloring for a specific
+4-element set using `blockColor_polychrom`. These are intermediate results used in
+subcases (1a) and (1c) of Case 1.
 
-These are used in subcases (1a) and (1c) of Main Case 1.
+| Lemma | Set | Block size r | Min m |
+|-------|-----|-------------|-------|
+| `table1_0123` | {0,1,2,3} | 3 | 6 |
+| `table1_0134` | {0,1,3,4} | 6 | 30 |
+| `table1_0235` | {0,2,3,5} | 6 | 30 |
+| `table1_0347` | {0,3,4,7} | 9 | 72 |
+| `table1_0358` | {0,3,5,8} | 9 | 72 |
+| `table1_0145` | {0,1,4,5} | 7 | 42 |
 -/
 
 section Table1
@@ -719,11 +609,9 @@ private lemma table1_of_blockColor (A B : List (Fin 3)) (offsets : List ℕ)
     (hm : m ≥ A.length * (A.length - 1))
     (hS : ∀ a : ZMod m, a ∈ S ↔ ∃ s ∈ offsets, (s : ZMod m) = a) :
     HasPolychromColouring (Fin 3) S := by
-  have hA_lt_m : A.length < m :=
-    calc A.length < A.length * 2 := by omega
-    _ ≤ A.length * (A.length - 1) := by gcongr; omega
-    _ ≤ m := hm
-  have hm_pos : 0 < m := by omega
+  have hA_lt_m : A.length < m := by
+    have : A.length * 2 ≤ A.length * (A.length - 1) := by gcongr; omega
+    omega
   haveI : NeZero m := ⟨by omega⟩
   haveI : Fact (1 < m) := ⟨by omega⟩
   obtain ⟨h, k, hm_eq, hhk⟩ := frobenius_consec (by omega : 1 < A.length) hm
@@ -733,51 +621,44 @@ private lemma table1_of_blockColor (A B : List (Fin 3)) (offsets : List ℕ)
   obtain ⟨s, hs_mem, hs_eq⟩ := blockColor_polychrom A B offsets (by omega) hBlen hmaxOff
     hpairs hhk hm_eq' (ZMod.val_lt n) target
   refine ⟨(s : ZMod m), (hS _).mpr ⟨s, hs_mem, rfl⟩, ?_⟩
-  have : s < m := lt_of_le_of_lt (le_trans (le_foldr_max hs_mem) hmaxOff) hA_lt_m
+  have : s < m := lt_of_le_of_lt (le_trans (List.le_max_of_le' 0 hs_mem le_rfl) hmaxOff) hA_lt_m
   rw [ZMod.val_add, ZMod.val_natCast, Nat.mod_eq_of_lt this]
   exact hs_eq
 
 /-- {0,1,2,3}: blocks [0,1,2] (r=3), [0,0,1,2] (r+1=4). Frobenius bound: m ≥ 6. -/
-lemma table1_0123 (hm : m ≥ 6) :
-    HasPolychromColouring (Fin 3) ({0, 1, 2, 3} : Finset (ZMod m)) :=
+lemma table1_0123 (hm : m ≥ 6) : HasPolychromColouring (Fin 3) ({0, 1, 2, 3} : Finset (ZMod m)) :=
   table1_of_blockColor m [0,1,2] [0,0,1,2] [0,1,2,3]
     {0, 1, 2, 3} (by simp) (by simp) (by decide) (by decide) hm
     (by intro a; simp; tauto)
 
 /-- {0,1,3,4}: blocks [0,0,1,2,1,2] (r=6), [0,0,0,1,2,1,2] (r+1=7). Frobenius: m ≥ 30. -/
-lemma table1_0134 (hm : m ≥ 30) :
-    HasPolychromColouring (Fin 3) ({0, 1, 3, 4} : Finset (ZMod m)) :=
+lemma table1_0134 (hm : m ≥ 30) : HasPolychromColouring (Fin 3) ({0, 1, 3, 4} : Finset (ZMod m)) :=
   table1_of_blockColor m [0,0,1,2,1,2] [0,0,0,1,2,1,2] [0,1,3,4]
     {0, 1, 3, 4} (by simp) (by simp) (by decide) (by decide) hm
     (by intro a; simp; tauto)
 
 /-- {0,2,3,5}: blocks [0,0,1,1,2,2] (r=6), [0,0,0,1,1,2,2] (r+1=7). Frobenius: m ≥ 30. -/
-lemma table1_0235 (hm : m ≥ 30) :
-    HasPolychromColouring (Fin 3) ({0, 2, 3, 5} : Finset (ZMod m)) :=
+lemma table1_0235 (hm : m ≥ 30) : HasPolychromColouring (Fin 3) ({0, 2, 3, 5} : Finset (ZMod m)) :=
   table1_of_blockColor m [0,0,1,1,2,2] [0,0,0,1,1,2,2] [0,2,3,5]
     {0, 2, 3, 5} (by simp) (by simp) (by decide) (by decide) hm
     (by intro a; simp; tauto)
 
 /-- {0,3,4,7}: blocks [0,0,0,1,1,1,2,2,2] (r=9), [0,0,0,0,1,1,1,2,2,2] (r+1=10).
     Frobenius: m ≥ 72. -/
-lemma table1_0347 (hm : m ≥ 72) :
-    HasPolychromColouring (Fin 3) ({0, 3, 4, 7} : Finset (ZMod m)) :=
+lemma table1_0347 (hm : m ≥ 72) : HasPolychromColouring (Fin 3) ({0, 3, 4, 7} : Finset (ZMod m)) :=
   table1_of_blockColor m [0,0,0,1,1,1,2,2,2] [0,0,0,0,1,1,1,2,2,2] [0,3,4,7]
     {0, 3, 4, 7} (by simp) (by simp) (by decide) (by decide) hm
     (by intro a; simp; tauto)
 
 /-- {0,3,5,8}: blocks [0,0,0,1,1,1,2,2,2] (r=9), [0,0,0,0,1,1,1,2,2,2] (r+1=10).
     Frobenius: m ≥ 72. -/
-lemma table1_0358 (hm : m ≥ 72) :
-    HasPolychromColouring (Fin 3) ({0, 3, 5, 8} : Finset (ZMod m)) :=
+lemma table1_0358 (hm : m ≥ 72) : HasPolychromColouring (Fin 3) ({0, 3, 5, 8} : Finset (ZMod m)) :=
   table1_of_blockColor m [0,0,0,1,1,1,2,2,2] [0,0,0,0,1,1,1,2,2,2] [0,3,5,8]
     {0, 3, 5, 8} (by simp) (by simp) (by decide) (by decide) hm
     (by intro a; simp; tauto)
 
-/-- {0,1,4,5}: blocks [0,0,0,1,2,1,2] (r=7), [0,0,0,0,1,2,1,2] (r+1=8).
-    Frobenius: m ≥ 42. -/
-lemma table1_0145 (hm : m ≥ 42) :
-    HasPolychromColouring (Fin 3) ({0, 1, 4, 5} : Finset (ZMod m)) :=
+/-- {0,1,4,5}: blocks [0,0,0,1,2,1,2] (r=7), [0,0,0,0,1,2,1,2] (r+1=8). Frobenius: m ≥ 42. -/
+lemma table1_0145 (hm : m ≥ 42) : HasPolychromColouring (Fin 3) ({0, 1, 4, 5} : Finset (ZMod m)) :=
   table1_of_blockColor m [0,0,0,1,2,1,2] [0,0,0,0,1,2,1,2] [0,1,4,5]
     {0, 1, 4, 5} (by simp) (by simp) (by decide) (by decide) hm
     (by intro a; simp; tauto)
@@ -805,8 +686,7 @@ variable (m : ℕ)
 
 -- In this section, we work with the affine transformed set {0, 1, g, g+1}.
 
-/-- Subcase (1a): g ∈ {2, 3, 4}.
-    Handled by the table constructions in subcase (1c). -/
+/-- **Subcase (1a):** g ∈ {2, 3, 4}. Reduces directly to Table 1 entries. -/
 lemma case_one_small_g (g : ℕ) (hm : m ≥ 289) (hg : g ∈ ({2, 3, 4} : Finset ℕ)) :
     HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by
   fin_cases hg <;> push_cast <;> norm_num
@@ -814,19 +694,16 @@ lemma case_one_small_g (g : ℕ) (hm : m ≥ 289) (hg : g ∈ ({2, 3, 4} : Finse
   · exact table1_0134 m (by grind)
   · exact table1_0145 m (by grind)
 
-/-! ### Helper lemmas for case 1b -/
+/-! ### Helper lemmas for subcase (1b)
 
-/-- Two pairs of consecutive mod-3 values with different phases cover {0,1,2}. -/
-private lemma two_pairs_cover (j₁ j₂ : ℕ) (hne : j₁ % 3 ≠ j₂ % 3)
-    (k : ℕ) (hk : k < 3) :
-    k = j₁ % 3 ∨ k = (j₁ + 1) % 3 ∨
-    k = j₂ % 3 ∨ k = (j₂ + 1) % 3 := by
-  omega
+These are technical arithmetic lemmas used in the proof of `case_one_interval`.
+They are not important on their own.
+-/
 
 private lemma lt_two' (n : ℕ) (h : n < 2) : n = 0 ∨ n = 1 := by omega
 
 /-- Phase differs when gap is 1 or 2 mod s, and 3 ∣ s. -/
-/- Aristotle alternative for `phase_ne_of_gap` (4 lines vs 13 original, -9).
+/- Aristotle alternative for `phase_ne_of_gap` (4 lines vs 11 original, -7).
 
 private lemma phase_ne_of_gap {s j₀ jg : ℕ} (hs3 : 3 ∣ s)
     (hj₀ : j₀ < s) (hjg : jg < s)
@@ -842,10 +719,8 @@ private lemma phase_ne_of_gap {s j₀ jg : ℕ} (hs3 : 3 ∣ s)
     (hgap : (jg + s - j₀) % s = 1 ∨ (jg + s - j₀) % s = 2) :
     j₀ % 3 ≠ jg % 3 := by
   obtain ⟨t, ht⟩ := hs3; subst ht
-  have ht_pos : 0 < t := by omega
-  have h3t_pos : 0 < 3 * t := by omega
   have hqlt : (jg + 3 * t - j₀) / (3 * t) < 2 := by
-    rw [Nat.div_lt_iff_lt_mul h3t_pos]; omega
+    rw [Nat.div_lt_iff_lt_mul (by omega)]; omega
   have hdam := Nat.div_add_mod (jg + 3 * t - j₀) (3 * t)
   rcases hgap with hmod | hmod <;>
     rcases lt_two' _ hqlt with hq | hq <;>
@@ -881,38 +756,32 @@ private lemma idx_in_interval' (s m : ℕ) (hs : 0 < s) (hs_le : s ≤ m)
     have hq1_pos : 0 < q + 1 := by omega
     have hj_lt_r : j < r := by
       rw [Nat.div_lt_iff_lt_mul hq1_pos]; exact hlt
-    have hdam : (q + 1) * j + p % (q + 1) = p :=
-      Nat.div_add_mod p (q + 1)
-    have hmod : p % (q + 1) < q + 1 :=
-      Nat.mod_lt p hq1_pos
+    have hdam : (q + 1) * j + p % (q + 1) = p := Nat.div_add_mod p (q + 1)
+    have hmod : p % (q + 1) < q + 1 := Nat.mod_lt p hq1_pos
     have hle : q * j + j ≤ p := by grind
     have hub : p < q * (j + 1) + (j + 1) := by grind
     refine ⟨by omega, ?_, ?_⟩
     · unfold equiEndpoint
-      rw [min_eq_right (by omega : j ≤ r)]
+      rw [min_eq_right (by omega)]
       change q * j + j ≤ p; exact hle
     · unfold equiEndpoint
-      rw [min_eq_right (by omega : j + 1 ≤ r)]
+      rw [min_eq_right (by omega)]
       change p < q * (j + 1) + (j + 1); exact hub
   · rename_i hge; push_neg at hge
     set d := (p - bd) / q
-    have hdam : q * d + (p - bd) % q = p - bd :=
-      Nat.div_add_mod (p - bd) q
-    have hmod : (p - bd) % q < q :=
-      Nat.mod_lt _ hq_pos
+    have hdam : q * d + (p - bd) % q = p - bd := Nat.div_add_mod (p - bd) q
+    have hmod : (p - bd) % q < q := Nat.mod_lt _ hq_pos
     have hqd_le : q * d ≤ p - bd := by omega
     have hqd_ub : p - bd < q * d + q := by omega
     have hd_lt : d < s - r := by
       rw [Nat.div_lt_iff_lt_mul hq_pos]; omega
     set j := r + d
     have hring_j : q * j + r = bd + q * d := by grind
-    have hring_j1 :
-        q * (j + 1) + r = bd + q * d + q := by grind
+    have hring_j1 : q * (j + 1) + r = bd + q * d + q := by grind
     have hle : q * j + r ≤ p := by omega
     have hub : p < q * (j + 1) + r := by omega
     have hr_le_j : r ≤ j := Nat.le_add_right r d
-    have hr_le_j1 : r ≤ j + 1 :=
-      Nat.le_succ_of_le hr_le_j
+    have hr_le_j1 : r ≤ j + 1 := Nat.le_succ_of_le hr_le_j
     refine ⟨by omega, ?_, ?_⟩
     · unfold equiEndpoint
       rw [min_eq_left hr_le_j]
@@ -921,8 +790,7 @@ private lemma idx_in_interval' (s m : ℕ) (hs : 0 < s) (hs_le : s ≤ m)
       rw [min_eq_left hr_le_j1]
       change p < q * (j + 1) + r; exact hub
 
-private lemma equiEndpoint_diff' (m s j : ℕ) :
-    Finpartition.equiEndpoint m s (j + 1) -
+private lemma equiEndpoint_diff' (m s j : ℕ) : Finpartition.equiEndpoint m s (j + 1) -
       Finpartition.equiEndpoint m s j =
       if j < m % s then m / s + 1 else m / s :=
   Finpartition.card_of_mem_equipartitionToIco_parts_aux
@@ -942,20 +810,16 @@ private lemma gap_exceeds_ilen (m s g : ℕ) (hs : 0 < s)
     have := Nat.le_div_iff_mul_le hs |>.mpr this; omega
 
 open Finpartition in
-open Finpartition in
 private lemma shift_within_two' (m s g : ℕ)
     (h_ub : g < 2 * (m / s))
     (j p : ℕ) (hhi : p < equiEndpoint m s (j + 1)) :
     p + g < equiEndpoint m s (j + 3) := by
-  have hm1 : equiEndpoint m s (j + 2) -
-      equiEndpoint m s (j + 1) ≥ m / s := by
+  have hm1 : equiEndpoint m s (j + 2) - equiEndpoint m s (j + 1) ≥ m / s := by
     rw [equiEndpoint_diff']; split <;> omega
-  have hm2 : equiEndpoint m s (j + 3) -
-      equiEndpoint m s (j + 2) ≥ m / s := by
+  have hm2 : equiEndpoint m s (j + 3) - equiEndpoint m s (j + 2) ≥ m / s := by
     rw [equiEndpoint_diff']; split <;> omega
   have hmono : equiEndpoint m s (j + 1) ≤
-      equiEndpoint m s (j + 2) :=
-    equiEndpoint_monotone (by omega)
+      equiEndpoint m s (j + 2) := equiEndpoint_monotone (by omega)
   omega
 
 open Finpartition in
@@ -968,13 +832,11 @@ private lemma idx_range_from_endpoints' (m s : ℕ)
     (hj_hi : p < equiEndpoint m s (j + 1)) :
     a ≤ j ∧ j < b := by
   constructor
-  · by_contra h; push_neg at h
-    have : equiEndpoint m s (j + 1) ≤ equiEndpoint m s a :=
-      equiEndpoint_monotone (by omega)
+  · by_contra! h
+    have : equiEndpoint m s (j + 1) ≤ equiEndpoint m s a := equiEndpoint_monotone (by omega)
     omega
-  · by_contra h; push_neg at h
-    have : equiEndpoint m s b ≤ equiEndpoint m s j :=
-      equiEndpoint_monotone (by omega)
+  · by_contra! h
+    have : equiEndpoint m s b ≤ equiEndpoint m s j := equiEndpoint_monotone (by omega)
     omega
 
 /-- Gap bound: idx of (v+g)%m differs from idx(v) by 1 or 2 mod s.
@@ -998,95 +860,69 @@ private lemma gap_bound_interval (s g m : ℕ) (hs : 0 < s)
     if p < bd then p / (q + 1) else r + (p - bd) / q
   set j₀ := idx v
   set jg := idx ((v + g) % m)
-  obtain ⟨hj₀_lt', hv_lo', hv_hi'⟩ :=
-    idx_in_interval' s m hs hs_le v hv_lt
+  obtain ⟨hj₀_lt', hv_lo', hv_hi'⟩ := idx_in_interval' s m hs hs_le v hv_lt
   have hj₀_lt : j₀ < s := hj₀_lt'
-  have hv_lo : Finpartition.equiEndpoint m s j₀ ≤ v :=
-    hv_lo'
-  have hv_hi : v <
-      Finpartition.equiEndpoint m s (j₀ + 1) := hv_hi'
-  have hvg_lt : (v + g) % m < m :=
-    Nat.mod_lt _ (by omega)
-  obtain ⟨hjg_lt', hvg_lo', hvg_hi'⟩ :=
-    idx_in_interval' s m hs hs_le ((v + g) % m) hvg_lt
+  have hv_lo : Finpartition.equiEndpoint m s j₀ ≤ v := hv_lo'
+  have hv_hi : v < Finpartition.equiEndpoint m s (j₀ + 1) := hv_hi'
+  have hvg_lt : (v + g) % m < m := Nat.mod_lt _ (by omega)
+  obtain ⟨hjg_lt', hvg_lo', hvg_hi'⟩ := idx_in_interval' s m hs hs_le ((v + g) % m) hvg_lt
   have hjg_lt : jg < s := hjg_lt'
-  have hvg_lo : Finpartition.equiEndpoint m s jg ≤
-      (v + g) % m := hvg_lo'
-  have hvg_hi : (v + g) % m <
-      Finpartition.equiEndpoint m s (jg + 1) := hvg_hi'
-  have hpast : Finpartition.equiEndpoint m s (j₀ + 1) ≤
-      v + g := by
+  have hvg_lo : Finpartition.equiEndpoint m s jg ≤ (v + g) % m := hvg_lo'
+  have hvg_hi : (v + g) % m < Finpartition.equiEndpoint m s (jg + 1) := hvg_hi'
+  have hpast : Finpartition.equiEndpoint m s (j₀ + 1) ≤ v + g := by
     have := gap_exceeds_ilen m s g hs h_lb j₀; omega
   have hwithin : v + g <
-      Finpartition.equiEndpoint m s (j₀ + 3) :=
-    shift_within_two' m s g h_ub j₀ v hv_hi
+      Finpartition.equiEndpoint m s (j₀ + 3) := shift_within_two' m s g h_ub j₀ v hv_hi
   have hg_lt_m : g < m := by
     have hqs : q * s ≤ m := Nat.div_mul_le_self m s
     have : 2 * q ≤ q * s := by nlinarith
     omega
-  have mod_small : ∀ d : ℕ, d = 1 ∨ d = 2 →
-      d % s = 1 ∨ d % s = 2 := by
+  have mod_small : ∀ d : ℕ, d = 1 ∨ d = 2 → d % s = 1 ∨ d % s = 2 := by
     intro d hd; rcases hd with h | h <;> subst h
     · left; exact Nat.mod_eq_of_lt (by omega)
     · right; exact Nat.mod_eq_of_lt (by omega)
-  have mod_shift : ∀ d : ℕ, d = 1 ∨ d = 2 →
-      (s + d) % s = 1 ∨ (s + d) % s = 2 := by
+  have mod_shift : ∀ d : ℕ, d = 1 ∨ d = 2 → (s + d) % s = 1 ∨ (s + d) % s = 2 := by
     intro d hd; rw [Nat.add_comm, Nat.add_mod_right]; exact mod_small d hd
   by_cases hvg_wrap : v + g < m
-  · have hvg_eq : (v + g) % m = v + g :=
-      Nat.mod_eq_of_lt hvg_wrap
+  · have hvg_eq : (v + g) % m = v + g := Nat.mod_eq_of_lt hvg_wrap
     rw [hvg_eq] at hvg_lo hvg_hi
     have hrange : j₀ + 1 ≤ jg ∧ jg < j₀ + 3 := by
       by_cases hj3 : j₀ + 3 ≤ s
-      · exact idx_range_from_endpoints' m s
-          (j₀+1) (j₀+3) (v+g) hpast hwithin jg hvg_lo hvg_hi
-      · have hvg_lt_ep : v + g <
-            Finpartition.equiEndpoint m s s := by
+      · exact idx_range_from_endpoints' m s (j₀+1) (j₀+3) (v+g) hpast hwithin jg hvg_lo hvg_hi
+      · have hvg_lt_ep : v + g < Finpartition.equiEndpoint m s s := by
           grind [Finpartition.equiEndpoint_hi (show s ≠ 0 by omega) (n := m) (k := s)]
-        have := idx_range_from_endpoints' m s
-          (j₀+1) s (v+g) hpast hvg_lt_ep jg hvg_lo hvg_hi
+        have := idx_range_from_endpoints' m s (j₀+1) s (v+g) hpast hvg_lt_ep jg hvg_lo hvg_hi
         omega
     have : jg - j₀ = 1 ∨ jg - j₀ = 2 := by omega
     have : jg + s - j₀ = s + (jg - j₀) := by omega
     rw [this]; exact mod_shift _ ‹jg - j₀ = 1 ∨ _›
   · push_neg at hvg_wrap
     have hvg_eq : (v + g) % m = v + g - m := by
-      conv_lhs =>
-        rw [← Nat.sub_add_cancel (by omega : m ≤ v + g)]
-      rw [Nat.add_mod_right]
-      exact Nat.mod_eq_of_lt (by omega)
+      rw [Nat.mod_eq_sub_mod (by omega), Nat.mod_eq_of_lt (by omega)]
     rw [hvg_eq] at hvg_lo hvg_hi
     have hj0_ge : j₀ ≥ s - 2 := by
-      by_contra h; push_neg at h
+      by_contra! h
       have : Finpartition.equiEndpoint m s (j₀ + 3) ≤
-          Finpartition.equiEndpoint m s s :=
-        Finpartition.equiEndpoint_monotone (by omega)
-      have := Finpartition.equiEndpoint_hi
-        (by omega : s ≠ 0) (n := m) (k := s)
+          Finpartition.equiEndpoint m s s := Finpartition.equiEndpoint_monotone (by omega)
+      have := Finpartition.equiEndpoint_hi (by omega : s ≠ 0) (n := m) (k := s)
       omega
     have hr_lt : r < s := Nat.mod_lt m hs
-    have hep_j3 : Finpartition.equiEndpoint m s
-        (j₀ + 3) = q * (j₀ + 3) + r := by
+    have hep_j3 : Finpartition.equiEndpoint m s (j₀ + 3) = q * (j₀ + 3) + r := by
       unfold Finpartition.equiEndpoint
-      rw [min_eq_left (by omega : r ≤ j₀ + 3)]
+      rw [min_eq_left (by omega)]
     have hm_eq : m = q * s + r := by grind [Nat.div_add_mod m s]
-    have hm_le_ep : m ≤
-        Finpartition.equiEndpoint m s (j₀ + 3) := by grind
+    have hm_le_ep : m ≤ Finpartition.equiEndpoint m s (j₀ + 3) := by grind
     have hep_diff :
         Finpartition.equiEndpoint m s (j₀ + 3) - m =
         q * (j₀ + 3 - s) := by
       rw [hep_j3, hm_eq]; grind [Nat.mul_add]
-    have hvgm_ub : v + g - m <
-        Finpartition.equiEndpoint m s
+    have hvgm_ub : v + g - m < Finpartition.equiEndpoint m s
           (j₀ + 3 - s) := by
-      have hvgm_lt : v + g - m <
-          q * (j₀ + 3 - s) := by
+      have : v + g - m < q * (j₀ + 3 - s) := by
         rw [← hep_diff]; omega
-      have : q * (j₀ + 3 - s) ≤
-          Finpartition.equiEndpoint m s
+      have : q * (j₀ + 3 - s) ≤ Finpartition.equiEndpoint m s
             (j₀ + 3 - s) := by
-        change q * (j₀ + 3 - s) ≤
-          q * (j₀ + 3 - s) + min r (j₀ + 3 - s)
+        change q * (j₀ + 3 - s) ≤ q * (j₀ + 3 - s) + min r (j₀ + 3 - s)
         omega
       omega
     have hrange := idx_range_from_endpoints' m s
@@ -1116,8 +952,7 @@ private lemma eqp_idx_m (q r s : ℕ) (hq : 0 < q) (hr : r < s) :
       · nlinarith;
       · exact Eq.symm ( by nlinarith [ Nat.div_mul_le_self ( s * q + r - r * ( q + 1 ) ) q, Nat.sub_add_cancel ( by linarith : r * ( q + 1 ) ≤ s * q + r ), Nat.div_add_mod ( s * q + r - r * ( q + 1 ) ) q, Nat.mod_lt ( s * q + r - r * ( q + 1 ) ) hq ] )
 -/
-private lemma eqp_idx_m (q r s : ℕ) (hq : 0 < q) (hr : r < s) :
-    eqp_idx q r (s * q + r) = s := by
+private lemma eqp_idx_m (q r s : ℕ) (hq : 0 < q) (hr : r < s) : eqp_idx q r (s * q + r) = s := by
   have hge : ¬(s * q + r < r * (q + 1)) := by nlinarith
   simp only [eqp_idx, if_neg hge]
   have hle : r * (q + 1) ≤ s * q + r := by nlinarith
@@ -1126,7 +961,7 @@ private lemma eqp_idx_m (q r s : ℕ) (hq : 0 < q) (hr : r < s) :
   rw [hsub, Nat.mul_div_cancel _ hq]; omega
 
 -- General fact: consecutive ℕ quotients differ by 0 or 1
-/- Aristotle alternative for `div_step` (6 lines vs 9 original, -3).
+/- Aristotle alternative for `div_step` (6 lines vs 7 original, -1).
 
 private lemma div_step (a b : ℕ) (hb : 0 < b) :
     (a + 1) / b = a / b ∨ (a + 1) / b = a / b + 1 := by
@@ -1137,19 +972,16 @@ private lemma div_step (a b : ℕ) (hb : 0 < b) :
       rcases b with ( _ | _ | b ) <;> simp_all +decide [ Nat.div_eq_of_lt, Nat.mod_eq_of_lt ];
       exact lt_or_ge _ _
 -/
-private lemma div_step (a b : ℕ) (hb : 0 < b) :
-    (a + 1) / b = a / b ∨ (a + 1) / b = a / b + 1 := by
-  have hle : a / b ≤ (a + 1) / b :=
-    Nat.div_le_div_right (Nat.le_succ a)
+private lemma div_step (a b : ℕ) (hb : 0 < b) : (a + 1) / b = a / b ∨ (a + 1) / b = a / b + 1 := by
+  have hle : a / b ≤ (a + 1) / b := Nat.div_le_div_right (Nat.le_succ a)
   suffices h : (a + 1) / b ≤ a / b + 1 by omega
   have h1 := Nat.div_add_mod a b
   have hmod := Nat.mod_lt a hb
   have hub : a + 1 ≤ b * (a / b + 1) := by grind
-  calc (a + 1) / b
-      ≤ b * (a / b + 1) / b := Nat.div_le_div_right hub
+  calc (a + 1) / b ≤ b * (a / b + 1) / b := Nat.div_le_div_right hub
     _ = a / b + 1 := Nat.mul_div_cancel_left _ hb
 
-/- Aristotle alternative for `eqp_idx_step` (13 lines vs 20 original, -7).
+/- Aristotle alternative for `eqp_idx_step` (13 lines vs 19 original, -6).
 
 private lemma eqp_idx_step (q r p : ℕ) (hq : 0 < q) :
     eqp_idx q r (p + 1) = eqp_idx q r p ∨
@@ -1186,8 +1018,7 @@ private lemma eqp_idx_step (q r p : ℕ) (hq : 0 < q) :
     have hidx_p : p / (q + 1) = r - 1 := by
       have := div_step p (q + 1) (by omega); omega
     rw [hpeq, Nat.sub_self, Nat.zero_div, hidx_p]; omega
-  · have hsub :
-        p + 1 - r * (q + 1) = (p - r * (q + 1)) + 1 := by
+  · have hsub : p + 1 - r * (q + 1) = (p - r * (q + 1)) + 1 := by
       omega
     rw [hsub]
     have := div_step (p - r * (q + 1)) q hq; omega
@@ -1208,7 +1039,7 @@ private lemma mod_zero_step (a b : ℕ) (hb : 0 < b)
   have h4 : b * ((a + 1) / b) = b * (a / b) + b := by grind
   grind
 
-/- Aristotle alternative for `eqp_off_succ_same` (18 lines vs 34 original, -16).
+/- Aristotle alternative for `eqp_off_succ_same` (18 lines vs 30 original, -12).
 
 private lemma eqp_off_succ_same (q r p : ℕ) (hq : 0 < q)
     (h : eqp_idx q r (p + 1) = eqp_idx q r p) :
@@ -1247,8 +1078,7 @@ private lemma eqp_off_succ_same (q r p : ℕ) (hq : 0 < q)
     grind
   · omega
   · exfalso
-    have h3 : eqp_idx q r (p + 1) =
-        r + (p + 1 - r * (q + 1)) / q := by
+    have h3 : eqp_idx q r (p + 1) = r + (p + 1 - r * (q + 1)) / q := by
       unfold eqp_idx; rw [if_neg h1]
     have h4 : eqp_idx q r p = p / (q + 1) := by
       unfold eqp_idx; rw [if_pos h2]
@@ -1258,19 +1088,16 @@ private lemma eqp_off_succ_same (q r p : ℕ) (hq : 0 < q)
       rw [h3]; exact Nat.le_add_right r _
     grind
   · rw [if_neg h1, if_neg h2]
-    have hsub : p + 1 - r * (q + 1) =
-        (p - r * (q + 1)) + 1 := by omega
+    have hsub : p + 1 - r * (q + 1) = (p - r * (q + 1)) + 1 := by omega
     rw [hsub]
     apply mod_step (p - r * (q + 1)) q
-    have h3 : eqp_idx q r (p + 1) =
-        r + (p + 1 - r * (q + 1)) / q := by
+    have h3 : eqp_idx q r (p + 1) = r + (p + 1 - r * (q + 1)) / q := by
       unfold eqp_idx; rw [if_neg h1]
-    have h4 : eqp_idx q r p =
-        r + (p - r * (q + 1)) / q := by
+    have h4 : eqp_idx q r p = r + (p - r * (q + 1)) / q := by
       unfold eqp_idx; rw [if_neg h2]
     rw [h3, h4, hsub] at h; omega
 
-/- Aristotle alternative for `eqp_off_succ_new` (10 lines vs 30 original, -20).
+/- Aristotle alternative for `eqp_off_succ_new` (10 lines vs 27 original, -17).
 
 private lemma eqp_off_succ_new (q r p : ℕ) (hq : 0 < q)
     (h : eqp_idx q r (p + 1) ≠ eqp_idx q r p) :
@@ -1306,33 +1133,17 @@ private lemma eqp_off_succ_new (q r p : ℕ) (hq : 0 < q)
     have : p + 1 = r * (q + 1) := by omega
     simp [this]
   · rw [if_neg h1]
-    have hsub : p + 1 - r * (q + 1) =
-        (p - r * (q + 1)) + 1 := by omega
+    have hsub : p + 1 - r * (q + 1) = (p - r * (q + 1)) + 1 := by omega
     rw [hsub]
     apply mod_zero_step (p - r * (q + 1)) q hq
-    have h3 : eqp_idx q r (p + 1) =
-        r + (p + 1 - r * (q + 1)) / q := by
+    have h3 : eqp_idx q r (p + 1) = r + (p + 1 - r * (q + 1)) / q := by
       unfold eqp_idx; rw [if_neg h1]
-    have h4 : eqp_idx q r p =
-        r + (p - r * (q + 1)) / q := by
+    have h4 : eqp_idx q r p = r + (p - r * (q + 1)) / q := by
       unfold eqp_idx; rw [if_neg h2]
     rw [h3, h4, hsub] at h
     have := div_step (p - r * (q + 1)) q hq
     omega
 
-/- Aristotle alternative for `gap_mod_cases_gen` (6 lines vs 8 original, -2).
-
-private lemma gap_mod_cases_gen (s j₀ jg d : ℕ)
-    (hj₀ : j₀ < s) (hjg : jg < s)
-    (hmod : (jg + s - j₀) % s = d) :
-    jg + s - j₀ = d ∨ jg + s - j₀ = s + d := by
-      -- Since $(jg + s - j₀) \mod s = d$, we have $jg + s - j₀ = k * s + d$ for some integer $k$.
-      obtain ⟨k, hk⟩ : ∃ k : ℕ, jg + s - j₀ = k * s + d := by
-        -- By the division algorithm, we can write $jg + s - j₀$ as $k * s + d$ for some integer $k$.
-        use (jg + s - j₀) / s;
-        rw [ ← hmod, Nat.div_add_mod' ];
-      rcases k with ( _ | _ | k ) <;> simp_all +decide [ Nat.succ_mul ] ; omega;
--/
 private lemma gap_mod_cases_gen (s j₀ jg d : ℕ)
     (hj₀ : j₀ < s) (hjg : jg < s)
     (hmod : (jg + s - j₀) % s = d) :
@@ -1342,12 +1153,9 @@ private lemma gap_mod_cases_gen (s j₀ jg d : ℕ)
   rw [hmod] at hdiv
   have hq_lt : (jg + s - j₀) / s < 2 := by
     rw [Nat.div_lt_iff_lt_mul (by omega)]; omega
-  rcases Nat.eq_zero_or_pos ((jg + s - j₀) / s) with h | h
-  · grind
-  · grind
+  rcases Nat.eq_zero_or_pos ((jg + s - j₀) / s) with h | h <;> grind
 
-private lemma equiEndpoint_diff_ge (m s j : ℕ) :
-    m / s ≤ Finpartition.equiEndpoint m s (j + 1) -
+private lemma equiEndpoint_diff_ge (m s j : ℕ) : m / s ≤ Finpartition.equiEndpoint m s (j + 1) -
         Finpartition.equiEndpoint m s j := by
   grind [Finpartition.equiEndpoint]
 
@@ -1361,30 +1169,25 @@ private lemma straddle1_gap2 (s g m : ℕ)
     (hvg_lo : equiEndpoint m s jg ≤ (v + g) % m)
     (hvg_hi : (v + g) % m < equiEndpoint m s (jg + 1))
     (hstrad : equiEndpoint m s (j₀ + 1) ≤ v + 1)
-    (hgap : (jg + s - j₀) % s = 1 ∨
-      (jg + s - j₀) % s = 2) :
+    (hgap : (jg + s - j₀) % s = 1 ∨ (jg + s - j₀) % s = 2) :
     (jg + s - j₀) % s = 2 := by
   by_contra hne
   have hgap1 : (jg + s - j₀) % s = 1 := by tauto
   have hv_eq : v + 1 = equiEndpoint m s (j₀ + 1) := by
     omega
-  have hjg_cases := gap_mod_cases_gen s j₀ jg 1 hj₀_lt hjg_lt
-    hgap1
+  have hjg_cases := gap_mod_cases_gen s j₀ jg 1 hj₀_lt hjg_lt hgap1
   have hq_pos : 0 < m / s := by
     grind
   have hg_lt_m : g < m := by
     have := Nat.div_mul_le_self m s; nlinarith
-  have hep_s : equiEndpoint m s s = m :=
-    equiEndpoint_hi (by omega)
+  have hep_s : equiEndpoint m s s = m := equiEndpoint_hi (by omega)
   by_cases hj₀_lt_s : j₀ + 1 < s
   · have hjg_val : jg = j₀ + 1 := by omega
     have hilen := gap_exceeds_ilen m s g hs h_lb (j₀ + 1)
     have hmono : equiEndpoint m s (j₀ + 1) ≤
-        equiEndpoint m s (j₀ + 1 + 1) :=
-      equiEndpoint_monotone (by omega)
+        equiEndpoint m s (j₀ + 1 + 1) := equiEndpoint_monotone (by omega)
     have hsac := Nat.sub_add_cancel hmono
-    have hvg_ge : v + g ≥
-        equiEndpoint m s (j₀ + 1 + 1) := by omega
+    have hvg_ge : v + g ≥ equiEndpoint m s (j₀ + 1 + 1) := by omega
     by_cases hwrap : v + g < m
     · have : (v + g) % m = v + g := Nat.mod_eq_of_lt hwrap
       rw [hjg_val] at hvg_hi
@@ -1392,20 +1195,16 @@ private lemma straddle1_gap2 (s g m : ℕ)
     · push_neg at hwrap
       rw [hjg_val] at hvg_lo
       have hvg_mod : (v + g) % m = v + g - m := by
-        rw [Nat.mod_eq_sub_mod hwrap]; exact Nat.mod_eq_of_lt (by omega)
+        rw [Nat.mod_eq_sub_mod hwrap, Nat.mod_eq_of_lt (by omega)]
       rw [hvg_mod] at hvg_lo
       omega
   · have hj₀_eq : j₀ = s - 1 := by omega
     have hjg_val : jg = 0 := by omega
-    rw [hj₀_eq] at hv_eq
-    have hep_s1 : equiEndpoint m s (s - 1 + 1) = m := by
-      rw [Nat.sub_add_cancel (by omega : 1 ≤ s)]; exact hep_s
-    rw [hep_s1] at hv_eq
+    rw [hj₀_eq, Nat.sub_add_cancel (by omega), hep_s] at hv_eq
     have hv_val : v = m - 1 := by omega
     have hg_pos : 0 < g := by
       have := gap_exceeds_ilen m s g hs h_lb 0
-      have := equiEndpoint_strictMono
-        (by omega : s ≠ 0) hs_le one_pos
+      have := equiEndpoint_strictMono (by omega : s ≠ 0) hs_le one_pos
       omega
     have hvg_mod : (v + g) % m = g - 1 := by
       have : m - 1 + g = m + (g - 1) := by omega
@@ -1413,8 +1212,7 @@ private lemma straddle1_gap2 (s g m : ℕ)
       exact Nat.mod_eq_of_lt (by omega)
     rw [hjg_val, hvg_mod] at hvg_hi
     simp only [Nat.zero_add] at hvg_hi
-    have hep1 : equiEndpoint m s 1 ≤
-        (m + s - 1) / s := by
+    have hep1 : equiEndpoint m s 1 ≤ (m + s - 1) / s := by
       rw [equiEndpoint]
       simp only [Nat.mul_one]
       by_cases hr : m % s = 0
@@ -1434,25 +1232,20 @@ private lemma straddle2_gap1 (s g m : ℕ)
     (hv_lo : equiEndpoint m s j₀ ≤ v)
     (hv_hi : v < equiEndpoint m s (j₀ + 1))
     (hvg_hi : (v + g) % m < equiEndpoint m s (jg + 1))
-    (hstrad : equiEndpoint m s (jg + 1) ≤
-      (v + g) % m + 1)
-    (hgap : (jg + s - j₀) % s = 1 ∨
-      (jg + s - j₀) % s = 2) :
+    (hstrad : equiEndpoint m s (jg + 1) ≤ (v + g) % m + 1)
+    (hgap : (jg + s - j₀) % s = 1 ∨ (jg + s - j₀) % s = 2) :
     (jg + s - j₀) % s = 1 := by
   by_contra hne
   have hgap2 : (jg + s - j₀) % s = 2 := by tauto
-  have hvg_eq : (v + g) % m + 1 =
-      equiEndpoint m s (jg + 1) := by omega
+  have hvg_eq : (v + g) % m + 1 = equiEndpoint m s (jg + 1) := by omega
   have hq_pos : 0 < m / s := by
     grind
   have hg_lt_m : g < m := by
     have := Nat.div_mul_le_self m s; nlinarith
-  have hjg_cases := gap_mod_cases_gen s j₀ jg 2 hj₀_lt hjg_lt
-    hgap2
+  have hjg_cases := gap_mod_cases_gen s j₀ jg 2 hj₀_lt hjg_lt hgap2
   have hep0 : equiEndpoint m s 0 = 0 := by
     simp [equiEndpoint]
-  have hep_s : equiEndpoint m s s = m :=
-    equiEndpoint_hi (by omega)
+  have hep_s : equiEndpoint m s s = m := equiEndpoint_hi (by omega)
   by_cases hj_nowrap : j₀ + 2 < s
   · have hjg_val : jg = j₀ + 2 := by omega
     rw [hjg_val] at hvg_eq
@@ -1470,25 +1263,20 @@ private lemma straddle2_gap1 (s g m : ℕ)
       omega
     · push_neg at hwrap
       have : (v + g) % m = v + g - m := by
-        rw [Nat.mod_eq_sub_mod hwrap]
-        exact Nat.mod_eq_of_lt (by omega)
+        rw [Nat.mod_eq_sub_mod hwrap, Nat.mod_eq_of_lt (by omega)]
       omega
   · have hjg_val : jg = j₀ + 2 - s := by omega
     have hpos_wrap : m ≤ v + g := by
-      by_contra h; push_neg at h
+      by_contra! h
       have : (v + g) % m = v + g := Nat.mod_eq_of_lt h
-      have : equiEndpoint m s (jg + 1) ≤
-          equiEndpoint m s j₀ :=
-        equiEndpoint_monotone (by omega)
+      have : equiEndpoint m s (jg + 1) ≤ equiEndpoint m s j₀ := equiEndpoint_monotone (by omega)
       have : 0 < g := by
         have := gap_exceeds_ilen m s g hs h_lb 0
-        have := equiEndpoint_strictMono
-          (by omega : s ≠ 0) hs_le one_pos
+        have := equiEndpoint_strictMono (by omega : s ≠ 0) hs_le one_pos
         omega
       omega
     have hvg_mod : (v + g) % m = v + g - m := by
-      rw [Nat.mod_eq_sub_mod hpos_wrap]
-      exact Nat.mod_eq_of_lt (by omega)
+      rw [Nat.mod_eq_sub_mod hpos_wrap, Nat.mod_eq_of_lt (by omega)]
     by_cases hj₀_eq : j₀ = s - 2
     · have hjg0 : jg = 0 := by omega
       rw [hjg0] at hvg_eq
@@ -1497,34 +1285,22 @@ private lemma straddle2_gap1 (s g m : ℕ)
       have : s - 2 + 1 = s - 1 := by omega
       rw [this] at hv_hi
       have hd1 := equiEndpoint_diff_ge m s (s - 1)
-      rw [Nat.sub_add_cancel (by omega : 1 ≤ s), hep_s]
-        at hd1
-      have hep_s1_le :
-          equiEndpoint m s (s - 1) ≤ m := by
-        calc equiEndpoint m s (s - 1)
-            ≤ equiEndpoint m s s :=
-              equiEndpoint_monotone (by omega)
-          _ = m := hep_s
+      rw [Nat.sub_add_cancel (by omega), hep_s] at hd1
+      have hep_s1_le : equiEndpoint m s (s - 1) ≤ m :=
+        le_trans (equiEndpoint_monotone (by omega)) hep_s.le
       have hsac_m := Nat.sub_add_cancel hep_s1_le
       have hd2 := equiEndpoint_diff_ge m s 0
-      rw [hep0] at hd2
-      simp only [Nat.zero_add] at hd2
+      rw [hep0, Nat.zero_add] at hd2
       omega
     · have hj₀_eq2 : j₀ = s - 1 := by omega
       have hjg1 : jg = 1 := by omega
       rw [hjg1] at hvg_eq
       rw [hj₀_eq2] at hv_hi
-      have hep_s1 :
-          equiEndpoint m s (s - 1 + 1) = m := by
-        rw [Nat.sub_add_cancel (by omega : 1 ≤ s)]
-        exact hep_s
-      rw [hep_s1] at hv_hi
+      rw [Nat.sub_add_cancel (by omega), hep_s] at hv_hi
       have hd1 := equiEndpoint_diff_ge m s 0
-      rw [hep0] at hd1
-      simp only [Nat.zero_add] at hd1
+      rw [hep0, Nat.zero_add] at hd1
       have hd2 := equiEndpoint_diff_ge m s 1
-      have hmono12 : equiEndpoint m s 1 ≤
-          equiEndpoint m s (1 + 1) := by omega
+      have hmono12 : equiEndpoint m s 1 ≤ equiEndpoint m s (1 + 1) := by omega
       have hsac12 := Nat.sub_add_cancel hmono12
       omega
 
@@ -1553,7 +1329,7 @@ private lemma eqp_idx_succ_lt_m (q r s p : ℕ)
     rw [hpm, hm_eq]
     exact eqp_idx_m q r s hq_pos hr_lt
 
-/- Aristotle alternative for `non_straddle_witness` (7 lines vs 10 original, -3).
+/- Aristotle alternative for `non_straddle_witness` (7 lines vs 9 original, -2).
 
 private lemma non_straddle_witness (q r p : ℕ)
     (hq_pos : 0 < q)
@@ -1579,11 +1355,9 @@ private lemma non_straddle_witness (q r p : ℕ)
     (j : ℕ) (hj : j = eqp_idx q r p)
     (t : ℕ) (hpair : t = j % 3 ∨ t = (j + 1) % 3) :
     ∃ d ∈ ({0, 1} : Finset ℕ),
-      (eqp_idx q r ((p + d) % m) +
-        eqp_off q r ((p + d) % m) % 2) % 3 = t := by
+      (eqp_idx q r ((p + d) % m) + eqp_off q r ((p + d) % m) % 2) % 3 = t := by
   have hoff := eqp_off_succ_same q r p hq_pos hsame
-  have : (j + (eqp_off q r p) % 2) % 3 = t ∨
-      (j + ((eqp_off q r p) + 1) % 2) % 3 = t := by omega
+  have : (j + (eqp_off q r p) % 2) % 3 = t ∨ (j + ((eqp_off q r p) + 1) % 2) % 3 = t := by omega
   rcases this with h | h
   · exact ⟨0, by simp, by
       simp only [Nat.add_zero, Nat.mod_eq_of_lt hp, ← hj]
@@ -1599,8 +1373,7 @@ private lemma straddle_boundary_color (q r s p : ℕ)
     (hp : p < m)
     (hstep : eqp_idx q r (p + 1) = eqp_idx q r p + 1)
     (j : ℕ) (hj : j = eqp_idx q r p) :
-    (eqp_idx q r ((p + 1) % m) +
-      eqp_off q r ((p + 1) % m) % 2) % 3 = (j + 1) % 3 := by
+    (eqp_idx q r ((p + 1) % m) + eqp_off q r ((p + 1) % m) % 2) % 3 = (j + 1) % 3 := by
   by_cases h : p + 1 < m
   · rw [Nat.mod_eq_of_lt h]
     have hoff := eqp_off_succ_new q r p hq_pos (by omega)
@@ -1615,22 +1388,9 @@ private lemma straddle_boundary_color (q r s p : ℕ)
     have hjs : j + 1 = s := by rw [hj]; omega
     grind
 
-private lemma vg_mod_shift (v g d : ℕ) :
-    (v + (g + d)) % m = ((v + g) % m + d) % m := by
+private lemma vg_mod_shift (v g d : ℕ) : (v + (g + d)) % m = ((v + g) % m + d) % m := by
   grind [Nat.add_mod (v + g) d m, Nat.add_mod ((v + g) % m) d m,
     Nat.mod_mod_of_dvd _ (dvd_refl m)]
-
-private lemma gap2_jg_mod3 (s j₀ jg : ℕ) (hs3 : 3 ∣ s)
-    (hj₀ : j₀ < s) (hjg : jg < s)
-    (hgap2 : (jg + s - j₀) % s = 2) :
-    (jg + 1) % 3 = j₀ % 3 := by
-  rcases gap_mod_cases_gen s j₀ jg 2 hj₀ hjg hgap2 with h | h <;> grind
-
-private lemma gap1_j0_mod3 (s j₀ jg : ℕ) (hs3 : 3 ∣ s)
-    (hj₀ : j₀ < s) (hjg : jg < s)
-    (hgap1 : (jg + s - j₀) % s = 1) :
-    (j₀ + 1) % 3 = jg % 3 := by
-  rcases gap_mod_cases_gen s j₀ jg 1 hj₀ hjg hgap1 with h | h <;> grind
 
 private lemma mod3_witness {s k : ℕ} (hs : s < 3) (hk : k < 3) :
     ((k + 3 - s) % 3 = 0 → s = k) ∧
@@ -1704,18 +1464,15 @@ private lemma lift_coloring_witness {m g : ℕ} [NeZero m] [Fact (1 < m)]
          rw [ZMod.val_add, ZMod.val_natCast, Nat.mod_eq_of_lt ha_lt]
        rw [this, hc_period, hca]⟩
 
-/-- Subcase (1b): interval coloring strategy.
+/-- **Subcase (1b): interval coloring strategy.**
     Let s be the smallest multiple of 3 such that g > ⌈m/s⌉. Split Z_m into s
     intervals of lengths ⌊m/s⌋ and ⌈m/s⌉, colored in a repeating 01/12/20
     pattern (repeated s/3 times). Since ⌈m/s⌉ < g < 2⌊m/s⌋, any translate of
     {0,1,g,g+1} where the pairs {0,1} and {g,g+1} lie in different intervals gets
-    all three colors. If one pair straddles two consecutive intervals, it gets only the
-    single color common to these two intervals, but the other pair lies fully inside
-    a third interval which is colored with the remaining two colors. -/
+    all three colors. This is the workhorse subcase, handling most values of g. -/
 lemma case_one_interval (s g : ℕ) (hs : 0 < s) (hs3 : 3 ∣ s)
     (h_lb : (m + s - 1) / s < g) (h_ub : g < 2 * (m / s)) :
-    HasPolychromColouring (Fin 3)
-      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by
+    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by
   set q := m / s
   set r := m % s
   have hm_eq : m = s * q + r := (Nat.div_add_mod m s).symm
@@ -1740,23 +1497,16 @@ lemma case_one_interval (s g : ℕ) (hs : 0 < s) (hs3 : 3 ∣ s)
     lift_coloring_witness hg1_lt_m hc_lt3 hc_period ?_⟩
   set v := n.val
   have hv_lt : v < m := ZMod.val_lt n
-  -- c(p) ∈ {idx(p%m)%3, (idx(p%m)+1)%3}
-  have hc_phase : ∀ p, c p = idx (p % m) % 3 ∨
-      c p = (idx (p % m) + 1) % 3 := by
-    intro p; simp only [c]
-    have : off (p % m) % 2 = 0 ∨ off (p % m) % 2 = 1 := by omega
-    rcases this with h | h <;> simp [h]
   -- Gap bound: idx((v+g)%m) differs from idx(v) by 1 or 2 mod s
   set j₀ := idx v with hj₀_def
   set jg := idx ((v + g) % m) with hjg_def
   have hs3_le : 3 ≤ s := Nat.le_of_dvd hs hs3
-  have hgap := gap_bound_interval s g m hs hs3_le hs_le
-    h_lb h_ub v hv_lt
+  have hgap := gap_bound_interval s g m hs hs3_le hs_le h_lb h_ub v hv_lt
   -- idx ranges
   have hidx_lt : ∀ p, p < m → idx p < s := by
     intro p hp; simp only [idx]; split
     · have : p / (q + 1) < r := by
-        rw [Nat.div_lt_iff_lt_mul (by omega : 0 < q + 1)]
+        rw [Nat.div_lt_iff_lt_mul (by omega)]
         exact ‹_›
       omega
     · rename_i hge; push_neg at hge
@@ -1769,15 +1519,12 @@ lemma case_one_interval (s g : ℕ) (hs : 0 < s) (hs3 : 3 ∣ s)
         omega
       omega
   have hj₀_lt : j₀ < s := hidx_lt v hv_lt
-  have hjg_lt : jg < s :=
-    hidx_lt ((v + g) % m) (Nat.mod_lt _ (by omega))
+  have hjg_lt : jg < s := hidx_lt ((v + g) % m) (Nat.mod_lt _ (by omega))
   -- Phase difference: j₀ % 3 ≠ jg % 3
-  have hphase : j₀ % 3 ≠ jg % 3 :=
-    phase_ne_of_gap hs3 hj₀_lt hjg_lt hgap
+  have hphase : j₀ % 3 ≠ jg % 3 := phase_ne_of_gap hs3 hj₀_lt hjg_lt hgap
   -- Interval bounds
   have hiv := idx_in_interval' s m hs hs_le v hv_lt
-  have hivg := idx_in_interval' s m hs hs_le
-    ((v + g) % m) (Nat.mod_lt _ (by omega))
+  have hivg := idx_in_interval' s m hs hs_le ((v + g) % m) (Nat.mod_lt _ (by omega))
   have hv_lo := hiv.2.1; have hv_hi := hiv.2.2
   have hvg_lo := hivg.2.1; have hvg_hi := hivg.2.2
   -- Bridge: eqp_idx step → equiEndpoint straddle condition
@@ -1789,27 +1536,20 @@ lemma case_one_interval (s g : ℕ) (hs : 0 < s) (hs3 : 3 ∣ s)
     by_cases hp1 : p + 1 < m
     · have hiv_p := idx_in_interval' s m hs hs_le (p + 1) hp1
       simp only at hiv_p
-      change eqp_idx q r (p + 1) < s ∧
-        equiEndpoint m s (eqp_idx q r (p + 1)) ≤ p + 1 ∧ _ at hiv_p
-      rw [hstep_p] at hiv_p; exact hiv_p.2.1
+      change eqp_idx q r (p + 1) < s ∧ equiEndpoint m s (eqp_idx q r (p + 1)) ≤ p + 1 ∧ _ at hiv_p
+      rw [hstep_p] at hiv_p
+      exact hiv_p.2.1
     · have hpm : p + 1 = m := by omega
-      rw [hpm]
-      calc equiEndpoint m s (eqp_idx q r p + 1)
-          ≤ equiEndpoint m s s :=
-            equiEndpoint_monotone (by omega)
-        _ = m := equiEndpoint_hi (by omega)
-  have hs3_le : 3 ≤ s := Nat.le_of_dvd hs hs3
+      rw [hpm]; exact (equiEndpoint_monotone (by omega)).trans (equiEndpoint_hi (by omega)).le
   -- Step 1: which pair covers k?
   have : (k.val = j₀ % 3 ∨ k.val = (j₀ + 1) % 3) ∨
       (k.val = jg % 3 ∨ k.val = (jg + 1) % 3) := by omega
-  rcases this
-    with hk1 | hk2
+  rcases this with hk1 | hk2
   · -- Pair 1 covers k: k ∈ {j₀%3, (j₀+1)%3}
     rcases eqp_idx_step q r v hq_pos with h1_same | h1_step
     · -- Pair 1 non-straddle
       have hv1_lt : v + 1 < m := by
-        rcases eqp_idx_succ_lt_m m q r s v hq_pos hr_lt hm_eq
-          hv_lt with h | h
+        rcases eqp_idx_succ_lt_m m q r s v hq_pos hr_lt hm_eq hv_lt with h | h
         · exact h
         · rw [h1_same] at h
           have : j₀ = s := h; omega
@@ -1819,23 +1559,19 @@ lemma case_one_interval (s g : ℕ) (hs : 0 < s) (hs3 : 3 ∣ s)
         Finset.mem_singleton] at hd_mem ⊢; omega, hd_eq⟩
     · -- Pair 1 straddles → gap = 2
       open Finpartition in
-      have hstrad1 : equiEndpoint m s (j₀ + 1) ≤ v + 1 :=
-        endpoint_bridge v hv_lt hj₀_lt h1_step
+      have hstrad1 : equiEndpoint m s (j₀ + 1) ≤ v + 1 := endpoint_bridge v hv_lt hj₀_lt h1_step
       have hgap2 := straddle1_gap2 s g m hs hs3_le hs_le h_lb
         h_ub v j₀ jg hv_lt hj₀_lt hjg_lt hv_hi hvg_lo
         hvg_hi hstrad1 hgap
-      have hjg1_eq := gap2_jg_mod3 s j₀ jg hs3 hj₀_lt hjg_lt
-        hgap2
+      have hjg1_eq : (jg + 1) % 3 = j₀ % 3 := by
+        grind [gap_mod_cases_gen]
       rcases hk1 with hk_eq | hk_eq
       · -- k = j₀%3 = (jg+1)%3: pair 2 must be non-straddle
-        rcases eqp_idx_step q r ((v + g) % m) hq_pos
-          with h2_same | h2_step
+        rcases eqp_idx_step q r ((v + g) % m) hq_pos with h2_same | h2_step
         · -- Pair 2 non-straddle → witness a = g+d
-          have hvg_lt : (v + g) % m < m :=
-            Nat.mod_lt _ (by omega)
+          have hvg_lt : (v + g) % m < m := Nat.mod_lt _ (by omega)
           have hvg1_lt : (v + g) % m + 1 < m := by
-            rcases eqp_idx_succ_lt_m m q r s ((v + g) % m) hq_pos
-              hr_lt hm_eq hvg_lt with h | h
+            rcases eqp_idx_succ_lt_m m q r s ((v + g) % m) hq_pos hr_lt hm_eq hvg_lt with h | h
             · exact h
             · rw [h2_same] at h
               have : jg = s := h; omega
@@ -1843,36 +1579,28 @@ lemma case_one_interval (s g : ℕ) (hs : 0 < s) (hs3 : 3 ∣ s)
             ((v + g) % m) hq_pos hvg_lt hvg1_lt h2_same jg rfl
             k.val (Or.inr (hk_eq ▸ hjg1_eq.symm))
           refine ⟨g + d, ?_, ?_⟩
-          · simp only [Finset.mem_insert, Finset.mem_singleton]
-              at hd_mem ⊢; omega
-          · change (idx ((v + (g + d)) % m) +
-                off ((v + (g + d)) % m) % 2) % 3 = k.val
+          · simp only [Finset.mem_insert, Finset.mem_singleton] at hd_mem ⊢; omega
+          · change (idx ((v + (g + d)) % m) + off ((v + (g + d)) % m) % 2) % 3 = k.val
             rw [vg_mod_shift m v g d]; exact hd_eq
         · -- Pair 2 straddles → contradiction: gap = 1
           open Finpartition in
-          have hstrad2 : equiEndpoint m s (jg + 1) ≤
-              (v + g) % m + 1 :=
-            endpoint_bridge ((v + g) % m)
-              (Nat.mod_lt _ (by omega)) hjg_lt h2_step
+          have hstrad2 : equiEndpoint m s (jg + 1) ≤ (v + g) % m + 1 :=
+            endpoint_bridge ((v + g) % m) (Nat.mod_lt _ (by omega)) hjg_lt h2_step
           have hgap1 := straddle2_gap1 s g m hs hs3_le hs_le
             h_lb h_ub v j₀ jg hv_lt hj₀_lt hjg_lt hv_lo hv_hi
             hvg_hi hstrad2 hgap
           omega
       · -- k = (j₀+1)%3: witness a = 1
         refine ⟨1, by simp, ?_⟩
-        change (eqp_idx q r ((v + 1) % m) +
-            eqp_off q r ((v + 1) % m) % 2) % 3 = k.val
-        rw [straddle_boundary_color m q r s v hq_pos hr_lt
-          hs3 hm_eq hv_lt h1_step j₀ rfl]
+        change (eqp_idx q r ((v + 1) % m) + eqp_off q r ((v + 1) % m) % 2) % 3 = k.val
+        rw [straddle_boundary_color m q r s v hq_pos hr_lt hs3 hm_eq hv_lt h1_step j₀ rfl]
         exact hk_eq.symm
   · -- Pair 2 covers k: k ∈ {jg%3, (jg+1)%3}
-    rcases eqp_idx_step q r ((v + g) % m) hq_pos
-      with h2_same | h2_step
+    rcases eqp_idx_step q r ((v + g) % m) hq_pos with h2_same | h2_step
     · -- Pair 2 non-straddle
       have hvg_lt : (v + g) % m < m := Nat.mod_lt _ (by omega)
       have hvg1_lt : (v + g) % m + 1 < m := by
-        rcases eqp_idx_succ_lt_m m q r s ((v + g) % m) hq_pos
-          hr_lt hm_eq hvg_lt with h | h
+        rcases eqp_idx_succ_lt_m m q r s ((v + g) % m) hq_pos hr_lt hm_eq hvg_lt with h | h
         · exact h
         · rw [h2_same] at h
           have : jg = s := h; omega
@@ -1880,29 +1608,25 @@ lemma case_one_interval (s g : ℕ) (hs : 0 < s) (hs3 : 3 ∣ s)
         ((v + g) % m) hq_pos hvg_lt hvg1_lt h2_same jg rfl
         k.val hk2
       refine ⟨g + d, ?_, ?_⟩
-      · simp only [Finset.mem_insert, Finset.mem_singleton]
-          at hd_mem ⊢; omega
-      · change (idx ((v + (g + d)) % m) +
-              off ((v + (g + d)) % m) % 2) % 3 = k.val
+      · simp only [Finset.mem_insert, Finset.mem_singleton] at hd_mem ⊢; omega
+      · change (idx ((v + (g + d)) % m) + off ((v + (g + d)) % m) % 2) % 3 = k.val
         rw [vg_mod_shift m v g d]; exact hd_eq
     · -- Pair 2 straddles → gap = 1
       have hvg_lt : (v + g) % m < m := Nat.mod_lt _ (by omega)
       open Finpartition in
       have hstrad2 : equiEndpoint m s (jg + 1) ≤
-          (v + g) % m + 1 :=
-        endpoint_bridge ((v + g) % m) hvg_lt hjg_lt h2_step
+          (v + g) % m + 1 := endpoint_bridge ((v + g) % m) hvg_lt hjg_lt h2_step
       have hgap1 := straddle2_gap1 s g m hs hs3_le hs_le h_lb
         h_ub v j₀ jg hv_lt hj₀_lt hjg_lt hv_lo hv_hi
         hvg_hi hstrad2 hgap
-      have hj01_eq := gap1_j0_mod3 s j₀ jg hs3 hj₀_lt hjg_lt
-        hgap1
+      have hj01_eq : (j₀ + 1) % 3 = jg % 3 := by
+        grind [gap_mod_cases_gen]
       rcases hk2 with hk_eq | hk_eq
       · -- k = jg%3 = (j₀+1)%3: pair 1 non-straddle
         rcases eqp_idx_step q r v hq_pos with h1_same | h1_step
         · -- Pair 1 non-straddle → witness a = d
           have hv1_lt : v + 1 < m := by
-            rcases eqp_idx_succ_lt_m m q r s v hq_pos hr_lt
-              hm_eq hv_lt with h | h
+            rcases eqp_idx_succ_lt_m m q r s v hq_pos hr_lt hm_eq hv_lt with h | h
             · exact h
             · rw [h1_same] at h
               have : j₀ = s := h; omega
@@ -1913,26 +1637,23 @@ lemma case_one_interval (s g : ℕ) (hs : 0 < s) (hs3 : 3 ∣ s)
             Finset.mem_singleton] at hd_mem ⊢; omega, hd_eq⟩
         · -- Pair 1 straddles → contradiction: gap = 2
           open Finpartition in
-          have hstrad1 : equiEndpoint m s (j₀ + 1) ≤ v + 1 :=
-            endpoint_bridge v hv_lt hj₀_lt h1_step
+          have hstrad1 : equiEndpoint m s (j₀ + 1) ≤ v + 1 := endpoint_bridge v hv_lt hj₀_lt h1_step
           have hgap2 := straddle1_gap2 s g m hs hs3_le hs_le
             h_lb h_ub v j₀ jg hv_lt hj₀_lt hjg_lt hv_hi
             hvg_lo hvg_hi hstrad1 hgap
           omega
       · -- k = (jg+1)%3: witness a = g+1
         refine ⟨g + 1, by simp, ?_⟩
-        change (idx ((v + (g + 1)) % m) +
-            off ((v + (g + 1)) % m) % 2) % 3 = k.val
+        change (idx ((v + (g + 1)) % m) + off ((v + (g + 1)) % m) % 2) % 3 = k.val
         rw [vg_mod_shift m v g 1]
-        change (eqp_idx q r (((v + g) % m + 1) % m) +
-            eqp_off q r (((v + g) % m + 1) % m) % 2) % 3 =
+        change (eqp_idx q r (((v + g) % m + 1) % m) + eqp_off q r (((v + g) % m + 1) % m) % 2) % 3 =
           k.val
         rw [straddle_boundary_color m q r s ((v + g) % m)
           hq_pos hr_lt hs3 hm_eq hvg_lt h2_step jg rfl]
         exact hk_eq.symm
 
-/-- Multiplication by a unit in ZMod m is an additive automorphism,
-    so it preserves HasPolychromColouring. This is Lemma 12(iv). -/
+/-- **Key lemma (Lemma 12(iv)).** Multiplication by a unit in ZMod m is an additive
+    automorphism, so it preserves HasPolychromColouring. Used throughout Case 1. -/
 lemma hasPolychromColouring_mul_unit (u : (ZMod m)ˣ) (S : Finset (ZMod m)) :
     HasPolychromColouring (Fin 3) (S.image (u.val * ·)) ↔
     HasPolychromColouring (Fin 3) S := by
@@ -1943,22 +1664,25 @@ lemma hasPolychromColouring_mul_unit (u : (ZMod m)ˣ) (S : Finset (ZMod m)) :
 
 /-! ### Subcase (1c): per-residue lemmas (paper §4.1, case 3 ∤ m)
 
-Each lemma reduces `{0, 1, g, g+1}` to a translate of a Table 1 set via
+Each lemma below reduces `{0, 1, g, g+1}` to a translate of a Table 1 set via
 multiplication by 3 (which is an automorphism of `ZMod m` when `3 ∤ m`).
-The six cases correspond to `m mod 3` and the value of `g` relative to `m/3`.
+The six individual `case_one_res_*` lemmas are routine; the important interface
+is `case_one_residues` which dispatches to them.
 -/
+
+section Case1c
 
 /-- m = 3g - 2: ×3 maps {0,1,g,g+1} to {0,3,3g,3g+3} ≡ {0,2,3,5}. -/
 lemma case_one_res_3g_sub_2 (g : ℕ) (hm : m ≥ 289)
     (hg : m = 3 * g - 2) :
-    HasPolychromColouring (Fin 3)
-      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
+    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
         Finset (ZMod m)) := by
   obtain ⟨u, hu⟩ := ZMod.isUnit_prime_of_not_dvd Nat.prime_three (by grind : ¬3 ∣ m)
   rw [← hasPolychromColouring_mul_unit m u]
   have h3g_mod : (3 : ZMod m) * (g : ZMod m) = 2 := by
     have : ((3 * g : ℕ) : ZMod m) = (m + 2 : ℕ) := by congr 1; grind
-    push_cast [ZMod.natCast_self] at this; grind
+    push_cast [ZMod.natCast_self] at this
+    grind
   have h3g1_mod : (3 : ZMod m) * ((g : ZMod m) + 1) = 5 := by grind
   simpa [hu, Nat.cast_ofNat, image_insert, mul_zero, mul_one, h3g_mod, image_singleton,
     h3g1_mod, insert_comm] using table1_0235 m (by grind)
@@ -1971,7 +1695,8 @@ lemma case_one_res_3g_sub_1 (g : ℕ) (hm : m ≥ 289)
   rw [← hasPolychromColouring_mul_unit m u]
   have h3g_mod : (3 : ZMod m) * g = 1 := by
     have : ((3 * g : ℕ) : ZMod m) = (m + 1 : ℕ) := by congr 1; grind
-    push_cast [ZMod.natCast_self] at this; grind
+    push_cast [ZMod.natCast_self] at this
+    grind
   have h3g1_mod : (3 : ZMod m) * ((g : ZMod m) + 1) = 4 := by grind
   simpa [hu, Nat.cast_ofNat, image_insert, mul_zero, mul_one, h3g_mod,
     image_singleton, h3g1_mod, insert_comm] using table1_0134 m (by grind)
@@ -1984,7 +1709,8 @@ lemma case_one_res_3g_add_1 (g : ℕ) (hm : m ≥ 289)
   rw [← hasPolychromColouring_mul_unit m u]
   have h3g_mod : (3 : ZMod m) * g = -1 := by
     have : ((3 * g + 1 : ℕ) : ZMod m) = (m : ℕ) := by rw [hg]
-    push_cast [ZMod.natCast_self] at this; grind
+    push_cast [ZMod.natCast_self] at this
+    grind
   have h3g1_mod : (3 : ZMod m) * ((g : ZMod m) + 1) = 2 := by grind
   have : {0, (3 : ZMod m), -1, 2} = (-1 : ZMod m) +ᵥ ({0, 1, 3, 4} : Finset (ZMod m)) := by
     simp only [vadd_finset_insert, vadd_finset_singleton, vadd_eq_add]
@@ -1999,7 +1725,8 @@ lemma case_one_res_3g_add_2 (g : ℕ) (hm : m ≥ 289)
   rw [← hasPolychromColouring_mul_unit m u]
   have h3g_mod : (3 : ZMod m) * g = -2 := by
     have : ((3 * g + 2 : ℕ) : ZMod m) = (m : ℕ) := by rw [hg]
-    push_cast [ZMod.natCast_self] at this; grind
+    push_cast [ZMod.natCast_self] at this
+    grind
   have h3g1_mod : (3 : ZMod m) * ((g : ZMod m) + 1) = 1 := by grind
   have : {0, (3 : ZMod m), -2, 1} = (-2 : ZMod m) +ᵥ ({0, 2, 3, 5} : Finset (ZMod m)) := by
     simp only [vadd_finset_insert, vadd_finset_singleton, vadd_eq_add]
@@ -2014,7 +1741,8 @@ lemma case_one_res_3g_add_4 (g : ℕ) (hm : m ≥ 289)
   rw [← hasPolychromColouring_mul_unit m u]
   have h3g_mod : (3 : ZMod m) * g = -4 := by
     have : ((3 * g + 4 : ℕ) : ZMod m) = (m : ℕ) := by rw [hg]
-    push_cast [ZMod.natCast_self] at this; grind
+    push_cast [ZMod.natCast_self] at this
+    grind
   have h3g1_mod : (3 : ZMod m) * ((g : ZMod m) + 1) = -1 := by grind
   have : {0, (3 : ZMod m), -4, -1} = (-4 : ZMod m) +ᵥ ({0, 3, 4, 7} : Finset (ZMod m)) := by
     simp only [vadd_finset_insert, vadd_finset_singleton, vadd_eq_add]
@@ -2029,14 +1757,15 @@ lemma case_one_res_3g_add_5 (g : ℕ) (hm : m ≥ 289)
   rw [← hasPolychromColouring_mul_unit m u]
   have h3g_mod : (3 : ZMod m) * g = -5 := by
     have : ((3 * g + 5 : ℕ) : ZMod m) = (m : ℕ) := by rw [hg]
-    push_cast [ZMod.natCast_self] at this; grind
+    push_cast [ZMod.natCast_self] at this
+    grind
   have h3g1_mod : (3 : ZMod m) * ((g : ZMod m) + 1) = -2 := by grind
   have : {0, (3 : ZMod m), -5, -2} = (-5 : ZMod m) +ᵥ ({0, 3, 5, 8} : Finset (ZMod m)) := by
     simp only [vadd_finset_insert, vadd_finset_singleton, vadd_eq_add]
     grind
   simpa [hu, h3g_mod, h3g1_mod, this] using table1_0358 m (by grind)
 
-/-- Subcase (1c) assembled: dispatches to the six per-residue lemmas above.
+/-- **Subcase (1c) assembled:** dispatches to the six per-residue lemmas above.
     Covers the case `3 ∤ m` with `2⌊m/6⌋ ≤ g ≤ ⌈m/3⌉` (paper §4.1). -/
 lemma case_one_residues (g : ℕ) (hm : m ≥ 289) (h_res : m % 3 ≠ 0)
     (h_range : 2 * (m / 6) ≤ g ∧ g ≤ (m + 2) / 3) :
@@ -2052,43 +1781,24 @@ lemma case_one_residues (g : ℕ) (hm : m ≥ 289) (h_res : m % 3 ≠ 0)
   · exact case_one_res_3g_add_4 _ g hm rfl
   · exact case_one_res_3g_add_5 _ g hm rfl
 
+end Case1c
+
 /-! ### Subcase (1d): 3 ∣ m, split by g mod 3 (paper §4.1, case 3 ∣ m)
 
-When `3 ∣ m`, multiplication by 3 is not available. Instead:
-- If `g ≢ 0 (mod 3)`: the uniform coloring `n ↦ n mod 3` works directly.
-- If `g ≡ 0 (mod 3)` and `m = 3g`: a diagonal coloring `n ↦ (n mod 3 + n/g) mod 3`.
-- If `g ≡ 0 (mod 3)` and `m = 3g+3`: a reversed diagonal coloring of period `g+1`.
+When `3 ∣ m`, multiplication by 3 is not available. Instead, explicit periodic
+colorings are constructed. The three individual lemmas (`case_one_div_g_not_three`,
+`case_one_div_3g`, `case_one_div_3g3`) are routine; `case_one_divisible` dispatches
+to them.
 -/
+
+section Case1d
 
 /-- (1d), g ≢ 0 (mod 3): the periodic coloring 012012...012 works because
     each translate of {0,1,g,g+1} hits all 3 residue classes mod 3. -/
-/- Aristotle alternative for `case_one_div_g_not_three` (13 lines vs 14 original, -1).
-
 lemma case_one_div_g_not_three (g : ℕ)
     (h_div : m = 3 * g ∨ m = 3 * g + 3)
     (hg3 : g % 3 ≠ 0) :
-    HasPolychromColouring (Fin 3)
-      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
-        Finset (ZMod m)) := by
-          -- Define the coloring function χ based on chromosome membership.
-          set χ : ZMod m → Fin 3 := fun n => if n.val % 3 = 0 then 0 else if n.val % 3 = 1 then 1 else 2;
-          use χ; intro n k; simp [χ];
-          rcases h_div with ( rfl | rfl ) <;> norm_num [ ZMod.val_add, Nat.add_mod ] at *;
-          · have h_cases_n : (n + 1).val % 3 = (n.val + 1) % 3 ∧ (n + g).val % 3 = (n.val + g) % 3 ∧ (n + (g + 1)).val % 3 = (n.val + g + 1) % 3 := by
-              cases g <;> simp_all +decide [ ZMod.val_add ];
-              exact ⟨ rfl, rfl, rfl ⟩;
-            grind +ring;
-          · -- By considering all possible values of $n.val \mod 3$ and $g \mod 3$, we can show that the if-then-else expressions cover all cases for $k$.
-            have h_cases : ∀ n : ZMod (3 * g + 3), ∀ g : ℕ, g % 3 ≠ 0 → (n.val % 3 = 0 ∨ n.val % 3 = 1 ∨ n.val % 3 = 2) ∧ (g % 3 = 1 ∨ g % 3 = 2) := by
-              grind +ring;
-            rcases h_cases n g hg3 with ⟨ hn | hn | hn, hg | hg ⟩ <;> fin_cases k <;> simp +decide [ hn, hg ] at hg3 ⊢;
-            all_goals simp +decide [ ZMod.val ] ;
--/
-lemma case_one_div_g_not_three (g : ℕ)
-    (h_div : m = 3 * g ∨ m = 3 * g + 3)
-    (hg3 : g % 3 ≠ 0) :
-    HasPolychromColouring (Fin 3)
-      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
+    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
         Finset (ZMod m)) := by
   have h3_dvd : 3 ∣ m := by rcases h_div with rfl | rfl <;> grind
   haveI : NeZero m := ⟨by grind⟩
@@ -2096,8 +1806,7 @@ lemma case_one_div_g_not_three (g : ℕ)
   simp only [Finset.image_insert, Finset.image_singleton,
     map_zero, map_one, map_add, map_natCast]
   have hg12 : g % 3 = 1 ∨ g % 3 = 2 := by grind
-  suffices ({0, 1, (g : ZMod 3), (g : ZMod 3) + 1} :
-      Finset (ZMod 3)) = Finset.univ by
+  suffices ({0, 1, (g : ZMod 3), (g : ZMod 3) + 1} : Finset (ZMod 3)) = Finset.univ by
     rw [this]; exact hasPolychromColouring_univ
   rcases hg12 with h | h <;> {
     have : (g : ZMod 3) = ↑(g % 3 : ℕ) := by
@@ -2108,8 +1817,7 @@ lemma case_one_div_g_not_three (g : ℕ)
 /-- (1d), m = 3g, g ≡ 0 (mod 3): diagonal coloring `n ↦ (n%3 + n/g) % 3`. -/
 lemma case_one_div_3g (g : ℕ) (hm_eq : m = 3 * g)
     (hg3 : 3 ∣ g) (hg : 0 < g) :
-    HasPolychromColouring (Fin 3)
-      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
+    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
         Finset (ZMod m)) := by
   haveI : NeZero m := ⟨by grind⟩
   haveI : Fact (1 < m) := ⟨by grind⟩
@@ -2119,9 +1827,8 @@ lemma case_one_div_3g (g : ℕ) (hm_eq : m = 3 * g)
   have hc_period : ∀ p, c (p % m) = c p := by
     intro p; simp only [c, hm_eq]
     rw [Nat.mod_mod_of_dvd p (dvd_mul_right 3 g)]
-    have h1 : (3 * (p / (3 * g))) * g = 3 * g * (p / (3 * g)) := by grind
-    have h2 : p = p % (3 * g) + (3 * (p / (3 * g))) * g := by
-      rw [h1]; exact (Nat.mod_add_div p (3 * g)).symm
+    have h2 : p = p % (3 * g) + 3 * (p / (3 * g)) * g := by
+      grind [Nat.mod_add_div p (3 * g)]
     have h3 : p / g = p % (3 * g) / g + 3 * (p / (3 * g)) := by
       conv_lhs => rw [h2]; exact Nat.add_mul_div_right _ _ hg
     conv_rhs => rw [h3]
@@ -2145,23 +1852,24 @@ lemma case_one_div_3g (g : ℕ) (hm_eq : m = 3 * g)
       rw [this, color_at (q + 1) (r + 1) (by grind)]
     exact endgame_witness (Nat.mod_lt _ (by grind)) 0 g (g + 1)
       (by simp) (by simp) (by simp)
-      hcv (by grind)
-        (by grind)
+      hcv (by grind) (by grind)
   · push_neg at hr_lt_gm1
     have hr_eq : r = g - 1 := by grind
     have hcv : c v = (2 + q) % 3 := by grind
     have hcv1 : c (v + 1) = (q + 1) % 3 := by
       have : v + 1 = g * (q + 1) + 0 := by grind
-      rw [this, color_at (q + 1) 0 hg]; grind
+      rw [this, color_at (q + 1) 0 hg]
+      grind
     have hcvg : c (v + g) = (2 + (q + 1)) % 3 := by
       have : v + g = g * (q + 1) + (g - 1) := by grind
-      rw [this]; grind
+      rw [this]
+      grind
     exact endgame_witness (Nat.mod_lt _ (by grind)) 0 g 1
       (by simp) (by simp) (by simp)
       hcv (by grind) (by grind)
 
 /-- (1d), m = 3g+3, g ≡ 0 (mod 3): reversed diagonal coloring of period `g+1`. -/
-/- Aristotle alternative for `case_one_div_3g3` (40 lines vs 53 original, -13).
+/- Aristotle alternative for `case_one_div_3g3` (40 lines vs 52 original, -12).
 
 lemma case_one_div_3g3 (g : ℕ) (hm_eq : m = 3 * g + 3) (hg3 : 3 ∣ g) (hg : 0 < g) :
     HasPolychromColouring (Fin 3)
@@ -2208,8 +1916,7 @@ lemma case_one_div_3g3 (g : ℕ) (hm_eq : m = 3 * g + 3) (hg3 : 3 ∣ g) (hg : 0
         haveI := Fact.mk ( by linarith : 1 < m ) ; erw [ ZMod.val_add ] ; aesop;)))
 -/
 lemma case_one_div_3g3 (g : ℕ) (hm_eq : m = 3 * g + 3) (hg3 : 3 ∣ g) (hg : 0 < g) :
-    HasPolychromColouring (Fin 3)
-      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by
+    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by
   haveI : NeZero m := ⟨by grind⟩
   haveI : Fact (1 < m) := ⟨by grind⟩
   obtain ⟨t, ht⟩ := hg3
@@ -2221,7 +1928,7 @@ lemma case_one_div_3g3 (g : ℕ) (hm_eq : m = 3 * g + 3) (hg3 : 3 ∣ g) (hg : 0
     have hm3h : m = 3 * h := by grind
     intro p; simp only [c, hm3h]
     have hp_eq : p = h * (3 * (p / (3 * h))) + p % (3 * h) := by
-      grind [(Nat.mod_add_div p (3 * h)).symm]
+      grind [Nat.mod_add_div p (3 * h)]
     conv_rhs => rw [hp_eq]
     grind [Nat.mul_add_mod, Nat.add_mul_div_left]
   refine ⟨fun x => ⟨c x.val, hc_lt3 _⟩, fun n k =>
@@ -2237,12 +1944,13 @@ lemma case_one_div_3g3 (g : ℕ) (hm_eq : m = 3 * g + 3) (hg3 : 3 ∣ g) (hg : 0
   by_cases hrg : r = g
   · have hcv : c v = (3 - q % 3) % 3 := by grind
     have hcvg : c (v + g) = (2 + (3 - (q + 1) % 3)) % 3 := by
-      have h1 : v + g = h * (q + 1) + (g - 1) := by grind
-      have h2 : 3 * t - 1 = 3 * (t - 1) + 2 := by grind
-      rw [h1, color_at (q + 1) (g - 1) (by grind), ht, h2]; simp
+      have : v + g = h * (q + 1) + (g - 1) := by grind
+      rw [this, color_at (q + 1) (g - 1) (by grind)]
+      grind
     have hcv1 : c (v + 1) = (3 - (q + 1) % 3) % 3 := by
       have : v + 1 = h * (q + 1) + 0 := by grind
-      rw [this, color_at (q + 1) 0 (by grind)]; grind
+      rw [this, color_at (q + 1) 0 (by grind)]
+      grind
     exact endgame_witness (Nat.mod_lt _ (by grind)) 0 g 1
       (by simp) (by simp) (by simp)
       hcv (by grind) (by grind)
@@ -2255,16 +1963,14 @@ lemma case_one_div_3g3 (g : ℕ) (hm_eq : m = 3 * g + 3) (hg3 : 3 ∣ g) (hg : 0
     exact endgame_witness (Nat.mod_lt _ (by grind)) 0 1 (g + 1)
       (by simp) (by simp) (by simp) rfl
       (by rw [hcv1]
-          change ((r + 1) % 3 + (3 - q % 3)) % 3 =
-            ((r % 3 + (3 - q % 3)) % 3 + 1) % 3
+          change ((r + 1) % 3 + (3 - q % 3)) % 3 = ((r % 3 + (3 - q % 3)) % 3 + 1) % 3
           omega)
       (by have : v + (g + 1) = v + g + 1 := by ring
           rw [this, hcvg1]
-          change (r % 3 + (3 - (q + 1) % 3)) % 3 =
-            ((r % 3 + (3 - q % 3)) % 3 + 2) % 3
+          change (r % 3 + (3 - (q + 1) % 3)) % 3 = ((r % 3 + (3 - q % 3)) % 3 + 2) % 3
           omega)
 
-/-- Subcase (1d) assembled: dispatches on `g % 3` and `m ∈ {3g, 3g+3}` (paper §4.1). -/
+/-- **Subcase (1d) assembled:** dispatches on `g % 3` and `m ∈ {3g, 3g+3}` (paper §4.1). -/
 lemma case_one_divisible (g : ℕ) (hm : m ≥ 289) (h_div : m = 3 * g ∨ m = 3 * g + 3) :
     HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by
   by_cases hg3 : g % 3 = 0
@@ -2273,43 +1979,16 @@ lemma case_one_divisible (g : ℕ) (hm : m ≥ 289) (h_div : m = 3 * g ∨ m = 3
     · exact case_one_div_3g3 m g h (Nat.dvd_of_mod_eq_zero hg3) (by grind)
   · exact case_one_div_g_not_three m g h_div hg3
 
-/-- Combined dispatch: applies subcases (1a)–(1d) for 2 ≤ g ≤ m/2 and m ≥ 289.
-    Let s be the smallest multiple of 3 such that g > ⌈m/s⌉.
-    - (1a): g ∈ {2,3,4}, handled by Table 1 entries
-    - (1b): 5 ≤ g < 2⌊m/s⌋, handled by the interval coloring
-    - (1c): 2⌊m/s⌋ ≤ g ≤ ⌈m/(s-3)⌉ with 3 ∤ m (paper shows s = 6 here),
-            handled by multiplying by 3 and reducing to Table 1
-    - (1d): 2⌊m/s⌋ ≤ g ≤ ⌈m/(s-3)⌉ with 3 ∣ m (paper shows s = 6 here),
-            handled by explicit periodic colorings -/
-/- Aristotle alternative for `case_one_dispatch` (17 body + 32 helpers = 49 vs 50 original, -1).
+end Case1d
 
+/-! ### Combined dispatch for Case 1 -/
+
+/-- **Case 1 combined dispatch:** applies subcases (1a)–(1d) for 2 ≤ g ≤ m/2 and m ≥ 289.
+    This is the main lemma for the single-cycle case, assuming the set has already been
+    reduced to the form {0, 1, g, g+1}. -/
 lemma case_one_dispatch (g : ℕ) (hm : m ≥ 289) (hg_ge : 2 ≤ g)
     (hg_le : g ≤ m / 2) :
-    HasPolychromColouring (Fin 3)
-      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
-        Finset (ZMod m)) := by
-          by_cases hg : g ≤ 4;
-          · apply case_one_small_g m g hm (by
-            grind);
-          · by_cases h_case2a : m ≤ 3 * g - 3;
-            · have h_case2a : 2 * g ≤ m ∧ m ≤ 3 * g - 3 := by
-                omega;
-              apply_rules [ case_one_s_three ];
-              linarith;
-            · by_cases h_case2b : 3 * g - 2 ≤ m ∧ m ≤ 3 * g + 5;
-              · exact?;
-              · -- Since $m \ge 3g + 6$, we can use `case_one_s_exists_refined` to find an $s$ such that $0 < s$, $3 \mid s$, $(m+s-1)/s < g < 2(m/s)$.
-                obtain ⟨s, hs_pos, hs_div, hs_lt_g, hs_gt_g⟩ : ∃ s, 0 < s ∧ 3 ∣ s ∧ (m + s - 1) / s < g ∧ g < 2 * (m / s) := by
-                  apply case_one_s_exists_refined;
-                  · linarith;
-                  · linarith;
-                  · omega;
-                apply_rules [ case_one_interval ]
--/
-lemma case_one_dispatch (g : ℕ) (hm : m ≥ 289) (hg_ge : 2 ≤ g)
-    (hg_le : g ≤ m / 2) :
-    HasPolychromColouring (Fin 3)
-      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
+    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
         Finset (ZMod m)) := by
   -- (1a): small g
   by_cases hg4 : g ≤ 4
@@ -2327,8 +2006,7 @@ lemma case_one_dispatch (g : ℕ) (hm : m ≥ 289) (hg_ge : 2 ≤ g)
         · exact case_one_residues m g hm h3 ⟨hg_lb6, hg_ub3⟩
       · -- g > ⌈m/3⌉: (1b) with s = 3
         push_neg at hg_ub3
-        exact case_one_interval m 3 g (by grind) ⟨1, rfl⟩
-          (by grind) (by grind : g < 2 * (m / 3))
+        exact case_one_interval m 3 g (by grind) ⟨1, rfl⟩ (by grind) (by grind : g < 2 * (m / 3))
     · -- g < 2⌊m/6⌋: (1b), find appropriate s
       push_neg at hg_lb6
       -- s is the smallest multiple of 3 with g > ⌈m/s⌉.
@@ -2342,18 +2020,17 @@ lemma case_one_dispatch (g : ℕ) (hm : m ≥ 289) (hg_ge : 2 ≤ g)
         set q := (m - 1) / (3 * (g - 1))
         have hq_lb : q * (3 * (g - 1)) ≤ m - 1 := Nat.div_mul_le_self _ _
         have hq2 : q ≥ 2 := by
-          by_contra hlt; push_neg at hlt
+          by_contra! hlt
           exact absurd ((Nat.div_lt_iff_lt_mul h3g1).mp hlt) (by grind)
         have hq_ub : m - 1 < 3 * (g - 1) * (q + 1) := Nat.lt_mul_div_succ _ h3g1
         have hm_lb : m ≥ q * (3 * (g - 1)) + 1 := by grind
-        exact case_one_interval m (3 * (q + 1)) g (by grind) ⟨q + 1, rfl⟩
-          (by -- ⌈m/s⌉ < g
-            rw [Nat.div_lt_iff_lt_mul (by grind : 0 < 3 * (q + 1))]
+        exact case_one_interval m (3 * (q + 1)) g (by grind) ⟨q + 1, rfl⟩ (by -- ⌈m/s⌉ < g
+            rw [Nat.div_lt_iff_lt_mul (by grind)]
             have : g * (3 * (q + 1)) = (g - 1 + 1) * (3 * (q + 1)) := by grind
             grind)
           (by -- g < 2⌊m/s⌋
             suffices h : (g + 2) / 2 ≤ m / (3 * (q + 1)) by grind
-            rw [Nat.le_div_iff_mul_le (by grind : 0 < 3 * (q + 1))]
+            rw [Nat.le_div_iff_mul_le (by grind)]
             suffices (g + 2) * (3 * (q + 1)) ≤ 2 * m by
               have := Nat.div_mul_le_self (g + 2) 2; nlinarith
             by_cases hg10 : g ≥ 10
@@ -2362,13 +2039,12 @@ lemma case_one_dispatch (g : ℕ) (hm : m ≥ 289) (hg_ge : 2 ≤ g)
             · have : g = 5 ∨ g = 6 ∨ g = 7 ∨ g = 8 ∨ g = 9 := by grind
               rcases this with rfl | rfl | rfl | rfl | rfl <;> grind)
 
-/-- WLOG g ≤ m/2: in ZMod m, {0,1,m-g,m-g+1} = (-g) +ᵥ {0,1,g,g+1},
-    so HasPolychromColouring is preserved. -/
-lemma case_one_complement (g : ℕ) (hg : g < m) :
-    HasPolychromColouring (Fin 3)
+/-! ### WLOG and aggregation lemmas for Case 1 -/
+
+/-- Auxiliary: WLOG g ≤ m/2, since {0,1,m-g,m-g+1} = (-g) +ᵥ {0,1,g,g+1}. -/
+lemma case_one_complement (g : ℕ) (hg : g < m) : HasPolychromColouring (Fin 3)
       ({0, 1, (↑(m - g) : ZMod m), (↑(m - g) : ZMod m) + 1} : Finset (ZMod m)) ↔
-    HasPolychromColouring (Fin 3)
-      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by
+    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by
   have key : (↑(m - g) : ZMod m) = -(↑g : ZMod m) := by
     rw [Nat.cast_sub hg.le, ZMod.natCast_self, zero_sub]
   have hset : ({0, 1, -(↑g : ZMod m), -(↑g : ZMod m) + 1} : Finset (ZMod m)) =
@@ -2381,17 +2057,16 @@ lemma case_one_complement (g : ℕ) (hg : g < m) :
 private lemma isUnit_intCast_of_natAbs_coprime {n : ℕ} {b : ℤ}
     (h : Nat.gcd b.natAbs n = 1) :
     IsUnit (Int.cast b : ZMod n) := by
-  have hu : IsUnit (b.natAbs : ZMod n) :=
-    (ZMod.isUnit_iff_coprime _ _).mpr h
+  have hu : IsUnit (b.natAbs : ZMod n) := (ZMod.isUnit_iff_coprime _ _).mpr h
   rcases Int.natAbs_eq b with hb | hb
   · have : (Int.cast b : ZMod n) = ↑b.natAbs := by rw [hb]; simp
     rwa [this]
   · have : (Int.cast b : ZMod n) = -↑b.natAbs := by rw [hb]; simp
     rw [this]; exact hu.neg
 
-/-- When gcd(b, m) = 1, there exists 2 ≤ g ≤ m - 2 with gb ≡ b - a (mod m),
-    and zmod_set m a b = (image of {0,1,g,g+1} under ×b). -/
-/- Aristotle alternative for `exists_g_of_coprime` (39 lines vs 49 original, -10).
+/-- **Key reduction for Case 1.** When gcd(b, m) = 1, finds the gap parameter g
+    such that zmod_set m a b = (image of {0,1,g,g+1} under ×b). -/
+/- Aristotle alternative for `exists_g_of_coprime` (39 lines vs 48 original, -9).
 
 lemma exists_g_of_coprime (a b : ℤ) (hd : Nat.gcd b.natAbs m = 1)
     (hm : 0 < m) (hcard : (zmod_set m a b).card = 4) :
@@ -2441,10 +2116,8 @@ lemma exists_g_of_coprime (a b : ℤ) (hd : Nat.gcd b.natAbs m = 1)
 -/
 lemma exists_g_of_coprime (a b : ℤ) (hd : Nat.gcd b.natAbs m = 1)
     (hm : 0 < m) (hcard : (zmod_set m a b).card = 4) :
-    ∃ g : ℕ, 2 ≤ g ∧ g ≤ m - 2 ∧
-      zmod_set m a b =
-        ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)).image
-          ((b : ZMod m) * ·) := by
+    ∃ g : ℕ, 2 ≤ g ∧ g ≤ m - 2 ∧ zmod_set m a b =
+        ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)).image ((b : ZMod m) * ·) := by
   have hm4 : 4 ≤ m := by
     haveI : NeZero m := ⟨by grind⟩
     calc 4 = (zmod_set m a b).card := hcard.symm
@@ -2460,8 +2133,7 @@ lemma exists_g_of_coprime (a b : ℤ) (hd : Nat.gcd b.natAbs m = 1)
     rw [← mul_assoc, ZMod.mul_inv_of_unit _ hub, one_mul]
   have hbg'1 : bz * (g' + 1) = 2 * bz - az := by
     rw [mul_add, mul_one, hbg']; ring
-  have hset : zmod_set m a b =
-      ({0, 1, g', g' + 1} : Finset (ZMod m)).image (bz * ·) := by
+  have hset : zmod_set m a b = ({0, 1, g', g' + 1} : Finset (ZMod m)).image (bz * ·) := by
     simp only [zmod_set, Finset.image_insert, Finset.image_singleton]
     simp only [mul_zero, mul_one, hbg', hbg'1]
     grind
@@ -2471,7 +2143,7 @@ lemma exists_g_of_coprime (a b : ℤ) (hd : Nat.gcd b.natAbs m = 1)
   have hcard4 : ({0, 1, g', g' + 1} : Finset (ZMod m)).card = 4 := by
     rwa [hset, Finset.card_image_of_injective _ hinj] at hcard
   refine ⟨g'.val, ?_, ?_, ?_⟩
-  · by_contra hlt; push_neg at hlt
+  · by_contra! hlt
     have hcases : g'.val = 0 ∨ g'.val = 1 := by grind
     rcases hcases with h | h
     · have hg'0 : g' = 0 := by rw [← hval, h, Nat.cast_zero]
@@ -2483,7 +2155,7 @@ lemma exists_g_of_coprime (a b : ℤ) (hd : Nat.gcd b.natAbs m = 1)
         rw [hg'1]; intro x; simp [Finset.mem_insert, Finset.mem_singleton]
       grind [Finset.card_le_card hsub,
         Finset.card_le_three (a := (0 : ZMod m)) (b := 1) (c := (1 : ZMod m) + 1)]
-  · by_contra hgt; push_neg at hgt
+  · by_contra! hgt
     have hval_lt := ZMod.val_lt g'
     have hgm1 : g'.val = m - 1 := by grind
     have hg'p1 : g' + 1 = 0 := by
@@ -2492,13 +2164,12 @@ lemma exists_g_of_coprime (a b : ℤ) (hd : Nat.gcd b.natAbs m = 1)
     have hsub : ({0, 1, g', g' + 1} : Finset (ZMod m)) ⊆ {0, 1, g'} := by grind
     grind [Finset.card_le_card hsub,
       Finset.card_le_three (a := (0 : ZMod m)) (b := 1) (c := g')]
-  · conv at hset => rhs; rw [hval.symm]
+  · conv at hset => rhs; rw [← hval]
     exact hset
 
-/-- Aggregation of Main Case 1.
-    Reduces to {0,1,g,g+1} via exists_g_of_coprime and hasPolychromColouring_mul_unit,
-    applies WLOG g ≤ m/2 via case_one_complement,
-    then dispatches via case_one_dispatch. -/
+/-- **Main Case 1 (Single Cycle).** Aggregates all subcases (1a)–(1d).
+    Reduces to {0,1,g,g+1} via `exists_g_of_coprime`, applies WLOG g ≤ m/2,
+    then dispatches via `case_one_dispatch`. -/
 lemma main_case_one (a b : ℤ) (hm : m ≥ 289)
     (hcard : (zmod_set m a b).card = 4)
     (h_gcd : Nat.gcd b.natAbs m = 1 ∨ Nat.gcd (b - a).natAbs m = 1) :
@@ -2539,8 +2210,7 @@ consecutive positions within each cycle.
 The proof splits into subcases based on the parity of $d_1$ and $e_1$:
 - **(2a) $e_1$ even:**
   Each cycle uses two alternating colors; adjacent cycles skip different colors.
-- **(2b) $d_1$ even, $e_1$ odd:**
-  Similar but with special "degenerate" handling for odd lengths.
+- **(2b) $d_1$ even, $e_1$ odd:** Similar but with special "degenerate" handling for odd lengths.
 - **(2c) Both odd, $e_1 \le 17$:** Shifted periodic colorings.
 - **(2d) Both odd, $e_1 \ge 19$:** Rotating patterns based on a 3-interval partition.
 -/
@@ -2549,19 +2219,22 @@ section Case2_MultipleCycles
 
 variable (m : ℕ) (a b : ℤ)
 
--- In this section, we work directly with `zmod_set` using cycle decompositions.
--- We inline d1 = gcd(b, m) and e1 = m / d1.
+/-! ### Arithmetic helpers for cycle decomposition
+
+These lemmas set up the orbit map infrastructure. They are not important individually
+but are used throughout Case 2.
+-/
 
 private lemma intCast_2ba_eq :
     ((2 * b - a : ℤ) : ZMod m) = ((b - a : ℤ) : ZMod m) + ((b : ℤ) : ZMod m) := by
   push_cast; ring
 
-private lemma zmod_val_add_one (d : ℕ) [NeZero d] (hd : d ≥ 2) (i : ZMod d) :
+private lemma ZMod.val_add_one {n : ℕ} [NeZero n] (x : ZMod n) : (x + 1).val = (x.val + 1) % n := by
+  rw [ZMod.val_add, ZMod.val_one_eq_one_mod, Nat.add_mod_mod]
+
+private lemma zmod_val_add_one (d : ℕ) [NeZero d] (_hd : d ≥ 2) (i : ZMod d) :
     (i + 1).val = if i.val + 1 < d then i.val + 1 else 0 := by
-  have hival : (i + 1).val = (i.val + 1) % d := by
-    rw [ZMod.val_add]; congr 1
-    haveI : Fact (1 < d) := ⟨by grind⟩; simp [ZMod.val_one]
-  rw [hival]; split_ifs with h
+  rw [ZMod.val_add_one]; split_ifs with h
   · exact Nat.mod_eq_of_lt h
   · grind [Nat.mod_self]
 
@@ -2634,17 +2307,12 @@ private lemma color_covers_even (d₁ e₁ : ℕ) [NeZero d₁] [NeZero e₁]
     · exact Or.inl h
     · exact Or.inr (Or.inl h)
 
-private lemma ZMod.val_add_one {n : ℕ} [NeZero n] (x : ZMod n) :
-    (x + 1).val = (x.val + 1) % n := by
-  rw [ZMod.val_add, ZMod.val_one_eq_one_mod, Nat.add_mod_mod]
-
 /--
 The orbit map $\phi : \mathbb{Z}_{d_1} \times \mathbb{Z}_{e_1} \to \mathbb{Z}_m$ defined by
 $\phi(i, j) = i(b-a) + jb \pmod m$. This map is a bijection when $\gcd(b-a, b, m) = 1$.
 It provides the coordinate system used to analyze the "Multiple Cycles" case.
 -/
-private def orbitMap (m : ℕ) (a b : ℤ) (d₁ e₁ : ℕ) :
-    ZMod d₁ × ZMod e₁ → ZMod m :=
+private def orbitMap (m : ℕ) (a b : ℤ) (d₁ e₁ : ℕ) : ZMod d₁ × ZMod e₁ → ZMod m :=
   fun p => (p.1.val : ZMod m) * ↑(b - a) + (p.2.val : ZMod m) * ↑b
 
 private lemma addOrderOf_b_eq {m : ℕ} {b : ℤ} {d₁ : ℕ} (hm : 0 < m)
@@ -2664,14 +2332,21 @@ private lemma b_zero_mod_d1 {m : ℕ} {b : ℤ} {d₁ : ℕ}
   rw [ZMod.intCast_zmod_eq_zero_iff_dvd]
   exact Int.natCast_dvd.mpr (hd1_def ▸ Nat.gcd_dvd_left b.natAbs m)
 
+/- Aristotle alternative for `ba_coprime_d1` (2 lines vs 5 original, -3).
+
+private lemma ba_coprime_d1 {m : ℕ} {a b : ℤ} {d₁ : ℕ}
+    (hd1_dvd : d₁ ∣ m)
+    (h_gcd_coprime : d₁.gcd (Nat.gcd (b - a).natAbs m) = 1) :
+    Nat.Coprime (b - a).natAbs d₁ := by
+      refine' Nat.Coprime.symm <| Nat.coprime_of_dvd _;
+      intro k hk hk' hk''; have := Nat.dvd_gcd hk' ( Nat.dvd_gcd hk'' ( show k ∣ m from dvd_trans hk' hd1_dvd ) ) ; aesop;
+-/
 private lemma ba_coprime_d1 {m : ℕ} {a b : ℤ} {d₁ : ℕ}
     (hd1_dvd : d₁ ∣ m)
     (h_gcd_coprime : d₁.gcd (Nat.gcd (b - a).natAbs m) = 1) :
     Nat.Coprime (b - a).natAbs d₁ :=
-  Nat.dvd_one.mp (h_gcd_coprime ▸
-    Nat.dvd_gcd (Nat.gcd_dvd_right _ _)
-      (Nat.dvd_gcd (Nat.gcd_dvd_left _ _)
-        (dvd_trans (Nat.gcd_dvd_right _ _) hd1_dvd)))
+  Nat.dvd_one.mp (h_gcd_coprime ▸ Nat.dvd_gcd (Nat.gcd_dvd_right _ _)
+      (Nat.dvd_gcd (Nat.gcd_dvd_left _ _) (dvd_trans (Nat.gcd_dvd_right _ _) hd1_dvd)))
 
 private lemma orbitMap_i_eq {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
     [NeZero m] [NeZero d₁]
@@ -2679,8 +2354,7 @@ private lemma orbitMap_i_eq {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
     (hb_zero : (b : ZMod d₁) = 0)
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
     {i₁ i₂ : ZMod d₁} {j₁ j₂ : ZMod e₁}
-    (heq : orbitMap m a b d₁ e₁ (i₁, j₁) =
-           orbitMap m a b d₁ e₁ (i₂, j₂)) :
+    (heq : orbitMap m a b d₁ e₁ (i₁, j₁) = orbitMap m a b d₁ e₁ (i₂, j₂)) :
     i₁ = i₂ := by
   simp only [orbitMap] at heq
   have := congr_arg (ZMod.castHom hd1_dvd (ZMod d₁)) heq
@@ -2768,8 +2442,7 @@ private lemma orbitMap_shift_b {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
     [NeZero e₁]
     (he1_b_zero : e₁ • (b : ZMod m) = 0) :
     ∀ p : ZMod d₁ × ZMod e₁,
-      orbitMap m a b d₁ e₁ p + (b : ZMod m) =
-        orbitMap m a b d₁ e₁ (p.1, p.2 + 1) := by
+      orbitMap m a b d₁ e₁ p + (b : ZMod m) = orbitMap m a b d₁ e₁ (p.1, p.2 + 1) := by
   intro ⟨i, j⟩
   simp only [orbitMap]
   by_cases hj : j.val + 1 < e₁
@@ -2787,8 +2460,7 @@ private lemma orbitMap_shift_b {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
 private lemma orbitMap_shift_ba {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero d₁]
     (i : ZMod d₁) (j : ZMod e₁)
     (hi : i.val + 1 < d₁) :
-    orbitMap m a b d₁ e₁ (i, j) + ((b - a : ℤ) : ZMod m) =
-      orbitMap m a b d₁ e₁ (i + 1, j) := by
+    orbitMap m a b d₁ e₁ (i, j) + ((b - a : ℤ) : ZMod m) = orbitMap m a b d₁ e₁ (i + 1, j) := by
   simp only [orbitMap]
   have : (i + 1).val = i.val + 1 := by rw [ZMod.val_add_one]; exact Nat.mod_eq_of_lt hi
   rw [this]; push_cast; ring
@@ -2800,8 +2472,7 @@ private lemma orbitMap_cycle_index {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
     (hb_zero : (b : ZMod d₁) = 0)
     (u : (ZMod d₁)ˣ) (hu : ↑u = ((b - a : ℤ) : ZMod d₁))
     (i : ZMod d₁) (j : ZMod e₁) :
-    ZMod.castHom hd1_dvd (ZMod d₁) (orbitMap m a b d₁ e₁ (i, j)) *
-      u⁻¹ = i := by
+    ZMod.castHom hd1_dvd (ZMod d₁) (orbitMap m a b d₁ e₁ (i, j)) * u⁻¹ = i := by
   simp only [orbitMap]
   rw [map_add, map_mul, map_mul, map_natCast, map_intCast, map_natCast,
     map_intCast, hb_zero, mul_zero, add_zero, mul_assoc,
@@ -2856,10 +2527,13 @@ private lemma equiv_symm_fst_eq {d₁ e₁ : ℕ} {γ : Type*}
   have h := hα (Φ.symm x).1 (Φ.symm x).2
   rw [Equiv.apply_symm_apply] at h; exact h.symm
 
-/-- Polychromaticity from an orbit coloring.
-    Given an orbit equivalence Φ with shift properties and a coloring f,
-    if f covers all colors at any translate, then f ∘ Φ.symm is polychromatic. -/
-/- Aristotle alternative for `orbit_coloring_polychrom` (4 lines vs 24 original, -20).
+/-! ### Orbit coloring framework -/
+
+/-- **Key infrastructure for Case 2.** Polychromaticity from an orbit coloring:
+    given an orbit equivalence Φ with shift properties and a coloring f,
+    if f covers all colors at any translate, then f ∘ Φ.symm is polychromatic.
+    All four Case 2 subcases use this as their final step. -/
+/- Aristotle alternative for `orbit_coloring_polychrom` (4 lines vs 23 original, -19).
 
 private lemma orbit_coloring_polychrom {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
     [NeZero m] [NeZero d₁] [NeZero e₁]
@@ -2903,8 +2577,7 @@ private lemma orbit_coloring_polychrom {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
   have hχ_n : χ n = f (i, j) := rfl
   have hχ_nb : χ (n + ↑b) = f (i, j + 1) := congr_arg f (hΦ_add_b n)
   have hi_shift : (Φ.symm (n + ↑(b - a))).1 = i + 1 := hΦ_cycle_shift n
-  have hχ_nba : χ (n + ↑(b - a)) = f (i + 1, j') :=
-    congr_arg f (Prod.ext hi_shift rfl)
+  have hχ_nba : χ (n + ↑(b - a)) = f (i + 1, j') := congr_arg f (Prod.ext hi_shift rfl)
   have hχ_n2ba : χ (n + ↑(2 * b - a)) = f (i + 1, j' + 1) := by
     have : (n : ZMod m) + ↑(2 * b - a) = (n + ↑(b - a)) + ↑b := by
       rw [intCast_2ba_eq, add_assoc]
@@ -2919,13 +2592,10 @@ private lemma orbit_coloring_polychrom {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
   · exact ⟨↑(b - a), by simp, by rw [hχ_nba, h]⟩
   · exact ⟨↑(2 * b - a), by simp, by rw [hχ_n2ba, h]⟩
 
-/--
-Case 2a: $e_1$ is even.
-The cycles are colored with alternating 01 and 02 patterns.
-Because $e_1$ is even, the patterns alternate perfectly without any degenerate positions.
-Adjacent cycles are assigned different "missing" colors to ensure all 3 colors are covered
-by any translate of the set.
--/
+/-! ### Subcase (2a): e₁ even -/
+
+/-- **Subcase (2a).** $e_1$ is even. Each cycle uses two alternating colors;
+    adjacent cycles skip different colors. The simplest of the four subcases. -/
 lemma case_two_e1_even (hm : m ≥ 289)
     (h_gcd_coprime : (Nat.gcd b.natAbs m).gcd (Nat.gcd (b - a).natAbs m) = 1)
     (h_min : min (Nat.gcd b.natAbs m) (Nat.gcd (b - a).natAbs m) > 1)
@@ -2936,8 +2606,8 @@ lemma case_two_e1_even (hm : m ≥ 289)
   have hd₁_dvd : d₁ ∣ m := Nat.gcd_dvd_right _ _
   have hm_eq : m = d₁ * e₁ := (Nat.mul_div_cancel' hd₁_dvd).symm
   have he₁_ge2 : e₁ ≥ 2 := by
-    have : 0 < e₁ := Nat.div_pos (Nat.le_of_dvd (by grind) hd₁_dvd)
-      (Nat.pos_of_ne_zero (by intro h; simp [h] at h_min)); grind
+    have : 0 < e₁ := Nat.div_pos (Nat.le_of_dvd (by grind) hd₁_dvd) (by grind)
+    grind
   haveI : NeZero m := ⟨by grind⟩
   haveI : NeZero d₁ := ⟨by grind⟩
   haveI : NeZero e₁ := ⟨by grind⟩
@@ -2945,8 +2615,7 @@ lemma case_two_e1_even (hm : m ≥ 289)
   have hba_unit : IsUnit (Int.cast (b - a) : ZMod d₁) :=
     isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 hd₁_dvd h_gcd_coprime)
   -- addOrderOf b in ZMod m is e₁
-  have hord : addOrderOf (b : ZMod m) = e₁ :=
-    addOrderOf_b_eq (by grind) rfl
+  have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind) rfl
   have he1_b : e₁ • (b : ZMod m) = 0 := hord ▸ addOrderOf_nsmul_eq_zero _
   -- Define the cycle map φ = orbitMap and derive bijectivity from shared infrastructure
   let φ := orbitMap m a b d₁ e₁
@@ -2954,28 +2623,24 @@ lemma case_two_e1_even (hm : m ≥ 289)
       φ (i, j + 1) = φ (i, j) + ↑b := by
     intro i j; exact (orbitMap_shift_b he1_b (i, j)).symm
   -- φ is bijective (from shared orbitMap infrastructure)
-  let Φ := Equiv.ofBijective φ
-    (orbitMap_bijective hm_eq hd₁_dvd hb_zero hba_unit hord)
+  let Φ := Equiv.ofBijective φ (orbitMap_bijective hm_eq hd₁_dvd hb_zero hba_unit hord)
   -- Cycle index function α : ZMod m → ZMod d₁
   obtain ⟨u_ba, hu_ba⟩ := hba_unit
   let α : ZMod m → ZMod d₁ :=
     fun x => ZMod.castHom hd₁_dvd (ZMod d₁) x * u_ba⁻¹
-  have hα_ba : ∀ x, α (x + ↑(b - a)) = α x + 1 :=
-    cycle_index_shift_ba hd₁_dvd u_ba hu_ba
+  have hα_ba : ∀ x, α (x + ↑(b - a)) = α x + 1 := cycle_index_shift_ba hd₁_dvd u_ba hu_ba
   have hα_φ : ∀ i : ZMod d₁, ∀ j : ZMod e₁, α (φ (i, j)) = i :=
     orbitMap_cycle_index hd₁_dvd hb_zero u_ba hu_ba
   have hΦ_add_b := equiv_symm_shift_b Φ hφ_add_b
   have hΦ_cycle := equiv_symm_fst_eq Φ α hα_φ
   have hd₁_ge2 : d₁ ≥ 2 := by grind
-  have hparity : ∀ j : ZMod e₁, j.val % 2 ≠ (j + 1).val % 2 :=
-    parity_flip_even e₁ he1_even he₁_ge2
-  have hΦ_cycle_shift : ∀ x : ZMod m,
-      (Φ.symm (x + ↑(b - a))).1 = (Φ.symm x).1 + 1 := fun x => by
-    rw [hΦ_cycle, hα_ba, ← hΦ_cycle]
-  exact orbit_coloring_polychrom Φ hΦ_add_b hΦ_cycle_shift (cycle_coloring d₁ e₁)
+  have hparity : ∀ j : ZMod e₁, j.val % 2 ≠ (j + 1).val % 2 := parity_flip_even e₁ he1_even he₁_ge2
+  exact orbit_coloring_polychrom Φ hΦ_add_b
+    (fun x => by rw [hΦ_cycle, hα_ba, ← hΦ_cycle])
+    (cycle_coloring d₁ e₁)
     (fun n k => color_covers_even d₁ e₁ hd₁_ge2 hparity _ _ _ k)
 
-/-! #### Case (2b): d₁ even, e₁ odd
+/-! ### Subcase (2b) construction: d₁ even, e₁ odd
 
 The coloring assigns each even cycle the pattern `01010…011` and each odd cycle
 the pattern `22020…020`. The degenerate pairs `{1,1}` and `{2,2}` occur at
@@ -3073,23 +2738,18 @@ private lemma case2b_coverage_gen (d₁ e₁ : ℕ) [NeZero d₁] [NeZero e₁]
     have hi1 : (i + 1).val % 2 = 1 := by grind
     fin_cases k
     · -- k = 0: by contradiction via degenerate position argument
-      by_contra h_not
-      push_neg at h_not
+      by_contra! h_not
       have hev1 : case2b_coloring d₁ e₁ (i, j₁) = 1 :=
-        case2b_fin3_eq_one (fun h => h_not.1 h.symm)
-          (case2b_even_ne_two d₁ e₁ i j₁ hi)
+        case2b_fin3_eq_one (fun h => h_not.1 h.symm) (case2b_even_ne_two d₁ e₁ i j₁ hi)
       have hev2 : case2b_coloring d₁ e₁ (i, j₁ + 1) = 1 :=
-        case2b_fin3_eq_one (fun h => h_not.2.1 h.symm)
-          (case2b_even_ne_two d₁ e₁ i (j₁ + 1) hi)
+        case2b_fin3_eq_one (fun h => h_not.2.1 h.symm) (case2b_even_ne_two d₁ e₁ i (j₁ + 1) hi)
       have hod1 : case2b_coloring d₁ e₁ (i + 1, j₂) = 2 :=
-        case2b_fin3_eq_two (fun h => h_not.2.2.1 h.symm)
-          (case2b_odd_ne_one d₁ e₁ (i + 1) j₂ hi1)
+        case2b_fin3_eq_two (fun h => h_not.2.2.1 h.symm) (case2b_odd_ne_one d₁ e₁ (i + 1) j₂ hi1)
       have hod2 : case2b_coloring d₁ e₁ (i + 1, j₂ + 1) = 2 :=
         case2b_fin3_eq_two (fun h => h_not.2.2.2 h.symm)
           (case2b_odd_ne_one d₁ e₁ (i + 1) (j₂ + 1) hi1)
       have hj1_eq := case2b_even_degenerate_pos d₁ e₁ he₁ i j₁ hi hev1 hev2
-      have hj2_eq := case2b_odd_degenerate_pos d₁ e₁ he₁_odd he₁
-        (i + 1) j₂ hi1 hod1 hod2
+      have hj2_eq := case2b_odd_degenerate_pos d₁ e₁ he₁_odd he₁ (i + 1) j₂ hi1 hod1 hod2
       exact absurd hj1_eq (h_compat' hj2_eq)
     · -- k = 1: appears in even row
       rcases case2b_even_has_one d₁ e₁ he₁_ge2 i j₁ hi with h | h
@@ -3104,17 +2764,13 @@ private lemma case2b_coverage_gen (d₁ e₁ : ℕ) [NeZero d₁] [NeZero e₁]
     have hi1 : (i + 1).val % 2 = 0 := by grind
     fin_cases k
     · -- k = 0: by contradiction
-      by_contra h_not
-      push_neg at h_not
+      by_contra! h_not
       have hod1 : case2b_coloring d₁ e₁ (i, j₁) = 2 :=
-        case2b_fin3_eq_two (fun h => h_not.1 h.symm)
-          (case2b_odd_ne_one d₁ e₁ i j₁ hi)
+        case2b_fin3_eq_two (fun h => h_not.1 h.symm) (case2b_odd_ne_one d₁ e₁ i j₁ hi)
       have hod2 : case2b_coloring d₁ e₁ (i, j₁ + 1) = 2 :=
-        case2b_fin3_eq_two (fun h => h_not.2.1 h.symm)
-          (case2b_odd_ne_one d₁ e₁ i (j₁ + 1) hi)
+        case2b_fin3_eq_two (fun h => h_not.2.1 h.symm) (case2b_odd_ne_one d₁ e₁ i (j₁ + 1) hi)
       have hev1 : case2b_coloring d₁ e₁ (i + 1, j₂) = 1 :=
-        case2b_fin3_eq_one (fun h => h_not.2.2.1 h.symm)
-          (case2b_even_ne_two d₁ e₁ (i + 1) j₂ hi1)
+        case2b_fin3_eq_one (fun h => h_not.2.2.1 h.symm) (case2b_even_ne_two d₁ e₁ (i + 1) j₂ hi1)
       have hev2 : case2b_coloring d₁ e₁ (i + 1, j₂ + 1) = 1 :=
         case2b_fin3_eq_one (fun h => h_not.2.2.2 h.symm)
           (case2b_even_ne_two d₁ e₁ (i + 1) (j₂ + 1) hi1)
@@ -3130,14 +2786,11 @@ private lemma case2b_coverage_gen (d₁ e₁ : ℕ) [NeZero d₁] [NeZero e₁]
       · exact Or.inl h.symm
       · exact Or.inr (Or.inl h.symm)
 
-/--
-Case 2b: $d_1$ is even and $e_1$ is odd.
-Even cycles use the pattern `0101...011`, and odd cycles use `22020...020`.
-Because $e_1$ is odd, a perfect alternating pattern would have one "degenerate" pair
-at the boundary ($e_1 - 1, 0$). The strategy here places these degenerate pairs
-at different positions for even and odd cycles so that they do not overlap
-when the set $S$ spans two adjacent cycles.
--/
+/-! ### Subcase (2b) main lemma -/
+
+/-- **Subcase (2b).** $d_1$ is even and $e_1$ is odd.
+    Alternating patterns with a "degenerate" position fixup at different positions
+    for even and odd cycles, ensuring they do not overlap across adjacent cycles. -/
 lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
     (h_gcd_coprime : (Nat.gcd b.natAbs m).gcd (Nat.gcd (b - a).natAbs m) = 1)
     (h_min : min (Nat.gcd b.natAbs m) (Nat.gcd (b - a).natAbs m) > 1)
@@ -3150,10 +2803,9 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
   have hd₁_pos : 0 < d₁ := Nat.pos_of_ne_zero (by intro h; simp [h] at h_min)
   have hm_eq : m = d₁ * e₁ := (Nat.mul_div_cancel' hd₁_dvd).symm
   -- e₁ ≥ 3: e₁ is odd and e₁ = 1 would give d₁ = m, contradicting gcd(d₁,d₂) = 1
-  have he₁_pos : 0 < e₁ :=
-    Nat.div_pos (Nat.le_of_dvd (by grind) hd₁_dvd) hd₁_pos
+  have he₁_pos : 0 < e₁ := Nat.div_pos (Nat.le_of_dvd (by grind) hd₁_dvd) hd₁_pos
   have he₁_ge3 : e₁ ≥ 3 := by
-    by_contra h; push_neg at h
+    by_contra! h
     rcases (by grind : e₁ = 1 ∨ e₁ = 2) with he | he
     · have hba_dvd_d₁ : Nat.gcd (b - a).natAbs m ∣ d₁ := by
         rw [hm_eq, he, mul_one]; exact Nat.gcd_dvd_right _ _
@@ -3170,8 +2822,7 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
   have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind) rfl
   have he1_b : e₁ • (b : ZMod m) = 0 := hord ▸ addOrderOf_nsmul_eq_zero _
   -- b/d₁ is coprime to e₁ (needed for compatibility argument)
-  have hd₁_dvd_b : (d₁ : ℤ) ∣ b :=
-    (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp hb_zero
+  have hd₁_dvd_b : (d₁ : ℤ) ∣ b := (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp hb_zero
   obtain ⟨q, hq⟩ := hd₁_dvd_b
   have hq_cop : Nat.Coprime q.natAbs e₁ := by
     have : q.natAbs = b.natAbs / d₁ := by
@@ -3179,8 +2830,7 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
     rw [this]; exact Nat.coprime_div_gcd_div_gcd hd₁_pos
   -- Define the cycle map φ = orbitMap and derive bijectivity from shared infrastructure
   let φ := orbitMap m a b d₁ e₁
-  let Φ := Equiv.ofBijective φ
-    (orbitMap_bijective hm_eq hd₁_dvd hb_zero hba_unit hord)
+  let Φ := Equiv.ofBijective φ (orbitMap_bijective hm_eq hd₁_dvd hb_zero hba_unit hord)
   have hφ_add_b : ∀ i : ZMod d₁, ∀ j : ZMod e₁,
       φ (i, j + 1) = φ (i, j) + ↑b := by
     intro i j; exact (orbitMap_shift_b he1_b (i, j)).symm
@@ -3188,8 +2838,7 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
   obtain ⟨u_ba, hu_ba⟩ := hba_unit
   let α : ZMod m → ZMod d₁ :=
     fun x => ZMod.castHom hd₁_dvd (ZMod d₁) x * u_ba⁻¹
-  have hα_ba : ∀ x, α (x + ↑(b - a)) = α x + 1 :=
-    cycle_index_shift_ba hd₁_dvd u_ba hu_ba
+  have hα_ba : ∀ x, α (x + ↑(b - a)) = α x + 1 := cycle_index_shift_ba hd₁_dvd u_ba hu_ba
   have hα_φ : ∀ i : ZMod d₁, ∀ j : ZMod e₁, α (φ (i, j)) = i :=
     orbitMap_cycle_index hd₁_dvd hb_zero u_ba hu_ba
   have hΦ_add_b := equiv_symm_shift_b Φ hφ_add_b
@@ -3219,8 +2868,7 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
     apply isUnit_intCast_of_natAbs_coprime
     -- gcd(b.natAbs, d₂) = 1: since d₂ coprime to d₁, and b = d₁*q with gcd(q,e₁)=1
     rw [hq, Int.natAbs_mul, Int.natAbs_natCast]
-    exact Nat.Coprime.mul_left h_gcd_coprime
-      (hq_cop.coprime_dvd_right hd₂_dvd_e₁)
+    exact Nat.Coprime.mul_left h_gcd_coprime (hq_cop.coprime_dvd_right hd₂_dvd_e₁)
   -- Degenerate positions can't coincide: use d₂ | (j-j') from projection
   -- π(n+(b-a)) = π(n) since π(b-a)=0, combined with π(φ(i,j))=j.val*π(b)
   -- gives d₂ | (j.val - j'.val). Then d₂ | e₁ and d₂ > 1, so e₁-2 and 0
@@ -3231,14 +2879,15 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
     intro j₁ j₂ heq hj₁ hj₂
     have hval_eq := hπ_b_unit.mul_right_cancel heq
     rw [hj₁, hj₂, Nat.cast_zero] at hval_eq
-    have hd₂_dvd_diff : d₂ ∣ (e₁ - 2) :=
-      (ZMod.natCast_eq_zero_iff _ _).mp hval_eq.symm
+    have hd₂_dvd_diff : d₂ ∣ (e₁ - 2) := (ZMod.natCast_eq_zero_iff _ _).mp hval_eq.symm
     have hd₂_dvd_2 : d₂ ∣ 2 := by
-      have h := Nat.dvd_sub hd₂_dvd_e₁ hd₂_dvd_diff
-      have h2 : e₁ - (e₁ - 2) = 2 := by grind
-      rwa [h2] at h
-    have hd₂_eq2 : d₂ = 2 := by have := Nat.le_of_dvd (by grind) hd₂_dvd_2; grind
-    obtain ⟨k, hk⟩ := hd₂_dvd_e₁; obtain ⟨l, hl⟩ := he1_odd; grind
+      have := Nat.dvd_sub hd₂_dvd_e₁ hd₂_dvd_diff
+      have : e₁ - (e₁ - 2) = 2 := by grind
+      grind
+    obtain ⟨k, hk⟩ := hd₂_dvd_e₁
+    obtain ⟨l, hl⟩ := he1_odd
+    have := Nat.le_of_dvd (by grind) hd₂_dvd_2
+    grind
   -- Define coloring and prove polychromaticity via orbit helper
   have hΦ_cycle_shift : ∀ x : ZMod m,
       (Φ.symm (x + ↑(b - a))).1 = (Φ.symm x).1 + 1 := fun x => by
@@ -3247,21 +2896,15 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
   have hπ_eq : ∀ n : ZMod m, π (n + ↑(b - a)) = π n := fun n => by
     simp only [π, map_add, map_intCast]
     rw [(ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mpr hd₂_dvd_ba, add_zero]
-  exact orbit_coloring_polychrom Φ hΦ_add_b hΦ_cycle_shift (case2b_coloring d₁ e₁)
-    (fun n k => by
+  exact orbit_coloring_polychrom Φ hΦ_add_b hΦ_cycle_shift (case2b_coloring d₁ e₁) (fun n k => by
       set p := Φ.symm n; set j := p.2
       set j' := (Φ.symm (n + ↑(b - a))).2
-      -- π(n) and π(n+(b-a)) give the same ZMod d₂ value
-      have hπ_eq : π (n + ↑(b - a)) = π n := by
-        simp only [π, map_add, map_intCast]
-        rw [(ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mpr hd₂_dvd_ba, add_zero]
       have hπn : π n = (j.val : ZMod d₂) * π (↑b) := by
         have : n = Φ p := (Equiv.apply_symm_apply Φ n).symm
         conv_lhs => rw [this]; exact hπ_φ p.1 j
       have hπn' : π n = (j'.val : ZMod d₂) * π (↑b) := by
         rw [← hπ_eq]
-        have : n + ↑(b - a) = Φ (Φ.symm (n + ↑(b - a))) :=
-          (Equiv.apply_symm_apply Φ _).symm
+        have : n + ↑(b - a) = Φ (Φ.symm (n + ↑(b - a))) := (Equiv.apply_symm_apply Φ _).symm
         conv_lhs => rw [this]; exact hπ_φ _ j'
       have hπ_jj' := hπn.symm.trans hπn'
       exact case2b_coverage_gen d₁ e₁ hd1_even he1_odd he₁_ge3 _ j j'
@@ -3299,7 +2942,7 @@ private lemma cover_mod3_general (p₁ p₂ : Fin 3)
     k = ⟨(j₁ + 1 + p₁.val) % 3, Nat.mod_lt _ (by grind)⟩ ∨
     k = ⟨(j₂ + p₂.val) % 3, Nat.mod_lt _ (by grind)⟩ ∨
     k = ⟨(j₂ + 1 + p₂.val) % 3, Nat.mod_lt _ (by grind)⟩ := by
-  by_contra hall; push_neg at hall
+  by_contra! hall
   obtain ⟨h1, h2, h3, h4⟩ := hall
   grind [Fin.ext_iff]
 
@@ -3319,10 +2962,12 @@ private lemma case2c_wrap_hyp (d₁ k₀ j : ℕ) (hd₁ : d₁ ≥ 3)
   obtain ⟨k, hk⟩ := hd₁_odd; subst hk
   grind [case2c_pattern]
 
-/-! ### Case (2d): d₁, e₁ both odd, e₁ ≥ 19
+/-! ### Subcase (2d): d₁, e₁ both odd, e₁ ≥ 19
 
-The base pattern on C₀ uses three alternating bicolor intervals of sizes u, v, w.
-Each subsequent cycle is a rotation of C₀. The rotation amount must be in [u, e₁-u].
+The most technically involved subcase. The base pattern on C₀ uses three
+alternating bicolor intervals of sizes u, v, w. Each subsequent cycle is a
+rotation of C₀. The many private lemmas below are technical helpers for
+verifying the rotation property; the important result is `case2d_coloring_works`.
 -/
 
 /-- Partition parameter: first interval size for case 2d.
@@ -3337,8 +2982,7 @@ private def case2d_v (e₁ : ℕ) : ℕ :=
   if e₁ % 3 = 1 then e₁ / 3 + 1 else e₁ / 3
 
 
-private lemma case2d_uv_le {e₁ : ℕ} (hge : e₁ ≥ 19) :
-    case2d_u e₁ + case2d_v e₁ ≤ e₁ := by
+private lemma case2d_uv_le {e₁ : ℕ} (hge : e₁ ≥ 19) : case2d_u e₁ + case2d_v e₁ ≤ e₁ := by
   grind [case2d_u, case2d_v]
 
 /-- The base pattern: three alternating bicolor intervals on {0,...,e₁-1}.
@@ -3381,8 +3025,7 @@ private lemma intervalColors_union_covers {i₁ i₂ : Fin 3} (h : i₁ ≠ i₂
   intro k; fin_cases i₁ <;> fin_cases i₂ <;> fin_cases k <;>
     simp_all [intervalColors, Finset.mem_insert, Finset.mem_singleton]
 
-/-- Consecutive positions (j, j+1) within the same interval produce
-    both colors of that interval. -/
+/-- Consecutive positions (j, j+1) within the same interval produce both colors of that interval. -/
 private lemma basePattern_consec_same_interval {e₁ j : ℕ}
     (hsame : whichInterval e₁ j = whichInterval e₁ (j + 1)) :
     {basePattern e₁ j, basePattern e₁ (j + 1)} = intervalColors (whichInterval e₁ j) := by
@@ -3398,8 +3041,7 @@ private lemma basePattern_consec_same_interval {e₁ j : ℕ}
 private lemma basePattern_consec_boundary {e₁ j : ℕ}
     (he : Odd e₁) (hge : e₁ ≥ 19) (hj : j < e₁)
     (hdiff : whichInterval e₁ j ≠ whichInterval e₁ ((j + 1) % e₁)) :
-    {basePattern e₁ j, basePattern e₁ ((j + 1) % e₁)} =
-      intervalColors (whichInterval e₁ j) := by
+    {basePattern e₁ j, basePattern e₁ ((j + 1) % e₁)} = intervalColors (whichInterval e₁ j) := by
   obtain ⟨ku, hku⟩ : Odd (case2d_u e₁) := by obtain ⟨k, hk⟩ := he; grind [case2d_u]
   obtain ⟨kv, hkv⟩ : Odd (case2d_v e₁) := by obtain ⟨k, hk⟩ := he; grind [case2d_v]
   obtain ⟨kw, hkw⟩ : Odd (e₁ - case2d_u e₁ - case2d_v e₁) := by
@@ -3421,8 +3063,7 @@ private lemma basePattern_consec_boundary {e₁ j : ℕ}
     interval pair of whichInterval(j). -/
 private lemma basePattern_consec_pair {e₁ j : ℕ}
     (he : Odd e₁) (hge : e₁ ≥ 19) (hj : j < e₁) :
-    intervalColors (whichInterval e₁ j) ⊆
-      {basePattern e₁ j, basePattern e₁ ((j + 1) % e₁)} := by
+    intervalColors (whichInterval e₁ j) ⊆ {basePattern e₁ j, basePattern e₁ ((j + 1) % e₁)} := by
   by_cases hsame : whichInterval e₁ j = whichInterval e₁ ((j + 1) % e₁)
   · -- Same interval: j+1 < e₁ (otherwise wrap changes interval)
     have hj1 : j + 1 < e₁ := by
@@ -3466,7 +3107,7 @@ private lemma rotation_changes_interval {e₁ j : ℕ}
 
 /-- Key polychromaticity lemma: if the base pattern is rotated by r ∈ [u, e₁-u],
     then at every position j, the 2×2 block covers all 3 colors. -/
-/- Aristotle alternative for `basePattern_rotation_covers` (15 lines vs 19 original, -4).
+/- Aristotle alternative for `basePattern_rotation_covers` (15 lines vs 18 original, -3).
 
 private lemma basePattern_rotation_covers {e₁ j : ℕ} (he : Odd e₁) (hge : e₁ ≥ 19)
     {r : ℕ} (hr_lo : case2d_u e₁ ≤ r) (hr_hi : r ≤ e₁ - case2d_u e₁)
@@ -3494,8 +3135,7 @@ private lemma basePattern_rotation_covers {e₁ j : ℕ} (he : Odd e₁) (hge : 
 private lemma basePattern_rotation_covers {e₁ j : ℕ} (he : Odd e₁) (hge : e₁ ≥ 19)
     {r : ℕ} (hr_lo : case2d_u e₁ ≤ r) (hr_hi : r ≤ e₁ - case2d_u e₁)
     (hj : j < e₁) :
-    ∀ k : Fin 3, k ∈
-      ({basePattern e₁ j, basePattern e₁ ((j + 1) % e₁),
+    ∀ k : Fin 3, k ∈ ({basePattern e₁ j, basePattern e₁ ((j + 1) % e₁),
         basePattern e₁ ((j + r) % e₁),
         basePattern e₁ ((j + r + 1) % e₁)} : Finset (Fin 3)) := by
   intro k
@@ -3505,8 +3145,7 @@ private lemma basePattern_rotation_covers {e₁ j : ℕ} (he : Odd e₁) (hge : 
   have hjr : (j + r) % e₁ < e₁ := Nat.mod_lt _ he₁_pos
   have h2 := basePattern_consec_pair he hge hjr
   -- Rewrite ((j + r) % e₁ + 1) % e₁ = (j + r + 1) % e₁
-  have hmod : ((j + r) % e₁ + 1) % e₁ = (j + r + 1) % e₁ :=
-    Nat.mod_add_mod (j + r) e₁ 1
+  have hmod : ((j + r) % e₁ + 1) % e₁ = (j + r + 1) % e₁ := Nat.mod_add_mod (j + r) e₁ 1
   rw [hmod] at h2
   have hcov := intervalColors_union_covers hI k
   simp only [Finset.mem_insert, Finset.mem_singleton]
@@ -3585,8 +3224,7 @@ private lemma case2d_shift_ba_wrap {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
     (hk₀ : (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m))
     (i : ZMod d₁) (hi : i.val = d₁ - 1) :
     ∀ (j : ZMod e₁),
-      orbitMap m a b d₁ e₁ (i, j) + ((b - a : ℤ) : ZMod m) =
-        orbitMap m a b d₁ e₁ (0, j + k₀) := by
+      orbitMap m a b d₁ e₁ (i, j) + ((b - a : ℤ) : ZMod m) = orbitMap m a b d₁ e₁ (0, j + k₀) := by
   intro j
   simp only [orbitMap, ZMod.val_zero, Nat.cast_zero, zero_mul, zero_add]
   have hpred : (d₁ - 1 + 1 : ℕ) = d₁ := Nat.succ_pred (NeZero.ne d₁)
@@ -3613,7 +3251,7 @@ private lemma case2d_shift_ba_wrap {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
 
 /-- Given d₁ ≥ 3 values each in [u, e₁-u] can sum to any target mod e₁,
     since the range has width ≥ e₁/3 and d₁ ≥ 3. -/
-/- Aristotle alternative for `case2d_rotation_sum_exists` (31 lines vs 80 original, -49).
+/- Aristotle alternative for `case2d_rotation_sum_exists` (31 lines vs 75 original, -44).
 
 private lemma case2d_rotation_sum_exists {e₁ d₁ : ℕ} [NeZero d₁]
     (hd1_ge : d₁ ≥ 5) (he1_ge : e₁ ≥ 19) (he1_odd : Odd e₁)
@@ -3664,8 +3302,7 @@ private lemma case2d_rotation_sum_exists {e₁ d₁ : ℕ} [NeZero d₁]
   have hdw' : d₁ * (e₁ - 2 * case2d_u e₁) ≥ e₁ := by
     change d₁ * (e₁ - 2 * (e₁ / 3 + e₁ % 3)) ≥ e₁
     obtain ⟨k, hk⟩ := he1_odd; subst hk
-    have h5w : 5 * ((2 * k + 1) - 2 * ((2 * k + 1) / 3 + (2 * k + 1) % 3)) ≥
-        2 * k + 1 := by grind
+    have h5w : 5 * ((2 * k + 1) - 2 * ((2 * k + 1) / 3 + (2 * k + 1) % 3)) ≥ 2 * k + 1 := by grind
     exact le_trans h5w (by gcongr)
   set u := case2d_u e₁
   set w := e₁ - 2 * u
@@ -3677,7 +3314,7 @@ private lemma case2d_rotation_sum_exists {e₁ d₁ : ℕ} [NeZero d₁]
   set r := deficit % w
   have hr_lt : r < w := Nat.mod_lt _ hw_pos
   have hq_lt : q < d₁ := by
-    by_contra hge; push_neg at hge
+    by_contra! hge
     have h1 : deficit ≥ d₁ * w :=
       calc deficit ≥ deficit / w * w := Nat.div_mul_le_self deficit w
         _ = q * w := rfl
@@ -3704,8 +3341,7 @@ private lemma case2d_rotation_sum_exists {e₁ d₁ : ℕ} [NeZero d₁]
       · simp only [Finset.sum_ite, Finset.sum_const_zero, add_zero, Finset.sum_const,
           smul_eq_mul]
         congr 1
-        trans (Finset.image ZMod.val
-          (Finset.univ.filter (fun i : ZMod d₁ => i.val < q))).card
+        trans (Finset.image ZMod.val (Finset.univ.filter (fun i : ZMod d₁ => i.val < q))).card
         · rw [Finset.card_image_of_injective _ (ZMod.val_injective _)]
         · have : Finset.image ZMod.val
               (Finset.univ.filter (fun i : ZMod d₁ => i.val < q)) =
@@ -3720,8 +3356,7 @@ private lemma case2d_rotation_sum_exists {e₁ d₁ : ℕ} [NeZero d₁]
           rw [this]; exact Finset.card_range q
       · rw [Finset.sum_ite, Finset.sum_const_zero, add_zero, Finset.sum_const, smul_eq_mul]
         have : (Finset.univ.filter (fun i : ZMod d₁ => i.val = q)).card = 1 := by
-          have : Finset.univ.filter (fun i : ZMod d₁ => i.val = q) =
-              {(q : ZMod d₁)} := by
+          have : Finset.univ.filter (fun i : ZMod d₁ => i.val = q) = {(q : ZMod d₁)} := by
             ext i; simp only [Finset.mem_filter, Finset.mem_univ, true_and,
               Finset.mem_singleton]
             constructor
@@ -3734,17 +3369,14 @@ private lemma case2d_rotation_sum_exists {e₁ d₁ : ℕ} [NeZero d₁]
     simp only [deficit]
     rw [Nat.add_mod_mod]
     have hle : d₁ * u ≤ target + e₁ * d₁ :=
-      le_add_left (le_trans (Nat.mul_le_mul_left d₁ (le_of_lt hu_lt))
-        (by rw [Nat.mul_comm]))
-    have hadd : d₁ * u + (target + e₁ * d₁ - d₁ * u) = target + e₁ * d₁ :=
-      Nat.add_sub_cancel' hle
+      le_add_left (le_trans (Nat.mul_le_mul_left d₁ (le_of_lt hu_lt)) (by rw [Nat.mul_comm]))
+    have hadd : d₁ * u + (target + e₁ * d₁ - d₁ * u) = target + e₁ * d₁ := Nat.add_sub_cancel' hle
     rw [hadd, Nat.add_mul_mod_self_left]
 
 private lemma zero_mem_zmod_set (m : ℕ) (a b : ℤ) : (0 : ZMod m) ∈ zmod_set m a b := by
   simp [zmod_set]
 
-private lemma intCast_b_mem_zmod_set (m : ℕ) (a b : ℤ) :
-    ((b : ℤ) : ZMod m) ∈ zmod_set m a b := by
+private lemma intCast_b_mem_zmod_set (m : ℕ) (a b : ℤ) : ((b : ℤ) : ZMod m) ∈ zmod_set m a b := by
   simp [zmod_set]
 
 private lemma intCast_ba_mem_zmod_set (m : ℕ) (a b : ℤ) :
@@ -3778,7 +3410,7 @@ private lemma zmod_filter_sum_last {n : ℕ} [NeZero n] (f : ZMod n → ℕ) (i 
   simp only [Finset.mem_filter, Finset.mem_univ, true_and]
   exact ⟨fun _ => True.intro, fun _ => by have := k.val_lt (n := n); grind⟩
 
--- Position arithmetic helpers for case2d_coloring_works
+-- Position arithmetic helpers for case2d_coloring_works (not important individually)
 
 /-- Position shift by 1: adding 1 to ZMod coordinate shifts position by 1 mod n. -/
 private lemma pos_shift_one {n : ℕ} [NeZero n] (j : ZMod n) (c : ℕ) :
@@ -3786,7 +3418,7 @@ private lemma pos_shift_one {n : ℕ} [NeZero n] (j : ZMod n) (c : ℕ) :
   rw [ZMod.val_add_one, Nat.mod_add_mod, Nat.mod_add_mod]; grind
 
 /-- (j + (S + V) % n) % n = ((j + S % n) % n + V) % n -/
-/- Aristotle alternative for `pos_shift_succ'` (2 lines vs 4 original, -2).
+/- Aristotle alternative for `pos_shift_succ'` (2 lines vs 3 original, -1).
 
 private lemma pos_shift_succ' (j S V n : ℕ) :
     (j + (S + V) % n) % n = ((j + S % n) % n + V) % n := by
@@ -3796,19 +3428,17 @@ private lemma pos_shift_succ' (j S V n : ℕ) :
 private lemma pos_shift_succ' (j S V n : ℕ) :
     (j + (S + V) % n) % n = ((j + S % n) % n + V) % n := by
   have h1 : j + (S + V) = j + S + V := by grind
-  have h2 : (j + S) % n = (j + S % n) % n :=
-    (Nat.add_mod_mod j S n).symm
+  have h2 : (j + S) % n = (j + S % n) % n := (Nat.add_mod_mod j S n).symm
   rw [Nat.add_mod_mod, h1, ← Nat.mod_add_mod (j + S) n V, h2]
 
-/-- Wrap case: if (S + V) % n = k₀ % n, then
-    (j + k₀) % n = ((j + S % n) % n + V) % n -/
+/-- Wrap case: if (S + V) % n = k₀ % n, then (j + k₀) % n = ((j + S % n) % n + V) % n -/
 private lemma pos_shift_wrap' (j S V k₀ n : ℕ)
     (hsum : (S + V) % n = k₀ % n) :
     (j + k₀) % n = ((j + S % n) % n + V) % n := by
   rw [← Nat.add_mod_mod j k₀ n, ← hsum, pos_shift_succ']
 
-/-- The coloring for case (2d), connecting to ZMod m. Uses cycle coordinates
-    c_{i,j} = i*(b-a) + j*b and the base pattern with rotations. -/
+/-- **Subcase (2d) assembled.** Constructs the coloring for the case when both d₁
+    and e₁ are odd with e₁ ≥ 19, using rotated interval patterns. -/
 private lemma case2d_coloring_works {m : ℕ} {a b : ℤ}
     (hm : m ≥ 289)
     (h_gcd_coprime : (Nat.gcd b.natAbs m).gcd (Nat.gcd (b - a).natAbs m) = 1)
@@ -3836,8 +3466,7 @@ private lemma case2d_coloring_works {m : ℕ} {a b : ℤ}
   obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hd1_dvd hb_zero hba_unit hord hm_eq
   -- d₁ is odd, > 1, and ¬(3∣d₁), so d₁ ≥ 5
   have hd1_ge5 : d₁ ≥ 5 := by grind
-  obtain ⟨vals, hvals_bound, hvals_sum⟩ :=
-    case2d_rotation_sum_exists hd1_ge5 he1_ge he1_odd k₀.val
+  obtain ⟨vals, hvals_bound, hvals_sum⟩ := case2d_rotation_sum_exists hd1_ge5 he1_ge he1_odd k₀.val
   -- Cumulative rotation: rot(i) = (Σ_{j<i} vals(j)) % e₁
   let rot : ZMod d₁ → ℕ := fun i =>
     ((Finset.univ.filter (fun j : ZMod d₁ => j.val < i.val)).sum vals) % e₁
@@ -3882,8 +3511,7 @@ private lemma case2d_coloring_works {m : ℕ} {a b : ℤ}
     · refine ⟨((2 * b - a : ℤ) : ZMod m), intCast_2ba_mem_zmod_set m a b, ?_⟩
       rw [← hΦ_2ba, hχ_eq, h]; congr 1
       calc ((j_new + 1 : ZMod e₁).val + rot i_new) % e₁
-          = ((j_new.val + rot i_new) % e₁ + 1) % e₁ :=
-            pos_shift_one j_new (rot i_new)
+          = ((j_new.val + rot i_new) % e₁ + 1) % e₁ := pos_shift_one j_new (rot i_new)
         _ = ((p + vals i) % e₁ + 1) % e₁ := by rw [hpos]
         _ = (p + vals i + 1) % e₁ := Nat.mod_add_mod (p + vals i) e₁ 1
   by_cases hi : i.val + 1 < d₁
@@ -3904,23 +3532,17 @@ private lemma case2d_coloring_works {m : ℕ} {a b : ℤ}
     refine ⟨0, j + k₀, ?_, ?_⟩
     · rw [← hn, hij]; exact (case2d_shift_ba_wrap he1_b_zero k₀ hk₀ i hi_eq j).symm
     · have hrot0 : rot (0 : ZMod d₁) = 0 := by simp [rot, ZMod.val_zero]
-      have htotal :
-          (Finset.univ.filter (fun k : ZMod d₁ => k.val < i.val)).sum vals +
-            vals i = Finset.univ.sum vals :=
-        zmod_filter_sum_last vals i hi_eq
+      have htotal : (Finset.univ.filter (fun k : ZMod d₁ => k.val < i.val)).sum vals +
+            vals i = Finset.univ.sum vals := zmod_filter_sum_last vals i hi_eq
       rw [hrot0, Nat.add_zero, ZMod.val_add, Nat.mod_mod_of_dvd _ (dvd_refl e₁)]
       exact pos_shift_wrap' j.val _ (vals i) k₀.val e₁ (by rw [htotal, hvals_sum])
 
 -- Mod 3 arithmetic: (a % e₁ + b) % 3 = (a + b) % 3 when 3 ∣ e₁
-private lemma case2c_mod3 {e₁ : ℕ} (h3e : 3 ∣ e₁) (x y : ℕ) :
-    (x % e₁ + y) % 3 = (x + y) % 3 := by
+private lemma case2c_mod3 {e₁ : ℕ} (h3e : 3 ∣ e₁) (x y : ℕ) : (x % e₁ + y) % 3 = (x + y) % 3 := by
   rw [Nat.add_mod, Nat.mod_mod_of_dvd x h3e, ← Nat.add_mod]
 
-/-- Subcase (2c): d₁ and e₁ are both odd, with e₁ ≤ 17 and 3 ∣ e₁.
-    Each cycle Cᵢ is colored with one of three shifted 012-patterns:
-      Pattern p: position j gets color (j + p) mod 3.
-    Adjacent cycles use different patterns, ensuring all 2×2 blocks
-    (translates of S) contain all 3 colors. -/
+/-- **Subcase (2c):** d₁ and e₁ are both odd, with e₁ ≤ 17 and 3 ∣ e₁.
+    Uses shifted periodic 012-patterns with different shifts for adjacent cycles. -/
 lemma case_two_odd_small (hm : m ≥ 289)
     (h_gcd_coprime : (Nat.gcd b.natAbs m).gcd (Nat.gcd (b - a).natAbs m) = 1)
     (h_min : min (Nat.gcd b.natAbs m) (Nat.gcd (b - a).natAbs m) > 1)
@@ -3933,9 +3555,7 @@ lemma case_two_odd_small (hm : m ≥ 289)
   set e₁ := m / d₁ with he1_def
   have hd1_dvd : d₁ ∣ m := Nat.gcd_dvd_right _ _
   have hd1_gt1 : d₁ > 1 := by grind
-  have he1_ge3 : e₁ ≥ 3 := by
-    grind
-  have he1_pos : 0 < e₁ := by grind
+  have he1_ge3 : e₁ ≥ 3 := by grind
   have hm_eq : m = d₁ * e₁ := (Nat.mul_div_cancel' hd1_dvd).symm
   haveI : NeZero m := ⟨by grind⟩
   haveI : NeZero d₁ := ⟨by grind⟩
@@ -4024,8 +3644,7 @@ lemma case_two_odd_small (hm : m ≥ 289)
     have hhyp : (j.val + p.val) % 3 ≠ (j.val + k₀.val + p₀.val) % 3 := by
       rw [hp_eq]; exact case2c_wrap_hyp d₁ k₀.val j.val hd1_ge3 hd1_odd
     -- Apply cover_mod3_general
-    rcases cover_mod3_general p p₀ j.val (j.val + k₀.val) hhyp k
-      with h | h | h | h
+    rcases cover_mod3_general p p₀ j.val (j.val + k₀.val) hhyp k with h | h | h | h
     · exact ⟨0, zero_mem_zmod_set m a b,
         by rw [add_zero, ← hn, hij, hχ_eq, h]⟩
     · refine ⟨((b : ℤ) : ZMod m), intCast_b_mem_zmod_set m a b, ?_⟩
@@ -4044,45 +3663,12 @@ lemma case_two_odd_small (hm : m ≥ 289)
         (j.val + k₀.val + 1 + p₀.val) % 3
       have hj'val : j'.val = (j.val + k₀.val) % e₁ := ZMod.val_add j k₀
       rw [ZMod.val_zero, hzmod_succ, hj'val]
-      rw [case2c_mod3 he1_div3 ((j.val + k₀.val) % e₁ + 1) p₀.val]
-      have h1 : (j.val + k₀.val) % e₁ + 1 + p₀.val =
-            (j.val + k₀.val) % e₁ + (1 + p₀.val) := by grind
-      have h2 : j.val + k₀.val + 1 + p₀.val =
-            j.val + k₀.val + (1 + p₀.val) := by grind
-      rw [h1, h2]
+      rw [case2c_mod3 he1_div3 ((j.val + k₀.val) % e₁ + 1) p₀.val,
+        Nat.add_assoc ((j.val + k₀.val) % e₁),
+        Nat.add_assoc (j.val + k₀.val)]
       exact case2c_mod3 he1_div3 (j.val + k₀.val) (1 + p₀.val)
 
-/-- When gcd(d₁,d₂) = 1, both d₁,d₂ > 1, both d₁,d₂ divide m,
-    and m/d₁ ≤ 17 and m/d₂ ≤ 17, we get m ≤ 289. Combined with
-    m ≥ 289 this forces m = 289 = 17², but then gcd(d₁,d₂) = 1 with
-    d₁,d₂ | 17² and d₁,d₂ > 1 is impossible. -/
-/- Aristotle alternative for `no_both_e_small` (18 lines vs 20 original, -2).
-
-private lemma no_both_e_small {m d₁ d₂ : ℕ}
-    (hm : m ≥ 289)
-    (hcop : Nat.gcd d₁ d₂ = 1)
-    (hd₁_gt1 : d₁ > 1) (hd₂_gt1 : d₂ > 1)
-    (hd₁_dvd : d₁ ∣ m) (hd₂_dvd : d₂ ∣ m)
-    (he₁_le : m / d₁ ≤ 17) (he₂_le : m / d₂ ≤ 17) : False := by
-      -- Since $d₁$ and $d₂$ are coprime and both divide $m$, their product $d₁*d₂$ must also divide $m$. Therefore, $m \geq d₁*d₂$.
-      have h_prod_div : d₁ * d₂ ∣ m := by
-        -- Since $d₁$ and $d₂$ are coprime and both divide $m$, their product $d₁*d₂$ must also divide $m$ by the property of coprime divisors.
-        apply Nat.Coprime.mul_dvd_of_dvd_of_dvd hcop hd₁_dvd hd₂_dvd;
-      -- Since $d₁$ and $d₂$ are coprime and both divide $m$, their product $d₁*d₂$ must also divide $m$. Therefore, $m \geq d₁*d₂$. Given that $m \geq 289$, we have $289 \leq d₁*d₂$.
-      have h_prod_ge : 289 ≤ d₁ * d₂ := by
-        -- Since $m$ is a multiple of $d₁ * d₂$, we have $m = (d₁ * d₂) * k$ for some integer $k$.
-        obtain ⟨k, hk⟩ : ∃ k, m = d₁ * d₂ * k := h_prod_div;
-        rcases k with ( _ | _ | k ) <;> simp_all! +arith +decide [ Nat.mul_div_assoc ];
-        simp_all +decide [ mul_assoc, Nat.mul_div_assoc ];
-        simp_all +decide [ Nat.mul_div_cancel_left _ ( by linarith : 0 < d₁ ), Nat.mul_div_cancel_left _ ( by linarith : 0 < d₂ ) ] ; nlinarith only [ hm, hd₁_gt1, hd₂_gt1, he₁_le, he₂_le ] ;
-      -- Combining the inequalities $m \geq d₁ * d₂$ and $m \leq 17 * d₁$ and $m \leq 17 * d₂$, we get $d₁ * d₂ \leq 17 * d₁$ and $d₁ * d₂ \leq 17 * d₂$.
-      have h_combined : d₁ * d₂ ≤ 17 * d₁ ∧ d₁ * d₂ ≤ 17 * d₂ := by
-        exact ⟨ by nlinarith [ Nat.div_mul_cancel hd₁_dvd, Nat.le_of_dvd ( by linarith ) h_prod_div ], by nlinarith [ Nat.div_mul_cancel hd₂_dvd, Nat.le_of_dvd ( by linarith ) h_prod_div ] ⟩;
-      -- Since $d₁$ and $d₂$ are both greater than 1 and their product is 289, the only possible pair is (17, 17), but this contradicts the coprimality condition.
-      have h_contra : d₁ = 17 ∧ d₂ = 17 := by
-        constructor <;> nlinarith only [ hd₁_gt1, hd₂_gt1, h_prod_ge, h_combined ];
-      aesop_cat
--/
+/-- Auxiliary: rules out both cycle lengths being ≤ 17 when m ≥ 289. -/
 private lemma no_both_e_small {m d₁ d₂ : ℕ}
     (hm : m ≥ 289)
     (hcop : Nat.gcd d₁ d₂ = 1)
@@ -4090,31 +3676,26 @@ private lemma no_both_e_small {m d₁ d₂ : ℕ}
     (hd₁_dvd : d₁ ∣ m) (hd₂_dvd : d₂ ∣ m)
     (he₁_le : m / d₁ ≤ 17) (he₂_le : m / d₂ ≤ 17) : False := by
   have hd₁_bound : m ≤ d₁ * 17 := by
-    calc m = d₁ * (m / d₁) := (Nat.mul_div_cancel' hd₁_dvd).symm
-      _ ≤ d₁ * 17 := by gcongr
+    rw [← Nat.mul_div_cancel' hd₁_dvd]; gcongr
   have hd₂_bound : m ≤ d₂ * 17 := by
-    calc m = d₂ * (m / d₂) := (Nat.mul_div_cancel' hd₂_dvd).symm
-      _ ≤ d₂ * 17 := by gcongr
+    rw [← Nat.mul_div_cancel' hd₂_dvd]; gcongr
   have hprod_le : d₁ * d₂ ≤ m :=
     Nat.le_of_dvd (by grind)
       (Nat.Coprime.mul_dvd_of_dvd_of_dvd (by rwa [Nat.Coprime]) hd₁_dvd hd₂_dvd)
   -- d₁*d₂ ≤ m ≤ d₁*17 → d₂ ≤ 17; similarly d₁ ≤ 17
-  have hd₂_le : d₂ ≤ 17 :=
-    Nat.le_of_mul_le_mul_left (hprod_le.trans hd₁_bound) (by grind)
+  have hd₂_le : d₂ ≤ 17 := Nat.le_of_mul_le_mul_left (hprod_le.trans hd₁_bound) (by grind)
   have hd₁_le : d₁ ≤ 17 :=
-    Nat.le_of_mul_le_mul_left
-      (mul_comm d₁ d₂ ▸ hprod_le.trans hd₂_bound) (by grind)
+    Nat.le_of_mul_le_mul_left (mul_comm d₁ d₂ ▸ hprod_le.trans hd₂_bound) (by grind)
   -- 289 ≤ m ≤ d₁*17 → d₁ ≥ 17; similarly d₂ ≥ 17
   -- So d₁ = d₂ = 17, gcd(17,17) = 17 ≠ 1.
   have hd₁_eq : d₁ = 17 := by grind
   have hd₂_eq : d₂ = 17 := by grind
   rw [hd₁_eq, hd₂_eq] at hcop; simp at hcop
 
-/-- Aggregation of Main Case 2.
-    Assumption: min(gcd(b, m), gcd(b-a, m)) > 1.
-    Matches the paper's proof structure: first WLOG swap so that 3 ∤ d₁
-    (choosing the smallest non-multiple-of-3), then split into subcases
-    (2a)–(2d). -/
+/-! ### Aggregation of Case 2 -/
+
+/-- **Main Case 2 (Multiple Cycles).** Aggregates all subcases (2a)–(2d).
+    First applies WLOG to ensure 3 ∤ d₁, then dispatches on parity of d₁ and e₁. -/
 lemma main_case_two (hm : m ≥ 289)
     (h_gcd_coprime : (Nat.gcd b.natAbs m).gcd (Nat.gcd (b - a).natAbs m) = 1)
     (h_min : min (Nat.gcd b.natAbs m) (Nat.gcd (b - a).natAbs m) > 1) :
@@ -4139,15 +3720,14 @@ lemma main_case_two (hm : m ≥ 289)
           set a' := (-a : ℤ); set b' := (b - a : ℤ)
           have hba_eq : (b' - a').natAbs = b.natAbs := by
             change (b - a - -a).natAbs = b.natAbs; congr 1; ring
-          have hcop' : (Nat.gcd b'.natAbs m).gcd
-              (Nat.gcd (b' - a').natAbs m) = 1 := by
+          have hcop' : (Nat.gcd b'.natAbs m).gcd (Nat.gcd (b' - a').natAbs m) = 1 := by
             rw [hba_eq]; rwa [Nat.gcd_comm]
-          have hmin' : min (Nat.gcd b'.natAbs m)
-              (Nat.gcd (b' - a').natAbs m) > 1 := by
+          have hmin' : min (Nat.gcd b'.natAbs m) (Nat.gcd (b' - a').natAbs m) > 1 := by
             rw [hba_eq]; rwa [min_comm]
           have h3' : ¬ (3 ∣ Nat.gcd b'.natAbs m) := by
             intro h3d'; have := Nat.dvd_gcd h3 h3d'
-            rw [h_gcd_coprime] at this; grind
+            rw [h_gcd_coprime] at this
+            grind
           rcases Nat.even_or_odd (m / Nat.gcd b'.natAbs m) with he' | ho'
           · exact case_two_e1_even m a' b' hm hcop' hmin' he'
           · rcases Nat.even_or_odd (Nat.gcd b'.natAbs m) with hd' | hd'
@@ -4161,8 +3741,7 @@ lemma main_case_two (hm : m ≥ 289)
       set e₁ := m / d₁
       have hd₁_dvd : d₁ ∣ m := Nat.gcd_dvd_right _ _
       have hd₂_dvd : d₂ ∣ m := Nat.gcd_dvd_right _ _
-      have hd₂_pos : 0 < d₂ :=
-        Nat.pos_of_ne_zero (by intro h; simp [h] at hmin)
+      have hd₂_pos : 0 < d₂ := Nat.pos_of_ne_zero (by intro h; simp [h] at hmin)
       by_cases he_le : e₁ ≤ 17
       · -- Case 2c: prove 3 ∣ e₁
         -- Since gcd(d₁,d₂)=1 and 3 ∤ d₁, if 3 ∣ d₂ then 3 ∣ m hence 3 ∣ e₁.
@@ -4170,24 +3749,19 @@ lemma main_case_two (hm : m ≥ 289)
         by_cases h3d₂ : 3 ∣ d₂
         · have h3m : 3 ∣ m := dvd_trans h3d₂ hd₂_dvd
           have h3e₁ : 3 ∣ e₁ := by
-            have h3de : 3 ∣ d₁ * e₁ :=
-              (Nat.mul_div_cancel' hd₁_dvd).symm ▸ h3m
-            have hcop3 : Nat.Coprime 3 d₁ :=
-              (Nat.Prime.coprime_iff_not_dvd (by decide)).mpr h3_nd₁
+            have h3de : 3 ∣ d₁ * e₁ := Nat.mul_div_cancel' hd₁_dvd ▸ h3m
+            have hcop3 : Nat.Coprime 3 d₁ := (Nat.Prime.coprime_iff_not_dvd (by decide)).mpr h3_nd₁
             exact hcop3.dvd_of_dvd_mul_left h3de
-          exact case_two_odd_small m a' b' hm hcop hmin hd₁_odd he₁_odd
-            he_le h3e₁
+          exact case_two_odd_small m a' b' hm hcop hmin hd₁_odd he₁_odd he_le h3e₁
         · -- 3 ∤ d₁ and 3 ∤ d₂ and e₁ ≤ 17: swap and show new e₁ ≥ 19.
           -- After swap, new e₁' = m/d₂. If e₁' ≤ 17 too, contradiction.
           rw [← zmod_set_swap m a' b']
           set a'' := (-a' : ℤ); set b'' := (b' - a' : ℤ)
           have hba_eq : (b'' - a'').natAbs = b'.natAbs := by
             change (b' - a' - -a').natAbs = b'.natAbs; congr 1; ring
-          have hcop' : (Nat.gcd b''.natAbs m).gcd
-              (Nat.gcd (b'' - a'').natAbs m) = 1 := by
+          have hcop' : (Nat.gcd b''.natAbs m).gcd (Nat.gcd (b'' - a'').natAbs m) = 1 := by
             rw [hba_eq]; rwa [Nat.gcd_comm]
-          have hmin' : min (Nat.gcd b''.natAbs m)
-              (Nat.gcd (b'' - a'').natAbs m) > 1 := by
+          have hmin' : min (Nat.gcd b''.natAbs m) (Nat.gcd (b'' - a'').natAbs m) > 1 := by
             rw [hba_eq]; rwa [min_comm]
           -- Dispatch on parity
           rcases Nat.even_or_odd (m / Nat.gcd b''.natAbs m) with he' | ho'
@@ -4197,28 +3771,23 @@ lemma main_case_two (hm : m ≥ 289)
             · -- Both odd after swap. Show e₁' ≥ 19 by contradiction.
               have he₁'_ge : m / Nat.gcd b''.natAbs m ≥ 19 := by
                 by_contra hlt; push_neg at hlt
-                have hle : m / Nat.gcd b''.natAbs m ≤ 17 := by grind
-                have hd₁_gt1 : d₁ > 1 := by grind
-                have hd₂_gt1 : d₂ > 1 := by grind
                 rw [Nat.gcd_comm] at hcop
-                exact no_both_e_small hm hcop hd₂_gt1 hd₁_gt1
-                  hd₂_dvd hd₁_dvd hle he_le
-              exact case2d_coloring_works hm hcop' hmin' hd' ho'
-                he₁'_ge h3d₂
+                exact no_both_e_small hm hcop (by grind) (by grind) hd₂_dvd hd₁_dvd (by grind) he_le
+              exact case2d_coloring_works hm hcop' hmin' hd' ho' he₁'_ge h3d₂
       · have he₁_ge : e₁ ≥ 19 := by grind
-        exact case2d_coloring_works hm hcop hmin hd₁_odd he₁_odd
-          he₁_ge h3_nd₁
+        exact case2d_coloring_works hm hcop hmin hd₁_odd he₁_odd he₁_ge h3_nd₁
 
 end Case2_MultipleCycles
 
-/-! ## Assembly
+/-! ## Assembly: connecting ZMod m back to ℤ
 
-The remaining lemmas connect the `ZMod m` analysis back to `ℤ`: cardinality of
-`zmod_set`, the GCD coprimality reduction, and the final theorem `normal_bit`
-which dispatches on `min(d₁, d₂) = 1` vs `> 1`.
+The remaining lemmas are the glue between the Case 1/Case 2 analysis in $\mathbb{Z}_m$
+and the final statement over $\mathbb{Z}$, culminating in `normal_bit`.
 -/
 
-/-- The set zmod_set m a b has 4 elements when 0 < a < b and 2b - a < m. -/
+section Assembly
+
+/-- Auxiliary: the set zmod_set m a b has 4 elements when 0 < a < b and 2b - a < m. -/
 lemma zmod_set_card_eq_four {a b : ℤ} {m : ℕ}
     (ha : 0 < a) (hab : a < b) (hbm : 2 * b - a < ↑m) :
     (zmod_set m a b).card = 4 := by
@@ -4240,8 +3809,7 @@ lemma zmod_set_card_eq_four {a b : ℤ} {m : ℕ}
   · simp only [mem_insert, mem_singleton]; push_neg; exact ⟨ne12, ne13⟩
   · simp only [mem_insert, mem_singleton]; push_neg; exact ⟨ne01, ne02, ne03⟩
 
-/-- The coprimality gcd(d₁, d₂) = 1 follows from gcd(a, b, c) = 1 and m = c - a + b,
-    since gcd(b-a, b, m) = gcd(b-a, b, c-a+b) = gcd(a, b, c). -/
+/-- Auxiliary: the coprimality gcd(d₁, d₂) = 1 follows from gcd(a, b, c) = 1. -/
 lemma gcd_coprime_of_gcd_abc {a b c : ℤ} {m : ℕ}
     (hm : (m : ℤ) = c - a + b) (hgcd : Finset.gcd {a, b, c} id = 1) :
     (Nat.gcd b.natAbs m).gcd (Nat.gcd (b - a).natAbs m) = 1 := by
@@ -4254,9 +3822,14 @@ lemma gcd_coprime_of_gcd_abc {a b c : ℤ} {m : ℕ}
   have hd_ba : (d : ℤ) ∣ (b - a) := Int.natCast_dvd.mpr
     ((Nat.gcd_dvd_right (Nat.gcd _ _) _).trans (Nat.gcd_dvd_left _ _))
   -- d | a and d | c follow from d | b, d | (b-a), d | m
-  have hd_a : (d : ℤ) ∣ a := (by ring : a = b - (b - a)) ▸ dvd_sub hd_b hd_ba
-  have hd_c : (d : ℤ) ∣ c := (by grind : (c : ℤ) = ↑m - b + a) ▸
-    dvd_add (dvd_sub hd_m hd_b) hd_a
+  have hd_a : (d : ℤ) ∣ a := by
+    have : a = b - (b - a) := by ring
+    rw [this]
+    exact dvd_sub hd_b hd_ba
+  have hd_c : (d : ℤ) ∣ c := by
+    have : (c : ℤ) = ↑m - b + a := by grind
+    rw [this]
+    exact dvd_add (dvd_sub hd_m hd_b) hd_a
   have hd_dvd_gcd : (d : ℤ) ∣ Finset.gcd {a, b, c} id :=
     Finset.dvd_gcd (fun x hx => by
       simp only [Finset.mem_insert, Finset.mem_singleton] at hx
@@ -4267,28 +3840,26 @@ lemma gcd_coprime_of_gcd_abc {a b c : ℤ} {m : ℕ}
   rw [hgcd] at hd_dvd_gcd
   exact Nat.eq_one_of_dvd_one (Int.natCast_dvd_natCast.mp hd_dvd_gcd)
 
-/-- Reduction from HasPolychromColouring on zmod_set to HasPolychromColouring on {0, a, b, c} in ℤ.
-    Combines the homomorphism ℤ → ZMod m (Lemma 12(ii)) with the translation
-    equivalence (Lemma 12(iii), i.e. `polychromNumber_zmod`). -/
+/-- Auxiliary: lifts polychromaticity from ZMod m back to ℤ, combining the
+    homomorphism ℤ → ZMod m (Lemma 12(ii)) with `polychromNumber_zmod`. -/
 lemma hasPolychromColouring_of_zmod_set {a b c : ℤ} {m : ℕ}
     (hm_eq : (m : ℤ) = c - a + b)
     (h : HasPolychromColouring (Fin 3) (zmod_set m a b)) :
     HasPolychromColouring (Fin 3) ({0, a, b, c} : Finset ℤ) := by
   apply HasPolychromColouring.of_image (Int.castAddHom (ZMod m))
-  change HasPolychromColouring (Fin 3)
-    (({0, a, b, c} : Finset ℤ).image (Int.cast : ℤ → ZMod m))
+  change HasPolychromColouring (Fin 3) (({0, a, b, c} : Finset ℤ).image (Int.cast : ℤ → ZMod m))
   apply hasPolychromColouring_fin_of_le (by simp)
   rw [polychromNumber_zmod hm_eq]
   exact le_polychromNumber h
 
 /--
-The main theorem of this file: every 4-element set $\{0, a, b, c\}$ satisfying the
+**Main theorem of this file.** Every 4-element set $\{0, a, b, c\}$ satisfying the
 normalization conditions ($0 < a < b$, $a + b \le c$, $c \ge 289$, $\gcd(a, b, c) = 1$)
 admits a 3-polychromatic coloring.
 
-This serves as the "combinatorial bit" of the overall polychromatic coloring theorem.
-The proof dispatches to `main_case_one` (Case 1: Single Cycle) or `main_case_two`
-(Case 2: Multiple Cycles) based on the value of $\min(\gcd(b, m), \gcd(b-a, m))$.
+This is the entry point used by `Main.lean` to handle the large-c case. The proof
+dispatches to `main_case_one` or `main_case_two` based on
+$\min(\gcd(b, m), \gcd(b{-}a, m))$.
 -/
 theorem normal_bit :
     ∀ a b c : ℤ, 0 < a → a < b → a + b ≤ c → 289 ≤ c → Finset.gcd {a, b, c} id = 1 →
@@ -4309,3 +3880,5 @@ theorem normal_bit :
   · have : 0 < d₁ := Nat.gcd_pos_of_pos_right _ hm_pos
     have : 0 < d₂ := Nat.gcd_pos_of_pos_right _ hm_pos
     exact main_case_two m a b (by grind) (gcd_coprime_of_gcd_abc hm_eq hgcd) (by grind)
+
+end Assembly

--- a/Lean/Polychromatic/FourThree/Combi.lean
+++ b/Lean/Polychromatic/FourThree/Combi.lean
@@ -63,10 +63,6 @@ def zmod_set (m : ℕ) (a b : ℤ) : Finset (ZMod m) :=
 
 /- Aristotle alternative for `polychromNumber_zmod` (10 lines vs 12 original, -2).
 
-
-def zmod_set (m : ℕ) (a b : ℤ) : Finset (ZMod m) :=
-  ({0, b - a, b, 2 * b - a} : Finset ℤ).image Int.cast
-
 lemma polychromNumber_zmod {a b c : ℤ} {m : ℕ} (hm : m = c - a + b) :
     polychromNumber (({0, a, b, c} : Finset ℤ).image Int.cast : Finset (ZMod m)) =
       polychromNumber (zmod_set m a b) := by
@@ -162,7 +158,6 @@ private lemma checkLinearPolychrom_spec {offsets : List ℕ} {L : List (Fin 3)}
 /-- Frobenius representation for consecutive block sizes r, r+1:
     any m ≥ r(r-1) can be written as r·h + (r+1)·k. -/
 /- Aristotle alternative for `frobenius_consec` (10 lines vs 11 original, -1).
-
 
 private lemma frobenius_consec {rA m : ℕ} (hrA : 1 < rA) (hm : m ≥ rA * (rA - 1)) :
     ∃ h k, rA * h + (rA + 1) * k = m ∧ 0 < h + k := by
@@ -287,17 +282,20 @@ private lemma sub_add_eq {i j s r q : ℕ} (hge : r ≤ j + s)
 
 /- Aristotle alternative for sub_region_eq (12 vs 13 lines, -1)
 
-
 private lemma sub_region_eq {i s r h : ℕ} (hr : 0 < r)
     (hi_lo : r * (h - 1) ≤ i) (hi_hi : i < r * h)
     (hjs_ge : r ≤ i % r + s) :
     i + s - r * h = i % r + s - r := by
+      -- By definition of modulo, we can write $i = r * (h - 1) + (i % r)$.
       have h_mod : i = r * (h - 1) + (i % r) := by
+        -- By the division algorithm, we can write $i$ as $r * (h - 1) + (i % r)$ because $i < r * h$ implies $i % r < r$.
         have h_div_alg : i = r * (i / r) + (i % r) := by
           rw [ Nat.div_add_mod ];
+        -- Since $i < r * h$, we have $i / r < h$. Also, since $r * (h - 1) \leq i$, we have $h - 1 \leq i / r$. Therefore, $i / r = h - 1$.
         have h_div_eq : i / r < h ∧ h - 1 ≤ i / r := by
           exact ⟨ Nat.div_lt_of_lt_mul <| by linarith, Nat.le_div_iff_mul_le hr |>.2 <| by linarith ⟩;
         grind +ring;
+      -- Substitute $i = r * (h - 1) + (i % r)$ into the left-hand side.
       rw [h_mod];
       rcases h with ( _ | _ | h ) <;> norm_num [ Nat.add_mod, Nat.mul_succ ] at * ; omega;
 -/
@@ -516,7 +514,6 @@ private lemma case_wrap_BA (A B : List (Fin 3)) (offsets : List ℕ)
 
 /- Aristotle alternative for case_wrap_BB (20 vs 33 lines, -13)
 
-
 private lemma case_wrap_BB (A B : List (Fin 3)) (offsets : List ℕ)
     (k m i : ℕ)
     (hBlen : B.length = A.length + 1)
@@ -527,14 +524,18 @@ private lemma case_wrap_BB (A B : List (Fin 3)) (offsets : List ℕ)
     (h_wrap : m ≤ i + offsets.foldr max 0)
     (hk_pos : 0 < k) :
     CaseGoal A B offsets 0 m i := by
+      -- Since $B$ is a list of length $A.length + 1$, and we're using $B ++ B$ (which has length $2 * (A.length + 1)$), the length of $XY$ must be at least $2 * (A.length + 1)$. But $j + \text{maxOff} < \text{length}(XY)$ implies that $\text{maxOff} < \text{length}(XY) - j$. Since $j$ is less than $m$ (which is $(A.length + 1) * k$), this should hold.
       use B ++ B, i % (A.length + 1);
+      -- Since $B$ is a list of length $A.length + 1$, and we're using $B ++ B$ (which has length $2 * (A.length + 1)$), the length of $XY$ must be at least $2 * (A.length + 1)$. But $j + \text{maxOff} < \text{length}(XY)$ implies that $\text{maxOff} < \text{length}(XY) - j$. Since $j$ is less than $m$ (which is $(A.length + 1) * k$), this should hold. Therefore, the third part of the conjunction holds.
       have h_third_part : ∀ s ≤ List.foldr Max.max 0 offsets, (B ++ B)[i % (A.length + 1) + s]? = Option.some (blockColorVal A B 0 ((i + s) % m)) := by
         intros s hs; rw [ blockColorVal ] ; simp +decide [ Nat.mod_eq_of_lt, * ] ;
         rw [ show ( i + s ) % m % ( A.length + 1 ) = ( i % ( A.length + 1 ) + s ) % ( A.length + 1 ) from ?_ ];
         · by_cases h : i % ( A.length + 1 ) + s < B.length <;> simp_all +decide [ Nat.mod_eq_of_lt ];
           · rw [ List.getElem?_append ] ; aesop;
-          · have h_mod : (i + s) % (A.length + 1) = (i % (A.length + 1) + s) % (A.length + 1) := by
+          · -- Since $i \% (A.length + 1) + s \geq A.length + 1$, we have $(i + s) \% (A.length + 1) = (i \% (A.length + 1) + s) \% (A.length + 1)$.
+            have h_mod : (i + s) % (A.length + 1) = (i % (A.length + 1) + s) % (A.length + 1) := by
               simp +decide [ Nat.add_mod ];
+            -- Since $i \% (A.length + 1) + s \geq A.length + 1$, we can write $i \% (A.length + 1) + s = (A.length + 1) + r$ for some $r$ such that $0 \leq r < A.length + 1$.
             obtain ⟨r, hr⟩ : ∃ r, i % (A.length + 1) + s = (A.length + 1) + r ∧ r < A.length + 1 := by
               exact ⟨ i % ( A.length + 1 ) + s - ( A.length + 1 ), by rw [ Nat.add_sub_cancel' h ], by rw [ tsub_lt_iff_left h ] ; linarith [ Nat.mod_lt i ( Nat.succ_pos A.length ) ] ⟩;
             simp +decide [ hr, h_mod ];
@@ -600,6 +601,7 @@ theorem blockColor_polychrom
     (hm : A.length * h + B.length * k = m)
     {i : ℕ} (hi : i < m) (c : Fin 3) :
     ∃ s ∈ offsets, blockColorVal A B h ((i + s) % m) = c := by
+      -- Apply the lemma `case_no_wrap_AA` to obtain a contradiction.
       have h_case : CaseGoal A B offsets h m i := by
         by_cases h_no_wrap : i + offsets.foldr Max.max 0 < m;
         · by_cases hA_region : i < A.length * h;
@@ -1502,11 +1504,6 @@ private lemma mod3_witness {s k : ℕ} (hs : s < 3) (hk : k < 3) :
 
 /- Aristotle alternative for `endgame_witness` (1 lines vs 5 original, -4).
 
-
-    ((k + 3 - s) % 3 = 0 → s = k) ∧
-    ((k + 3 - s) % 3 = 1 → (s + 1) % 3 = k) ∧
-    ((k + 3 - s) % 3 = 2 → (s + 2) % 3 = k) := by admit
-
 private lemma endgame_witness {g : ℕ} {c : ℕ → ℕ}
     {v s : ℕ} {k : Fin 3} (hs : s < 3)
     (a₀ a₁ a₂ : ℕ)
@@ -1537,7 +1534,6 @@ private lemma endgame_witness {g : ℕ} {c : ℕ → ℕ}
 
 /-- Lift a ℕ-level coloring witness for {0,1,g,g+1} to ZMod m. -/
 /- Aristotle alternative for `lift_coloring_witness` (7 lines vs 11 original, -4).
-
 
 private lemma lift_coloring_witness {m g : ℕ} [NeZero m] [Fact (1 < m)]
     (hg_lt : g + 1 < m) {c : ℕ → ℕ} (hc_lt : ∀ p, c p < 3)
@@ -1933,7 +1929,6 @@ When `3 ∣ m`, multiplication by 3 is not available. Instead:
     each translate of {0,1,g,g+1} hits all 3 residue classes mod 3. -/
 /- Aristotle alternative for `case_one_div_g_not_three` (13 lines vs 14 original, -1).
 
-
 lemma case_one_div_g_not_three (g : ℕ)
     (h_div : m = 3 * g ∨ m = 3 * g + 3)
     (hg3 : g % 3 ≠ 0) :
@@ -2032,34 +2027,6 @@ lemma case_one_div_3g (g : ℕ) (hm_eq : m = 3 * g)
 
 /-- (1d), m = 3g+3, g ≡ 0 (mod 3): reversed diagonal coloring of period `g+1`. -/
 /- Aristotle alternative for `case_one_div_3g3` (40 lines vs 53 original, -13).
-
-
-    ((r + 1) % 3 + (3 - q % 3)) % 3 =
-      ((r % 3 + (3 - q % 3)) % 3 + 1) % 3 := by admit
-
-    (r % 3 + (3 - (q + 1) % 3)) % 3 =
-      ((r % 3 + (3 - q % 3)) % 3 + 2) % 3 := by admit
-
-    ((k + 3 - s) % 3 = 0 → s = k) ∧
-    ((k + 3 - s) % 3 = 1 → (s + 1) % 3 = k) ∧
-    ((k + 3 - s) % 3 = 2 → (s + 2) % 3 = k) := by admit
-
-    {v s : ℕ} {k : Fin 3} (hs : s < 3)
-    (a₀ a₁ a₂ : ℕ)
-    (ha₀ : a₀ ∈ ({0, 1, g, g + 1} : Finset ℕ))
-    (ha₁ : a₁ ∈ ({0, 1, g, g + 1} : Finset ℕ))
-    (ha₂ : a₂ ∈ ({0, 1, g, g + 1} : Finset ℕ))
-    (hc₀ : c (v + a₀) = s)
-    (hc₁ : c (v + a₁) = (s + 1) % 3)
-    (hc₂ : c (v + a₂) = (s + 2) % 3) :
-    ∃ a ∈ ({0, 1, g, g + 1} : Finset ℕ), c (v + a) = k.val := by admit
-
-    (hg_lt : g + 1 < m) {c : ℕ → ℕ} (hc_lt : ∀ p, c p < 3)
-    (hc_period : ∀ p, c (p % m) = c p)
-    {n : ZMod m} {k : Fin 3}
-    (h : ∃ a ∈ ({0, 1, g, g + 1} : Finset ℕ), c (n.val + a) = k.val) :
-    ∃ s ∈ ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)),
-      (⟨c (n + s).val, hc_lt _⟩ : Fin 3) = k := by admit
 
 lemma case_one_div_3g3 (g : ℕ) (hm_eq : m = 3 * g + 3) (hg3 : 3 ∣ g) (hg : 0 < g) :
     HasPolychromColouring (Fin 3)
@@ -2181,146 +2148,6 @@ lemma case_one_divisible (g : ℕ) (hm : m ≥ 289) (h_div : m = 3 * g ∨ m = 3
             handled by explicit periodic colorings -/
 /- Aristotle alternative for `case_one_dispatch` (17 body + 32 helpers = 49 vs 50 original, -1).
 
-
-    HasPolychromColouring (Fin 3) ({0, 1, 2, 3} : Finset (ZMod m)) := by admit
-
-    HasPolychromColouring (Fin 3) ({0, 1, 3, 4} : Finset (ZMod m)) := by admit
-
-    HasPolychromColouring (Fin 3) ({0, 2, 3, 5} : Finset (ZMod m)) := by admit
-
-    HasPolychromColouring (Fin 3) ({0, 3, 4, 7} : Finset (ZMod m)) := by admit
-
-    HasPolychromColouring (Fin 3) ({0, 3, 5, 8} : Finset (ZMod m)) := by admit
-
-    HasPolychromColouring (Fin 3) ({0, 1, 4, 5} : Finset (ZMod m)) := by admit
-
-    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by admit
-
-    (h_lb : (m + s - 1) / s < g) (h_ub : g < 2 * (m / s)) :
-    HasPolychromColouring (Fin 3)
-      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by admit
-
-    HasPolychromColouring (Fin 3) (S.image (u.val * ·)) ↔
-    HasPolychromColouring (Fin 3) S := by admit
-
-    (hg : m = 3 * g - 2) :
-    HasPolychromColouring (Fin 3)
-      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
-        Finset (ZMod m)) := by admit
-
-    (hg : m = 3 * g - 1) :
-    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by admit
-
-    (hg : m = 3 * g + 1) :
-    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by admit
-
-    (hg : m = 3 * g + 2) :
-    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by admit
-
-    (hg : m = 3 * g + 4) :
-    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by admit
-
-    (hg : m = 3 * g + 5) :
-    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by admit
-
-    (h_range : 2 * (m / 6) ≤ g ∧ g ≤ (m + 2) / 3) :
-    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by admit
-
-    (h_div : m = 3 * g ∨ m = 3 * g + 3)
-    (hg3 : g % 3 ≠ 0) :
-    HasPolychromColouring (Fin 3)
-      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
-        Finset (ZMod m)) := by admit
-
-    ((r + 1) % 3 + (3 - q % 3)) % 3 =
-      ((r % 3 + (3 - q % 3)) % 3 + 1) % 3 := by admit
-
-    (r % 3 + (3 - (q + 1) % 3)) % 3 =
-      ((r % 3 + (3 - q % 3)) % 3 + 2) % 3 := by admit
-
-    ((k + 3 - s) % 3 = 0 → s = k) ∧
-    ((k + 3 - s) % 3 = 1 → (s + 1) % 3 = k) ∧
-    ((k + 3 - s) % 3 = 2 → (s + 2) % 3 = k) := by admit
-
-    {v s : ℕ} {k : Fin 3} (hs : s < 3)
-    (a₀ a₁ a₂ : ℕ)
-    (ha₀ : a₀ ∈ ({0, 1, g, g + 1} : Finset ℕ))
-    (ha₁ : a₁ ∈ ({0, 1, g, g + 1} : Finset ℕ))
-    (ha₂ : a₂ ∈ ({0, 1, g, g + 1} : Finset ℕ))
-    (hc₀ : c (v + a₀) = s)
-    (hc₁ : c (v + a₁) = (s + 1) % 3)
-    (hc₂ : c (v + a₂) = (s + 2) % 3) :
-    ∃ a ∈ ({0, 1, g, g + 1} : Finset ℕ), c (v + a) = k.val := by admit
-
-    (hg_lt : g + 1 < m) {c : ℕ → ℕ} (hc_lt : ∀ p, c p < 3)
-    (hc_period : ∀ p, c (p % m) = c p)
-    {n : ZMod m} {k : Fin 3}
-    (h : ∃ a ∈ ({0, 1, g, g + 1} : Finset ℕ), c (n.val + a) = k.val) :
-    ∃ s ∈ ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)),
-      (⟨c (n + s).val, hc_lt _⟩ : Fin 3) = k := by admit
-
-    (hg3 : 3 ∣ g) (hg : 0 < g) :
-    HasPolychromColouring (Fin 3)
-      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
-        Finset (ZMod m)) := by admit
-
-    HasPolychromColouring (Fin 3)
-      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by admit
-
-    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by admit
-
-noncomputable section AristotleLemmas
-
-/-
-If $m$ is close to $3g$ (specifically $3g-2 \le m \le 3g+5$), then the set $\{0, 1, g, g+1\}$ has a polychromatic colouring.
--/
-lemma case_one_middle (g : ℕ) (hm : m ≥ 289) (h_approx : 3 * g - 2 ≤ m ∧ m ≤ 3 * g + 5) :
-    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by
-      by_cases hm3g : m = 3 * g ∨ m = 3 * g + 3;
-      · exact?;
-      · by_cases hm3g_sub2 : m = 3 * g - 2 ∨ m = 3 * g - 1 ∨ m = 3 * g + 1 ∨ m = 3 * g + 2 ∨ m = 3 * g + 4 ∨ m = 3 * g + 5;
-        · rcases hm3g_sub2 with ( rfl | rfl | rfl | rfl | rfl | rfl );
-          exact?;
-          · exact?;
-          · exact?;
-          · exact?;
-          · exact?;
-          · exact?;
-        · omega
-
-/-
-For $5 \le g$ and $3g+6 \le m$, there exists a multiple of 3, $s$, such that $(m+s-1)/s < g < 2(m/s)$.
--/
-
-lemma case_one_s_exists_refined (g : ℕ) (hm : m ≥ 289) (hg5 : 5 ≤ g) (hg_upper : 3 * g + 6 ≤ m) :
-    ∃ s, 0 < s ∧ 3 ∣ s ∧ (m + s - 1) / s < g ∧ g < 2 * (m / s) := by
-      -- Let's choose k as the smallest integer greater than (m-1)/(3g-3).
-      obtain ⟨k, hk⟩ : ∃ k : ℕ, (m - 1) < 3 * k * (g - 1) ∧ 3 * k * (g - 1) ≤ m + 3 * (g - 1) - 1 := by
-        rcases g with ( _ | _ | g ) <;> norm_num at *;
-        exact ⟨ ( m - 1 ) / ( 3 * ( g + 1 ) ) + 1, by linarith [ Nat.div_add_mod ( m - 1 ) ( 3 * ( g + 1 ) ), Nat.mod_lt ( m - 1 ) ( by linarith : 0 < 3 * ( g + 1 ) ) ], by rw [ Nat.le_sub_iff_add_le ] <;> nlinarith [ Nat.div_mul_le_self ( m - 1 ) ( 3 * ( g + 1 ) ), Nat.sub_add_cancel ( by linarith : 1 ≤ m ) ] ⟩;
-      use 3 * k; rcases k with ( _ | _ | k ) <;> simp_all +arith +decide;
-      · omega;
-      · rw [ Nat.div_lt_iff_lt_mul <| by positivity ] ; rcases g with ( _ | _ | g ) <;> simp_all +decide [ Nat.mul_succ ] ; (
-        constructor <;> try linarith [ Nat.sub_add_cancel ( by linarith : 1 ≤ m ) ] ; ; rcases k with ( _ | _ | k ) <;> norm_num at * ; omega;
-        · omega;
-        · nlinarith [ Nat.div_add_mod m ( 3 * ( k + 1 + 1 ) + 6 ), Nat.mod_lt m ( by linarith : 0 < ( 3 * ( k + 1 + 1 ) + 6 ) ) ] ;)
-
-/-
-For $g \ge 5$ and $2g \le m \le 3g-3$, using $s=3$ works.
--/
-
-lemma case_one_s_three (g : ℕ) (hm : m ≥ 289) (hg5 : 5 ≤ g) (h_range : 2 * g ≤ m ∧ m ≤ 3 * g - 3) :
-    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by
-      -- Apply `case_one_interval` with $s=3$.
-      apply case_one_interval;
-      rotate_right;
-      exact 3;
-      · norm_num;
-      · norm_num;
-      · omega;
-      · omega
-
-
 lemma case_one_dispatch (g : ℕ) (hm : m ≥ 289) (hg_ge : 2 ≤ g)
     (hg_le : g ≤ m / 2) :
     HasPolychromColouring (Fin 3)
@@ -2430,12 +2257,6 @@ private lemma isUnit_intCast_of_natAbs_coprime {n : ℕ} {b : ℤ}
 /-- When gcd(b, m) = 1, there exists 2 ≤ g ≤ m - 2 with gb ≡ b - a (mod m),
     and zmod_set m a b = (image of {0,1,g,g+1} under ×b). -/
 /- Aristotle alternative for `exists_g_of_coprime` (39 lines vs 49 original, -10).
-
-
-  ({0, b - a, b, 2 * b - a} : Finset ℤ).image Int.cast
-
-    (h : Nat.gcd b.natAbs n = 1) :
-    IsUnit (Int.cast b : ZMod n) := by admit
 
 lemma exists_g_of_coprime (a b : ℤ) (hd : Nat.gcd b.natAbs m = 1)
     (hm : 0 < m) (hcard : (zmod_set m a b).card = 4) :
@@ -2734,7 +2555,6 @@ private lemma orbitMap_i_eq {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
 
 /- Aristotle alternative for `orbitMap_j_eq` (7 lines vs 10 original, -3).
 
-
 private lemma orbitMap_j_eq {m : ℕ} {b : ℤ} {e₁ : ℕ} [NeZero e₁]
     (hord : addOrderOf (b : ZMod m) = e₁)
     {j₁ j₂ : ZMod e₁}
@@ -2765,25 +2585,6 @@ private lemma orbitMap_j_eq {m : ℕ} {b : ℤ} {e₁ : ℕ} [NeZero e₁]
     exact ZMod.val_injective _ (by grind)
 
 /- Aristotle alternative for `orbitMap_injective` (7 lines vs 8 original, -1).
-
-
-private def orbitMap (m : ℕ) (a b : ℤ) (d₁ e₁ : ℕ) :
-    ZMod d₁ × ZMod e₁ → ZMod m :=
-  fun p => (p.1.val : ZMod m) * ↑(b - a) + (p.2.val : ZMod m) * ↑b
-
-    [NeZero m] [NeZero d₁]
-    (hd1_dvd : d₁ ∣ m)
-    (hb_zero : (b : ZMod d₁) = 0)
-    (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
-    {i₁ i₂ : ZMod d₁} {j₁ j₂ : ZMod e₁}
-    (heq : orbitMap m a b d₁ e₁ (i₁, j₁) =
-           orbitMap m a b d₁ e₁ (i₂, j₂)) :
-    i₁ = i₂ := by admit
-
-    (hord : addOrderOf (b : ZMod m) = e₁)
-    {j₁ j₂ : ZMod e₁}
-    (hj_smul : (j₁.val : ℕ) • (b : ZMod m) = (j₂.val : ℕ) • (b : ZMod m)) :
-    j₁ = j₂ := by admit
 
 private lemma orbitMap_injective {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
     [NeZero m] [NeZero d₁] [NeZero e₁]
@@ -3305,7 +3106,6 @@ private def case2c_pattern (d₁ k₀ i : ℕ) : Fin 3 :=
 -- General coverage: if (j₁ + p₁) % 3 ≠ (j₂ + p₂) % 3, all 3 colors appear.
 /- Aristotle alternative for `cover_mod3_general` (2 lines vs 3 original, -1).
 
-
 private lemma cover_mod3_general (p₁ p₂ : Fin 3)
     (j₁ j₂ : ℕ)
     (hne : (j₁ + p₁.val) % 3 ≠ (j₂ + p₂.val) % 3)
@@ -3397,12 +3197,6 @@ private def intervalColors : Fin 3 → Finset (Fin 3)
 
 /-- Any two distinct interval color pairs union to {0, 1, 2}. -/
 /- Aristotle alternative for `intervalColors_union_covers` (1 lines vs 2 original, -1).
-
-
-private def intervalColors : Fin 3 → Finset (Fin 3)
-  | 0 => {0, 1}
-  | 1 => {1, 2}
-  | 2 => {0, 2}
 
 private lemma intervalColors_union_covers {i₁ i₂ : Fin 3} (h : i₁ ≠ i₂) :
     ∀ k : Fin 3, k ∈ intervalColors i₁ ∨ k ∈ intervalColors i₂ := by
@@ -3500,56 +3294,6 @@ private lemma rotation_changes_interval {e₁ j : ℕ}
     then at every position j, the 2×2 block covers all 3 colors. -/
 /- Aristotle alternative for `basePattern_rotation_covers` (15 lines vs 19 original, -4).
 
-
-private def case2d_u (e₁ : ℕ) : ℕ := e₁ / 3 + e₁ % 3
-
-  if e₁ % 3 = 1 then e₁ / 3 + 1 else e₁ / 3
-
-    Odd (e₁ - case2d_u e₁ - case2d_v e₁) := by admit
-
-    case2d_u e₁ + case2d_v e₁ ≤ e₁ := by admit
-
-    e₁ - (case2d_u e₁ + case2d_v e₁) ≤ case2d_u e₁ := by admit
-
-private def basePattern (e₁ : ℕ) (j : ℕ) : Fin 3 :=
-  let u := case2d_u e₁
-  let v := case2d_v e₁
-  if j < u then
-    if j % 2 = 0 then 0 else 1
-  else if j < u + v then
-    if (j - u) % 2 = 0 then 1 else 2
-  else
-    if (j - u - v) % 2 = 0 then 2 else 0
-
-private def whichInterval (e₁ j : ℕ) : Fin 3 :=
-  let u := case2d_u e₁
-  let v := case2d_v e₁
-  if j < u then 0
-  else if j < u + v then 1
-  else 2
-
-  | 0 => {0, 1}
-  | 1 => {1, 2}
-  | 2 => {0, 2}
-
-    ∀ k : Fin 3, k ∈ intervalColors i₁ ∨ k ∈ intervalColors i₂ := by admit
-
-    (hsame : whichInterval e₁ j = whichInterval e₁ (j + 1)) :
-    {basePattern e₁ j, basePattern e₁ (j + 1)} = intervalColors (whichInterval e₁ j) := by admit
-
-    (he : Odd e₁) (hge : e₁ ≥ 19) (hj : j < e₁)
-    (hdiff : whichInterval e₁ j ≠ whichInterval e₁ ((j + 1) % e₁)) :
-    {basePattern e₁ j, basePattern e₁ ((j + 1) % e₁)} =
-      intervalColors (whichInterval e₁ j) := by admit
-
-    (he : Odd e₁) (hge : e₁ ≥ 19) (hj : j < e₁) :
-    intervalColors (whichInterval e₁ j) ⊆
-      {basePattern e₁ j, basePattern e₁ ((j + 1) % e₁)} := by admit
-
-    (hge : e₁ ≥ 19) (hj : j < e₁)
-    {r : ℕ} (hr_lo : case2d_u e₁ ≤ r) (hr_hi : r ≤ e₁ - case2d_u e₁) :
-    whichInterval e₁ j ≠ whichInterval e₁ ((j + r) % e₁) := by admit
-
 private lemma basePattern_rotation_covers {e₁ j : ℕ} (he : Odd e₁) (hge : e₁ ≥ 19)
     {r : ℕ} (hr_lo : case2d_u e₁ ≤ r) (hr_hi : r ≤ e₁ - case2d_u e₁)
     (hj : j < e₁) :
@@ -3637,11 +3381,6 @@ private lemma case2d_wrap_shift {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
 
 /- Aristotle alternative for `case2d_shift_ba_wrap` (13 lines vs 23 original, -10).
 
-
-private def orbitMap (m : ℕ) (a b : ℤ) (d₁ e₁ : ℕ) :
-    ZMod d₁ × ZMod e₁ → ZMod m :=
-  fun p => (p.1.val : ZMod m) * ↑(b - a) + (p.2.val : ZMod m) * ↑b
-
 private lemma case2d_shift_ba_wrap {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
     [NeZero e₁] [NeZero d₁]
     (he1_b_zero : e₁ • (b : ZMod m) = 0)
@@ -3701,9 +3440,6 @@ private lemma case2d_shift_ba_wrap {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
 /-- Given d₁ ≥ 3 values each in [u, e₁-u] can sum to any target mod e₁,
     since the range has width ≥ e₁/3 and d₁ ≥ 3. -/
 /- Aristotle alternative for `case2d_rotation_sum_exists` (31 lines vs 80 original, -49).
-
-
-private def case2d_u (e₁ : ℕ) : ℕ := e₁ / 3 + e₁ % 3
 
 private lemma case2d_rotation_sum_exists {e₁ d₁ : ℕ} [NeZero d₁]
     (hd1_ge : d₁ ≥ 5) (he1_ge : e₁ ≥ 19) (he1_odd : Odd e₁)
@@ -3877,7 +3613,6 @@ private lemma pos_shift_one {n : ℕ} [NeZero n] (j : ZMod n) (c : ℕ) :
 
 /-- (j + (S + V) % n) % n = ((j + S % n) % n + V) % n -/
 /- Aristotle alternative for `pos_shift_succ'` (2 lines vs 4 original, -2).
-
 
 private lemma pos_shift_succ' (j S V n : ℕ) :
     (j + (S + V) % n) % n = ((j + S % n) % n + V) % n := by
@@ -4148,7 +3883,6 @@ lemma case_two_odd_small (hm : m ≥ 289)
     m ≥ 289 this forces m = 289 = 17², but then gcd(d₁,d₂) = 1 with
     d₁,d₂ | 17² and d₁,d₂ > 1 is impossible. -/
 /- Aristotle alternative for `no_both_e_small` (18 lines vs 20 original, -2).
-
 
 private lemma no_both_e_small {m d₁ d₂ : ℕ}
     (hm : m ≥ 289)

--- a/Lean/Polychromatic/FourThree/Combi.lean
+++ b/Lean/Polychromatic/FourThree/Combi.lean
@@ -62,7 +62,7 @@ def zmod_set (m : ℕ) (a b : ℤ) : Finset (ZMod m) :=
   ({0, b - a, b, 2 * b - a} : Finset ℤ).image Int.cast
 
 /- Aristotle alternative for `polychromNumber_zmod` (10 lines vs 12 original, -2).
-   Full proof: `aristotle_results/result_polychromNumber_zmod.lean`
+
 
 def zmod_set (m : ℕ) (a b : ℤ) : Finset (ZMod m) :=
   ({0, b - a, b, 2 * b - a} : Finset ℤ).image Int.cast
@@ -162,7 +162,7 @@ private lemma checkLinearPolychrom_spec {offsets : List ℕ} {L : List (Fin 3)}
 /-- Frobenius representation for consecutive block sizes r, r+1:
     any m ≥ r(r-1) can be written as r·h + (r+1)·k. -/
 /- Aristotle alternative for `frobenius_consec` (10 lines vs 11 original, -1).
-   Full proof: `aristotle_results/result_frobenius_consec.lean`
+
 
 private lemma frobenius_consec {rA m : ℕ} (hrA : 1 < rA) (hm : m ≥ rA * (rA - 1)) :
     ∃ h k, rA * h + (rA + 1) * k = m ∧ 0 < h + k := by
@@ -285,6 +285,22 @@ private lemma sub_add_eq {i j s r q : ℕ} (hge : r ≤ j + s)
     (hi : j + q = i) :
     i + s - (q + r) = j + s - r := by grind
 
+/- Aristotle alternative for sub_region_eq (12 vs 13 lines, -1)
+
+
+private lemma sub_region_eq {i s r h : ℕ} (hr : 0 < r)
+    (hi_lo : r * (h - 1) ≤ i) (hi_hi : i < r * h)
+    (hjs_ge : r ≤ i % r + s) :
+    i + s - r * h = i % r + s - r := by
+      have h_mod : i = r * (h - 1) + (i % r) := by
+        have h_div_alg : i = r * (i / r) + (i % r) := by
+          rw [ Nat.div_add_mod ];
+        have h_div_eq : i / r < h ∧ h - 1 ≤ i / r := by
+          exact ⟨ Nat.div_lt_of_lt_mul <| by linarith, Nat.le_div_iff_mul_le hr |>.2 <| by linarith ⟩;
+        grind +ring;
+      rw [h_mod];
+      rcases h with ( _ | _ | h ) <;> norm_num [ Nat.add_mod, Nat.mul_succ ] at * ; omega;
+-/
 /-- When i is in the last block before boundary `r*h`, and j = i%r:
     `i + s - r*h = j + s - r`. -/
 private lemma sub_region_eq {i s r h : ℕ} (hr : 0 < r)
@@ -498,6 +514,36 @@ private lemma case_wrap_BA (A B : List (Fin 3)) (offsets : List ℕ)
     rw [List.getElem?_append_right
       (by grind : B.length ≤ j + s)]
 
+/- Aristotle alternative for case_wrap_BB (20 vs 33 lines, -13)
+
+
+private lemma case_wrap_BB (A B : List (Fin 3)) (offsets : List ℕ)
+    (k m i : ℕ)
+    (hBlen : B.length = A.length + 1)
+    (hmaxOff : offsets.foldr max 0 ≤ A.length)
+    (hBB : checkLinearPolychrom offsets (B ++ B) = true)
+    (hm : B.length * k = m)
+    (hi : i < m)
+    (h_wrap : m ≤ i + offsets.foldr max 0)
+    (hk_pos : 0 < k) :
+    CaseGoal A B offsets 0 m i := by
+      use B ++ B, i % (A.length + 1);
+      have h_third_part : ∀ s ≤ List.foldr Max.max 0 offsets, (B ++ B)[i % (A.length + 1) + s]? = Option.some (blockColorVal A B 0 ((i + s) % m)) := by
+        intros s hs; rw [ blockColorVal ] ; simp +decide [ Nat.mod_eq_of_lt, * ] ;
+        rw [ show ( i + s ) % m % ( A.length + 1 ) = ( i % ( A.length + 1 ) + s ) % ( A.length + 1 ) from ?_ ];
+        · by_cases h : i % ( A.length + 1 ) + s < B.length <;> simp_all +decide [ Nat.mod_eq_of_lt ];
+          · rw [ List.getElem?_append ] ; aesop;
+          · have h_mod : (i + s) % (A.length + 1) = (i % (A.length + 1) + s) % (A.length + 1) := by
+              simp +decide [ Nat.add_mod ];
+            obtain ⟨r, hr⟩ : ∃ r, i % (A.length + 1) + s = (A.length + 1) + r ∧ r < A.length + 1 := by
+              exact ⟨ i % ( A.length + 1 ) + s - ( A.length + 1 ), by rw [ Nat.add_sub_cancel' h ], by rw [ tsub_lt_iff_left h ] ; linarith [ Nat.mod_lt i ( Nat.succ_pos A.length ) ] ⟩;
+            simp +decide [ hr, h_mod ];
+            simp +decide [ List.getElem?_append, hr.2, Nat.mod_eq_of_lt ];
+            simp +decide [ hBlen, hr.2 ];
+        · rw [ Nat.mod_mod_of_dvd _ ( show A.length + 1 ∣ m from hm ▸ dvd_mul_of_dvd_left ( by aesop ) _ ) ] ; simp +decide [ Nat.add_mod ] ;
+      simp_all +decide [ Nat.mod_lt ];
+      linarith [ Nat.mod_lt i ( Nat.succ_pos A.length ) ]
+-/
 /-! ### Case 6: Wrap, B region, h = 0 → BB -/
 private lemma case_wrap_BB (A B : List (Fin 3)) (offsets : List ℕ)
     (k m i : ℕ)
@@ -543,6 +589,51 @@ private lemma case_wrap_BB (A B : List (Fin 3)) (offsets : List ℕ)
     rw [List.getElem?_append_right
       (by grind : B.length ≤ j + s)]
 
+/- Aristotle alternative for blockColor_polychrom (34 vs 46 lines, -12)
+
+theorem blockColor_polychrom
+    (A B : List (Fin 3)) (offsets : List ℕ)
+    (hA : 0 < A.length) (hBlen : B.length = A.length + 1)
+    (hmaxOff : offsets.foldr max 0 ≤ A.length)
+    (hpairs : checkBlockPairs offsets A B = true)
+    {h k : ℕ} (hhk : 0 < h + k) {m : ℕ}
+    (hm : A.length * h + B.length * k = m)
+    {i : ℕ} (hi : i < m) (c : Fin 3) :
+    ∃ s ∈ offsets, blockColorVal A B h ((i + s) % m) = c := by
+      have h_case : CaseGoal A B offsets h m i := by
+        by_cases h_no_wrap : i + offsets.foldr Max.max 0 < m;
+        · by_cases hA_region : i < A.length * h;
+          · by_cases h_cross : A.length * h ≤ i + offsets.foldr Max.max 0;
+            · apply case_no_wrap_AB A B offsets h k m i hA hBlen hmaxOff (by
+              unfold checkBlockPairs at hpairs; aesop;) hm h_no_wrap hA_region h_cross;
+            · apply case_no_wrap_AA A B offsets h k m i hA hmaxOff (by
+              unfold checkBlockPairs at hpairs; aesop;) hm h_no_wrap (by
+              grind);
+          · apply case_no_wrap_BB A B offsets h k m i hBlen hmaxOff (by
+            unfold checkBlockPairs at hpairs; aesop;) hm h_no_wrap (by
+            grind);
+        · by_cases hB_region : A.length * h ≤ i;
+          · by_cases hk_pos : 0 < k;
+            · by_cases hh_pos : 0 < h;
+              · apply case_wrap_BA A B offsets h k m i hA hBlen hmaxOff (by
+                unfold checkBlockPairs at hpairs; aesop;) hm hi (by
+                linarith) hB_region hh_pos hk_pos;
+              · have h_case : CaseGoal A B offsets 0 m i := by
+                  have hBB : checkLinearPolychrom offsets (B ++ B) = true := by
+                    unfold checkBlockPairs at hpairs; aesop;
+                  apply case_wrap_BB A B offsets k m i hBlen hmaxOff hBB (by
+                  aesop) hi (by
+                  grind) hk_pos;
+                aesop;
+            · grind;
+          · apply case_wrap_A;
+            all_goals try linarith;
+            · unfold checkBlockPairs at hpairs; aesop;
+            · nlinarith [ show k = 0 by nlinarith ];
+      obtain ⟨ XY, j, hj₁, hj₂, hj₃ ⟩ := h_case;
+      have := checkLinearPolychrom_spec hj₁ hj₂ c; simp_all +decide ;
+      obtain ⟨ s, hs₁, hs₂ ⟩ := this; specialize hj₃ s ( le_foldr_max hs₁ ) ; aesop;
+-/
 /-! ### Main theorem: combine all cases -/
 /-- The main theorem: if all block-pair checks pass, the block coloring is
     polychromatic for any m expressible as rA·h + rB·k. -/
@@ -1410,7 +1501,7 @@ private lemma mod3_witness {s k : ℕ} (hs : s < 3) (hk : k < 3) :
     ((k + 3 - s) % 3 = 2 → (s + 2) % 3 = k) := by grind
 
 /- Aristotle alternative for `endgame_witness` (1 lines vs 5 original, -4).
-   Full proof: `aristotle_results/result_endgame_witness.lean`
+
 
     ((k + 3 - s) % 3 = 0 → s = k) ∧
     ((k + 3 - s) % 3 = 1 → (s + 1) % 3 = k) ∧
@@ -1446,7 +1537,7 @@ private lemma endgame_witness {g : ℕ} {c : ℕ → ℕ}
 
 /-- Lift a ℕ-level coloring witness for {0,1,g,g+1} to ZMod m. -/
 /- Aristotle alternative for `lift_coloring_witness` (7 lines vs 11 original, -4).
-   Full proof: `aristotle_results/result_lift_coloring_witness.lean`
+
 
 private lemma lift_coloring_witness {m g : ℕ} [NeZero m] [Fact (1 < m)]
     (hg_lt : g + 1 < m) {c : ℕ → ℕ} (hc_lt : ∀ p, c p < 3)
@@ -1841,7 +1932,7 @@ When `3 ∣ m`, multiplication by 3 is not available. Instead:
 /-- (1d), g ≢ 0 (mod 3): the periodic coloring 012012...012 works because
     each translate of {0,1,g,g+1} hits all 3 residue classes mod 3. -/
 /- Aristotle alternative for `case_one_div_g_not_three` (13 lines vs 14 original, -1).
-   Full proof: `aristotle_results/result_case_one_div_g_not_three.lean`
+
 
 lemma case_one_div_g_not_three (g : ℕ)
     (h_div : m = 3 * g ∨ m = 3 * g + 3)
@@ -1941,7 +2032,7 @@ lemma case_one_div_3g (g : ℕ) (hm_eq : m = 3 * g)
 
 /-- (1d), m = 3g+3, g ≡ 0 (mod 3): reversed diagonal coloring of period `g+1`. -/
 /- Aristotle alternative for `case_one_div_3g3` (40 lines vs 53 original, -13).
-   Full proof: `aristotle_results/result_case_one_div_3g3.lean`
+
 
     ((r + 1) % 3 + (3 - q % 3)) % 3 =
       ((r % 3 + (3 - q % 3)) % 3 + 1) % 3 := by admit
@@ -2089,7 +2180,7 @@ lemma case_one_divisible (g : ℕ) (hm : m ≥ 289) (h_div : m = 3 * g ∨ m = 3
     - (1d): 2⌊m/s⌋ ≤ g ≤ ⌈m/(s-3)⌉ with 3 ∣ m (paper shows s = 6 here),
             handled by explicit periodic colorings -/
 /- Aristotle alternative for `case_one_dispatch` (17 body + 32 helpers = 49 vs 50 original, -1).
-   Full proof: `aristotle_results/result_case_one_dispatch.lean`
+
 
     HasPolychromColouring (Fin 3) ({0, 1, 2, 3} : Finset (ZMod m)) := by admit
 
@@ -2339,7 +2430,7 @@ private lemma isUnit_intCast_of_natAbs_coprime {n : ℕ} {b : ℤ}
 /-- When gcd(b, m) = 1, there exists 2 ≤ g ≤ m - 2 with gb ≡ b - a (mod m),
     and zmod_set m a b = (image of {0,1,g,g+1} under ×b). -/
 /- Aristotle alternative for `exists_g_of_coprime` (39 lines vs 49 original, -10).
-   Full proof: `aristotle_results/result_exists_g_of_coprime.lean`
+
 
   ({0, b - a, b, 2 * b - a} : Finset ℤ).image Int.cast
 
@@ -2642,7 +2733,7 @@ private lemma orbitMap_i_eq {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
   exact hba_unit.mul_right_cancel this
 
 /- Aristotle alternative for `orbitMap_j_eq` (7 lines vs 10 original, -3).
-   Full proof: `aristotle_results/result_new_orbitMap_j_eq.lean`
+
 
 private lemma orbitMap_j_eq {m : ℕ} {b : ℤ} {e₁ : ℕ} [NeZero e₁]
     (hord : addOrderOf (b : ZMod m) = e₁)
@@ -2674,7 +2765,7 @@ private lemma orbitMap_j_eq {m : ℕ} {b : ℤ} {e₁ : ℕ} [NeZero e₁]
     exact ZMod.val_injective _ (by grind)
 
 /- Aristotle alternative for `orbitMap_injective` (7 lines vs 8 original, -1).
-   Full proof: `aristotle_results/result_new_orbitMap_injective.lean`
+
 
 private def orbitMap (m : ℕ) (a b : ℤ) (d₁ e₁ : ℕ) :
     ZMod d₁ × ZMod e₁ → ZMod m :=
@@ -3213,7 +3304,7 @@ private def case2c_pattern (d₁ k₀ i : ℕ) : Fin 3 :=
 
 -- General coverage: if (j₁ + p₁) % 3 ≠ (j₂ + p₂) % 3, all 3 colors appear.
 /- Aristotle alternative for `cover_mod3_general` (2 lines vs 3 original, -1).
-   Full proof: `aristotle_results/result_cover_mod3_general.lean`
+
 
 private lemma cover_mod3_general (p₁ p₂ : Fin 3)
     (j₁ j₂ : ℕ)
@@ -3306,7 +3397,7 @@ private def intervalColors : Fin 3 → Finset (Fin 3)
 
 /-- Any two distinct interval color pairs union to {0, 1, 2}. -/
 /- Aristotle alternative for `intervalColors_union_covers` (1 lines vs 2 original, -1).
-   Full proof: `aristotle_results/result_intervalColors_union_covers.lean`
+
 
 private def intervalColors : Fin 3 → Finset (Fin 3)
   | 0 => {0, 1}
@@ -3408,7 +3499,7 @@ private lemma rotation_changes_interval {e₁ j : ℕ}
 /-- Key polychromaticity lemma: if the base pattern is rotated by r ∈ [u, e₁-u],
     then at every position j, the 2×2 block covers all 3 colors. -/
 /- Aristotle alternative for `basePattern_rotation_covers` (15 lines vs 19 original, -4).
-   Full proof: `aristotle_results/result_basePattern_rotation_covers.lean`
+
 
 private def case2d_u (e₁ : ℕ) : ℕ := e₁ / 3 + e₁ % 3
 
@@ -3545,7 +3636,7 @@ private lemma case2d_wrap_shift {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
   exact hφq.symm
 
 /- Aristotle alternative for `case2d_shift_ba_wrap` (13 lines vs 23 original, -10).
-   Full proof: `aristotle_results/result_case2d_shift_ba_wrap.lean`
+
 
 private def orbitMap (m : ℕ) (a b : ℤ) (d₁ e₁ : ℕ) :
     ZMod d₁ × ZMod e₁ → ZMod m :=
@@ -3610,7 +3701,7 @@ private lemma case2d_shift_ba_wrap {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
 /-- Given d₁ ≥ 3 values each in [u, e₁-u] can sum to any target mod e₁,
     since the range has width ≥ e₁/3 and d₁ ≥ 3. -/
 /- Aristotle alternative for `case2d_rotation_sum_exists` (31 lines vs 80 original, -49).
-   Full proof: `aristotle_results/result_case2d_rotation_sum_exists.lean`
+
 
 private def case2d_u (e₁ : ℕ) : ℕ := e₁ / 3 + e₁ % 3
 
@@ -3786,7 +3877,7 @@ private lemma pos_shift_one {n : ℕ} [NeZero n] (j : ZMod n) (c : ℕ) :
 
 /-- (j + (S + V) % n) % n = ((j + S % n) % n + V) % n -/
 /- Aristotle alternative for `pos_shift_succ'` (2 lines vs 4 original, -2).
-   Full proof: `aristotle_results/result_pos_shift_succ'.lean`
+
 
 private lemma pos_shift_succ' (j S V n : ℕ) :
     (j + (S + V) % n) % n = ((j + S % n) % n + V) % n := by
@@ -4057,7 +4148,7 @@ lemma case_two_odd_small (hm : m ≥ 289)
     m ≥ 289 this forces m = 289 = 17², but then gcd(d₁,d₂) = 1 with
     d₁,d₂ | 17² and d₁,d₂ > 1 is impossible. -/
 /- Aristotle alternative for `no_both_e_small` (18 lines vs 20 original, -2).
-   Full proof: `aristotle_results/result_no_both_e_small.lean`
+
 
 private lemma no_both_e_small {m d₁ d₂ : ℕ}
     (hm : m ≥ 289)

--- a/Lean/Polychromatic/FourThree/Combi.lean
+++ b/Lean/Polychromatic/FourThree/Combi.lean
@@ -16,54 +16,43 @@ The proof works in the cyclic group $\mathbb{Z}_m$ where $m = c - a + b$.
 As shown in §4 of the paper, the polychromaticity of $S$ in $\mathbb{Z}$ follows from
 its polychromaticity in $\mathbb{Z}_m$.
 
-## Main results
+The analysis splits into two main cases based on the subgroup structure of $\mathbb{Z}_m$
+relative to the differences in $S$:
 
-- `normal_bit` — **the main theorem**: every normalized 4-element set admits a
-  3-polychromatic coloring. This is the entry point used by `Main.lean`.
+- **Case 1: Single Cycle (§4.1)**
+  This case occurs when at least one of $\gcd(b, m)$ or $\gcd(b-a, m)$ is 1.
+  The set $S$ is shown to be equivalent (via an affine transformation $x \mapsto ux + v$)
+  to a set of the form $\{0, 1, g, g+1\}$. The proof then branches:
+  - **(1a) Small $g$:** $g \in \{2, 3, 4\}$. Handled by the "Table 1" block colorings.
+  - **(1b) Interval Coloring:** For larger $g$, we partition $\mathbb{Z}_m$ into $s$
+    intervals (where $s$ is a multiple of 3) and use a repeating color pattern.
+  - **(1c/1d) Specific Residues:** When the interval bound is tight, we use multiplication
+    by 3 (if $3 \nmid m$) or explicit periodic colorings (if $3 \mid m$).
 
-## Proof structure
+- **Case 2: Multiple Cycles (§4.2)**
+  This case occurs when both $d_1 = \gcd(b, m) > 1$ and $d_2 = \gcd(b-a, m) > 1$.
+  The group $\mathbb{Z}_m$ is viewed via the isomorphism
+  $\mathbb{Z}_{d_1} \times \mathbb{Z}_{e_1} \cong \mathbb{Z}_m$
+  (where $e_1 = m/d_1$). The set $S$ then interacts with two adjacent cycles in this
+  decomposition. Colorings are constructed cycle-by-cycle:
+  - **(2a) Even cycle length ($e_1$ even):** Parity-based alternation.
+  - **(2b) Even cycle count ($d_1$ even, $e_1$ odd):** Parity-based alternation with
+    a "degenerate" position fixup.
+  - **(2c/2d) Both odd:** Rotating color patterns based on a partition $e_1 = u+v+w$.
 
-Let $d_1 = \gcd(b, m)$ and $d_2 = \gcd(b{-}a, m)$. The proof dispatches on whether
-one of these GCDs equals 1 (so the corresponding element generates all of
-$\mathbb{Z}_m$) or both are greater than 1 (so $\mathbb{Z}_m$ decomposes into
-shorter cycles):
+## Infrastructure
 
-- `main_case_one` — **Case 1: Single Cycle (§4.1).**
-  Applies when $\min(d_1, d_2) = 1$. The set reduces to $\{0,1,g,g{+}1\}$ via an
-  affine transformation (`exists_g_of_coprime`). Subcases by the gap parameter $g$:
-  - `case_one_small_g` — **(1a)** $g \in \{2,3,4\}$, via Table 1 block colorings.
-  - `case_one_interval` — **(1b)** General $g$, via interval coloring.
-  - `case_one_residues` — **(1c)** $3 \nmid m$, via multiplication by 3.
-  - `case_one_divisible` — **(1d)** $3 \mid m$, via explicit periodic colorings.
+The file provides `blockColor_polychrom`, a general tool for proving polychromaticity of
+cyclic colorings formed by concatenating two types of blocks (lengths $r$ and $r+1$).
+This reduces the proof of polychromaticity to checking a finite number of block-pair
+boundaries, which is done using `decide`.
 
-- `main_case_two` — **Case 2: Multiple Cycles (§4.2).**
-  Applies when both $d_1, d_2 > 1$. Setting $e_1 = m/d_1$, we use the isomorphism
-  $\mathbb{Z}_{d_1} \times \mathbb{Z}_{e_1} \cong \mathbb{Z}_m$ to define colorings
-  cycle-by-cycle. Subcases by the parity of $d_1$ and $e_1$:
-  - `case_two_e1_even` — **(2a)** $e_1$ even: parity-based alternation.
-  - `case_two_d1_even_e1_odd` — **(2b)** $d_1$ even, $e_1$ odd: alternation with fixup.
-  - `case_two_odd_small` — **(2c)** Both odd, $e_1 \le 17$: shifted periodic colorings.
-  - `case2d_coloring_works` — **(2d)** Both odd, $e_1 \ge 19$: rotating interval patterns.
+## Completion status
 
-## File organization
-
-The file is organized into Lean `section`s:
-
-- `BlockColorInfra` — General tool (`blockColor_polychrom`) for proving polychromaticity
-  of cyclic colorings formed by concatenating two block sizes.
-- `Table1` — Concrete block colorings for six specific 4-element sets.
-- `Case1_SingleCycle` — Case 1 subcases (1a)–(1d) and their aggregation.
-- `Case2_MultipleCycles` — Case 2 subcases (2a)–(2d) and their aggregation.
-- `Assembly` — Glue connecting the $\mathbb{Z}_m$ analysis back to $\mathbb{Z}$,
-  culminating in `normal_bit`.
-
-Most `private` lemmas are modular arithmetic helpers or case-analysis plumbing.
-
+Total: 9 sorries (5 Table 1 + 1 interval + 3 Case 2)
 -/
 
 open Finset Pointwise
-
-/-! ## Preliminaries: the normalized set in ZMod m -/
 
 /--
 A helper to define the transformed set in ZMod m.
@@ -72,8 +61,26 @@ Corresponds to S = {0, b-a, b, 2b-a} in the informal text.
 def zmod_set (m : ℕ) (a b : ℤ) : Finset (ZMod m) :=
   ({0, b - a, b, 2 * b - a} : Finset ℤ).image Int.cast
 
-/-- Auxiliary: the polychromatic number is invariant under the translation that
-    maps `{0, a, b, c}` to `zmod_set m a b`. -/
+/- Aristotle alternative for `polychromNumber_zmod` (10 lines vs 12 original, -2).
+   Full proof: `aristotle_results/result_polychromNumber_zmod.lean`
+
+def zmod_set (m : ℕ) (a b : ℤ) : Finset (ZMod m) :=
+  ({0, b - a, b, 2 * b - a} : Finset ℤ).image Int.cast
+
+lemma polychromNumber_zmod {a b c : ℤ} {m : ℕ} (hm : m = c - a + b) :
+    polychromNumber (({0, a, b, c} : Finset ℤ).image Int.cast : Finset (ZMod m)) =
+      polychromNumber (zmod_set m a b) := by
+        unfold zmod_set;
+        rw [ show c = a - b + m by linarith ] ; ring;
+        rw [ show ( Finset.image Int.cast { 0, -a + b, b, -a + b * 2 } : Finset ( ZMod m ) ) = ( Finset.image ( fun x : ℤ => x + ( -a + b ) ) { 0, a, b, a - b } |> Finset.image Int.cast ) from ?_ ];
+        · rw [ ← polychromNumber_vadd ] ; ring;
+          swap;
+          exact ↑b + -↑a;
+          congr ; ext ; ring;
+          simp +decide [ Finset.mem_vadd_finset, Finset.mem_insert, Finset.mem_singleton ] ; ring_nf ; aesop;
+        · ext; simp [Finset.mem_image];
+          grind +ring
+-/
 lemma polychromNumber_zmod {a b c : ℤ} {m : ℕ} (hm : m = c - a + b) :
     polychromNumber (({0, a, b, c} : Finset ℤ).image Int.cast : Finset (ZMod m)) =
       polychromNumber (zmod_set m a b) := by
@@ -92,20 +99,20 @@ lemma polychromNumber_zmod {a b c : ℤ} {m : ℕ} (hm : m = c - a + b) :
 
 /-- The set {0, b-a, b, 2b-a} is symmetric in the two repeated differences b and b-a:
     swapping them (replacing a by -a, b by b-a) gives the same set. -/
-lemma zmod_set_swap (m : ℕ) (a b : ℤ) : zmod_set m (-a) (b - a) = zmod_set m a b := by
+lemma zmod_set_swap (m : ℕ) (a b : ℤ) :
+    zmod_set m (-a) (b - a) = zmod_set m a b := by
   grind [zmod_set]
 
-/-! ## Block coloring infrastructure
+/-! ## Block coloring infrastructure for Table 1
 
-Given blocks A (length r) and B (length r+1), concatenate h copies of A followed
-by k copies of B to color ℤ_m where m = r·h + (r+1)·k. Polychromaticity reduces
-to checking 4 block-pair boundaries (AA, AB, BA, BB), which is decidable for
-concrete blocks. The key result is `blockColor_polychrom` at the end of this section.
+For each set S in Table 1 (paper §4), we define a block-based coloring:
+given blocks A (length r) and B (length r+1), concatenate h copies of A
+followed by k copies of B to color Z_m where m = r·h + (r+1)·k.
 
-The remaining lemmas in this section are technical plumbing.
+The polychromaticity reduces to checking 4 block-pair boundaries (AA, AB, BA, BB),
+which is decidable for concrete blocks. The general theorem `blockColor_polychrom`
+proves that passing these checks implies cyclic polychromaticity.
 -/
-
-section BlockColorInfra
 
 /--
 Check that every starting position in the list `L` hits all three colors {0, 1, 2}
@@ -115,7 +122,8 @@ that is handled by checking all possible block-pair concatenations.
 -/
 def checkLinearPolychrom (offsets : List ℕ) (L : List (Fin 3)) : Bool :=
   let maxOff := offsets.foldr max 0
-  (List.range (L.length - maxOff)).all fun i => ([0, 1, 2] : List (Fin 3)).all fun c =>
+  (List.range (L.length - maxOff)).all fun i =>
+    ([0, 1, 2] : List (Fin 3)).all fun c =>
       offsets.any fun s => L[i + s]? == some c
 
 /--
@@ -137,8 +145,10 @@ followed by some copies of block `B`.
 The resulting pattern colors $\mathbb{Z}_m$ where $m = h|A| + k|B|$.
 -/
 def blockColorVal (A B : List (Fin 3)) (h : ℕ) (p : ℕ) : Fin 3 :=
-  if p < A.length * h then (A[p % A.length]?).getD 0
-  else (B[(p - A.length * h) % B.length]?).getD 0
+  if p < A.length * h then
+    (A[p % A.length]?).getD 0
+  else
+    (B[(p - A.length * h) % B.length]?).getD 0
 
 
 private lemma checkLinearPolychrom_spec {offsets : List ℕ} {L : List (Fin 3)}
@@ -151,12 +161,29 @@ private lemma checkLinearPolychrom_spec {offsets : List ℕ} {L : List (Fin 3)}
 
 /-- Frobenius representation for consecutive block sizes r, r+1:
     any m ≥ r(r-1) can be written as r·h + (r+1)·k. -/
+/- Aristotle alternative for `frobenius_consec` (10 lines vs 11 original, -1).
+   Full proof: `aristotle_results/result_frobenius_consec.lean`
+
+private lemma frobenius_consec {rA m : ℕ} (hrA : 1 < rA) (hm : m ≥ rA * (rA - 1)) :
+    ∃ h k, rA * h + (rA + 1) * k = m ∧ 0 < h + k := by
+      -- By the properties of linear combinations, since $rA$ and $rA + 1$ are coprime, there exist non-negative integers $h$ and $k$ such that $rA * h + (rA + 1) * k = m$.
+      have h_comb : ∃ h k : ℤ, rA * h + (rA + 1) * k = m ∧ 0 ≤ h ∧ h < rA + 1 := by
+        have h_comb : ∃ h k : ℤ, rA * h + (rA + 1) * k = m := by
+          exact ⟨ m * rA, -m * ( rA - 1 ), by ring ⟩;
+        obtain ⟨ h, k, hk ⟩ := h_comb; exact ⟨ h % ( rA + 1 ), k + h / ( rA + 1 ) * rA, by nth_rw 1 [ ← hk ] ; nlinarith [ Int.emod_add_mul_ediv h ( rA + 1 ) ], Int.emod_nonneg _ ( by positivity ), Int.emod_lt_of_pos _ ( by positivity ) ⟩ ;
+      obtain ⟨ h, k, h₁, h₂, h₃ ⟩ := h_comb;
+      refine' ⟨ Int.toNat h, Int.toNat k, _, _ ⟩;
+      · nlinarith [ Int.toNat_of_nonneg h₂, Int.toNat_of_nonneg ( by nlinarith [ Nat.sub_add_cancel hrA.le ] : 0 ≤ k ) ];
+      · rcases rA with ( _ | _ | rA ) <;> simp_all +decide;
+        exact Classical.or_iff_not_imp_left.2 fun h => by nlinarith;
+-/
 private lemma frobenius_consec {rA m : ℕ} (hrA : 1 < rA) (hm : m ≥ rA * (rA - 1)) :
     ∃ h k, rA * h + (rA + 1) * k = m ∧ 0 < h + k := by
   obtain ⟨a, b, hab⟩ := Nat.exists_add_mul_eq_of_gcd_dvd_of_mul_pred_le rA (rA + 1) m
     (by rw [(Nat.coprime_self_add_right.mpr (Nat.coprime_one_right _)).gcd_eq_one]; exact one_dvd _)
     (by grind [Nat.pred_eq_sub_one, mul_comm rA (rA - 1)])
   refine ⟨a, b, by grind [mul_comm a rA, mul_comm b (rA + 1)], ?_⟩
+  -- a + b = 0 → a = b = 0 → m = 0, but m ≥ rA * (rA - 1) > 0
   by_contra hle; push_neg at hle
   have ha0 : a = 0 := by omega
   have hb0 : b = 0 := by omega
@@ -169,11 +196,18 @@ private lemma hasPolychromColouring_of_cyclic {m : ℕ} [NeZero m] [Fact (1 < m)
     (c : ℕ → Fin 3) (S : Finset (ZMod m))
     (hpoly : ∀ n : ZMod m, ∀ k : Fin 3, ∃ a ∈ S, c (n + a).val = k) :
     HasPolychromColouring (Fin 3) S :=
-  ⟨fun x => c x.val, hpoly⟩
+  ⟨fun x => c x.val, fun n k => by
+    obtain ⟨a, ha, heq⟩ := hpoly n k
+    exact ⟨a, ha, by change c (n + a).val = k; exact heq⟩⟩
 
+/-- Key: offsets in a list are bounded by foldr max. -/
+private lemma le_foldr_max {offsets : List ℕ} {s : ℕ} (hs : s ∈ offsets) :
+    s ≤ offsets.foldr max 0 :=
+  List.le_max_of_le' 0 hs le_rfl
 
 /-- If `i % r + s < r`, then `(i + s) % r = i % r + s`. -/
-private lemma add_mod_of_lt {i s r : ℕ} (h : i % r + s < r) : (i + s) % r = i % r + s := by
+private lemma add_mod_of_lt {i s r : ℕ} (h : i % r + s < r) :
+    (i + s) % r = i % r + s := by
   have hs : s < r := by omega
   rw [Nat.add_mod, Nat.mod_eq_of_lt hs]
   exact Nat.mod_eq_of_lt h
@@ -191,7 +225,8 @@ private lemma add_mod_sub {i s r : ℕ} (hr : 0 < r) (hge : r ≤ i % r + s)
   exact Nat.mod_eq_of_lt (by omega)
 
 /-- If `M ≤ n` and `n - M < M`, then `n % M = n - M`. -/
-private lemma mod_eq_sub {n M : ℕ} (hge : M ≤ n) (hlt : n - M < M) : n % M = n - M := by
+private lemma mod_eq_sub {n M : ℕ} (hge : M ≤ n) (hlt : n - M < M) :
+    n % M = n - M := by
   conv_lhs => rw [← Nat.sub_add_cancel hge]
   rw [Nat.add_mod_right, Nat.mod_eq_of_lt hlt]
 
@@ -211,8 +246,7 @@ private lemma ge_mul_of_mod_add_ge {i s r n : ℕ} (hr : 0 < r) (hn : 0 < n)
     r * n ≤ i + s := by
   have := Nat.mod_add_div i r
   have := Nat.mod_lt i hr
-  have : n - 1 ≤ i / r := by
-    rw [Nat.le_div_iff_mul_le hr]; grind
+  have : n - 1 ≤ i / r := by rw [Nat.le_div_iff_mul_le hr]; grind [mul_comm r (n - 1)]
   have : n ≤ i / r + 1 := by omega
   grind [Nat.mul_le_mul_left r this]
 
@@ -251,16 +285,23 @@ private lemma sub_add_eq {i j s r q : ℕ} (hge : r ≤ j + s)
     (hi : j + q = i) :
     i + s - (q + r) = j + s - r := by grind
 
-/-- When i is in the last block before boundary `r*h`, and j = i%r: `i + s - r*h = j + s - r`. -/
+/-- When i is in the last block before boundary `r*h`, and j = i%r:
+    `i + s - r*h = j + s - r`. -/
 private lemma sub_region_eq {i s r h : ℕ} (hr : 0 < r)
     (hi_lo : r * (h - 1) ≤ i) (hi_hi : i < r * h)
     (hjs_ge : r ≤ i % r + s) :
     i + s - r * h = i % r + s - r := by
+  have hmod := Nat.mod_lt i hr
   have hdiv := Nat.mod_add_div i r
-  have hle : h - 1 ≤ i / r := by rw [Nat.le_div_iff_mul_le hr]; grind
-  have hlt : i / r < h := Nat.div_lt_of_lt_mul (by grind)
-  have hh : 1 ≤ h := by omega
-  have hQr : r * h = r * (i / r) + r := by grind [Nat.sub_add_cancel]
+  have hle : h - 1 ≤ i / r := by
+    rw [Nat.le_div_iff_mul_le hr]; grind [mul_comm r (h - 1)]
+  have hlt : i / r < h := Nat.div_lt_of_lt_mul (by grind [mul_comm r h])
+  have hq : i / r = h - 1 := by grind
+  set Q := r * (i / r) with hQ_def
+  have hQr : r * h = Q + r := by
+    rw [hQ_def, hq]
+    have : h = (h - 1) + 1 := by grind
+    conv_lhs => rw [this, Nat.mul_add, Nat.mul_one]
   rw [hQr]
   exact sub_add_eq hjs_ge hdiv
 
@@ -273,11 +314,14 @@ produces a `CaseGoal`, and the main theorem dispatches to them.
 -/
 
 /-- The common proof obligation for each case of `blockColor_polychrom`. -/
-private def CaseGoal (A B : List (Fin 3)) (offsets : List ℕ) (h m i : ℕ) : Prop :=
+private def CaseGoal (A B : List (Fin 3)) (offsets : List ℕ) (h m i : ℕ) :
+    Prop :=
   ∃ (XY : List (Fin 3)) (j : ℕ),
     checkLinearPolychrom offsets XY = true ∧
     j + offsets.foldr max 0 < XY.length ∧
-    ∀ s, s ≤ offsets.foldr max 0 → XY[j + s]? = some (blockColorVal A B h ((i + s) % m))
+    ∀ s, s ≤ offsets.foldr max 0 →
+      (XY[j + s]? : Option (Fin 3)) =
+        some (blockColorVal A B h ((i + s) % m))
 
 /-! ### Case 1: No wrap, AA interior -/
 private lemma case_no_wrap_AA (A B : List (Fin 3)) (offsets : List ℕ)
@@ -293,7 +337,7 @@ private lemma case_no_wrap_AA (A B : List (Fin 3)) (offsets : List ℕ)
   set j := i % A.length
   have hj_lt : j < A.length := Nat.mod_lt _ hA
   refine ⟨A ++ A, j, hAA, by grind, fun s hsle => ?_⟩
-  rw [Nat.mod_eq_of_lt (by grind)]
+  rw [Nat.mod_eq_of_lt (by grind : i + s < m)]
   have his_A : i + s < A.length * h := by grind
   by_cases hjs_lt : j + s < A.length
   · exact bcv_eq_A A B h _ _ _ _ his_A
@@ -303,7 +347,7 @@ private lemma case_no_wrap_AA (A B : List (Fin 3)) (offsets : List ℕ)
     have hjs_2r : i % A.length + s < 2 * A.length := by grind
     exact bcv_eq_A A B h _ _ _ _ his_A
       (add_mod_sub hA hjs_lt hjs_2r) hjs_sub
-      (by rw [List.getElem?_append_right (by grind)])
+      (by rw [List.getElem?_append_right (by grind : A.length ≤ j + s)])
 
 /-! ### Case 2: No wrap, AB boundary -/
 private lemma case_no_wrap_AB (A B : List (Fin 3)) (offsets : List ℕ)
@@ -320,9 +364,10 @@ private lemma case_no_wrap_AB (A B : List (Fin 3)) (offsets : List ℕ)
   set j := i % A.length
   have hj_lt : j < A.length := Nat.mod_lt _ hA
   have hh_pos : 0 < h := by grind
-  have hi_lo : A.length * (h - 1) ≤ i := by grind [Nat.mul_sub]
+  have hi_lo : A.length * (h - 1) ≤ i := by
+    grind [Nat.mul_sub]
   refine ⟨A ++ B, j, hAB, by grind, fun s hsle => ?_⟩
-  rw [Nat.mod_eq_of_lt (by grind)]
+  rw [Nat.mod_eq_of_lt (by grind : i + s < m)]
   by_cases hjs_lt : j + s < A.length
   · exact bcv_eq_A A B h _ _ _ _
       (add_lt_of_mod_add_lt hA hA_region hjs_lt)
@@ -330,12 +375,13 @@ private lemma case_no_wrap_AB (A B : List (Fin 3)) (offsets : List ℕ)
       (List.getElem?_append_left hjs_lt)
   · push_neg at hjs_lt
     have hjs_B : j + s - A.length < B.length := by grind
-    have his_ge : A.length * h ≤ i + s := ge_mul_of_mod_add_ge hA hh_pos hi_lo hjs_lt
+    have his_ge : A.length * h ≤ i + s :=
+      ge_mul_of_mod_add_ge hA hh_pos hi_lo hjs_lt
     have hnot_A : ¬(i + s < A.length * h) := by grind
     refine bcv_eq_B A B h _ _ _ _ hnot_A ?_ hjs_B ?_
     · rw [sub_region_eq hA hi_lo hA_region hjs_lt,
         Nat.mod_eq_of_lt (by grind)]
-    · rw [List.getElem?_append_right (by grind)]
+    · rw [List.getElem?_append_right (by grind : A.length ≤ j + s)]
 
 /-! ### Case 3: No wrap, BB -/
 private lemma case_no_wrap_BB (A B : List (Fin 3)) (offsets : List ℕ)
@@ -351,7 +397,7 @@ private lemma case_no_wrap_BB (A B : List (Fin 3)) (offsets : List ℕ)
   set j := (i - A.length * h) % B.length
   have hj_lt : j < B.length := Nat.mod_lt _ (by grind)
   refine ⟨B ++ B, j, hBB, by grind, fun s hsle => ?_⟩
-  rw [Nat.mod_eq_of_lt (by grind)]
+  rw [Nat.mod_eq_of_lt (by grind : i + s < m)]
   by_cases hjs_lt : j + s < B.length
   · exact bcv_eq_B A B h _ _ _ _ (by grind)
       (by rw [Nat.sub_add_comm hB_region]; exact add_mod_of_lt hjs_lt)
@@ -361,7 +407,8 @@ private lemma case_no_wrap_BB (A B : List (Fin 3)) (offsets : List ℕ)
     exact bcv_eq_B A B h _ _ _ _ (by grind)
       (by rw [Nat.sub_add_comm hB_region]; exact add_mod_sub (by grind) hjs_lt (by grind))
       hjs_sub
-      (by rw [List.getElem?_append_right (by grind)])
+      (by rw [List.getElem?_append_right
+            (by grind : B.length ≤ j + s)])
 
 /-! ### Case 4: Wrap, A region (k = 0) -/
 private lemma case_wrap_A (A B : List (Fin 3)) (offsets : List ℕ)
@@ -380,22 +427,27 @@ private lemma case_wrap_A (A B : List (Fin 3)) (offsets : List ℕ)
   have hj_lt : j < A.length := Nat.mod_lt _ hA
   have hh_pos : 0 < h := by grind
   have hi_lo : A.length * (h - 1) ≤ i := by grind [Nat.mul_sub]
-  have hAh : A.length ≤ A.length * h := Nat.le_mul_of_pos_right _ hh_pos
+  have hAh : A.length ≤ A.length * h :=
+    Nat.le_mul_of_pos_right _ hh_pos
   refine ⟨A ++ A, j, hAA, by grind, fun s hsle => ?_⟩
   by_cases hjs_lt : j + s < A.length
-  · have his_lt : i + s < A.length * h := add_lt_of_mod_add_lt hA (by grind) hjs_lt
+  · have his_lt : i + s < A.length * h :=
+      add_lt_of_mod_add_lt hA (by grind) hjs_lt
     rw [Nat.mod_eq_of_lt his_lt]
     exact bcv_eq_A A B h _ _ _ _ his_lt
       (add_mod_of_lt hjs_lt) hjs_lt (List.getElem?_append_left hjs_lt)
   · push_neg at hjs_lt
-    have his_ge : A.length * h ≤ i + s := ge_mul_of_mod_add_ge hA hh_pos hi_lo hjs_lt
-    have hmod : (i + s) % (A.length * h) = i + s - A.length * h := mod_eq_sub his_ge (by grind)
+    have his_ge : A.length * h ≤ i + s :=
+      ge_mul_of_mod_add_ge hA hh_pos hi_lo hjs_lt
+    have hmod : (i + s) % (A.length * h) = i + s - A.length * h :=
+      mod_eq_sub his_ge (by grind)
     have hsub_eq := sub_region_eq hA hi_lo (by grind) hjs_lt
     have hjs_idx : j + s - A.length < A.length := by grind
     refine bcv_eq_A A B h _ _ _ _ (by grind)
       (by rw [hmod, Nat.mod_eq_of_lt (by grind), hsub_eq])
       hjs_idx ?_
-    rw [List.getElem?_append_right (by grind)]
+    rw [List.getElem?_append_right
+      (by grind : A.length ≤ j + s)]
 
 /-! ### Case 5: Wrap, B region, h > 0 → BA -/
 private lemma case_wrap_BA (A B : List (Fin 3)) (offsets : List ℕ)
@@ -410,35 +462,41 @@ private lemma case_wrap_BA (A B : List (Fin 3)) (offsets : List ℕ)
     (hh_pos : 0 < h) (hk_pos : 0 < k) :
     CaseGoal A B offsets h m i := by
   set maxOff := offsets.foldr max 0
-  have hAh : A.length ≤ A.length * h := Nat.le_mul_of_pos_right _ hh_pos
-  have hBk : B.length ≤ B.length * k := Nat.le_mul_of_pos_right _ hk_pos
+  have hAh : A.length ≤ A.length * h :=
+    Nat.le_mul_of_pos_right _ hh_pos
+  have hBk : B.length ≤ B.length * k :=
+    Nat.le_mul_of_pos_right _ hk_pos
   set j := (i - A.length * h) % B.length
   have hj_lt : j < B.length := Nat.mod_lt _ (by grind)
   have hi_B : i - A.length * h < B.length * k := by grind
-  have hk_lo : B.length * (k - 1) ≤ i - A.length * h := by grind [Nat.mul_sub]
+  have hk_lo : B.length * (k - 1) ≤ i - A.length * h := by
+    grind [Nat.mul_sub]
   refine ⟨B ++ A, j, hBA, by grind, fun s hsle => ?_⟩
   by_cases hjs_lt : j + s < B.length
   · -- Still in B
     have his_lt : (i - A.length * h) + s < B.length * k :=
       add_lt_of_mod_add_lt (by grind) hi_B hjs_lt
-    rw [Nat.mod_eq_of_lt (by grind)]
+    rw [Nat.mod_eq_of_lt (by grind : i + s < m)]
     exact bcv_eq_B A B h _ _ _ _ (by grind)
       (by rw [Nat.sub_add_comm hB_region]; exact add_mod_of_lt hjs_lt)
       hjs_lt (List.getElem?_append_left hjs_lt)
   · -- Wrapped to A region
     push_neg at hjs_lt
     have his_ge : m ≤ i + s := by
-      have := ge_mul_of_mod_add_ge (by grind) hk_pos hk_lo hjs_lt
-      grind
+      have := ge_mul_of_mod_add_ge (by grind : 0 < B.length)
+        hk_pos hk_lo hjs_lt; grind
     have hmod : (i + s) % m = i + s - m := mod_eq_sub his_ge (by grind)
     have hsub_eq : i + s - m = j + s - B.length := by
-      have := sub_region_eq (by grind) hk_lo hi_B hjs_lt
+      have key : (i - A.length * h) + s - B.length * k =
+          j + s - B.length :=
+        sub_region_eq (by grind) hk_lo hi_B hjs_lt
       grind
     have hjs_idx : j + s - B.length < A.length := by grind
     refine bcv_eq_A A B h _ _ _ _ (by grind)
       (by rw [hmod, Nat.mod_eq_of_lt (by grind), hsub_eq])
       hjs_idx ?_
-    rw [List.getElem?_append_right (by grind)]
+    rw [List.getElem?_append_right
+      (by grind : B.length ≤ j + s)]
 
 /-! ### Case 6: Wrap, B region, h = 0 → BB -/
 private lemma case_wrap_BB (A B : List (Fin 3)) (offsets : List ℕ)
@@ -452,22 +510,25 @@ private lemma case_wrap_BB (A B : List (Fin 3)) (offsets : List ℕ)
     (hk_pos : 0 < k) :
     CaseGoal A B offsets 0 m i := by
   set maxOff := offsets.foldr max 0
-  have hBk : B.length ≤ B.length * k := Nat.le_mul_of_pos_right _ hk_pos
+  have hBk : B.length ≤ B.length * k :=
+    Nat.le_mul_of_pos_right _ hk_pos
   set j := i % B.length
   have hj_lt : j < B.length := Nat.mod_lt _ (by grind)
-  have hk_lo : B.length * (k - 1) ≤ i := by grind [Nat.mul_sub]
+  have hk_lo : B.length * (k - 1) ≤ i := by
+    grind [Nat.mul_sub]
   refine ⟨B ++ B, j, hBB, by grind, fun s hsle => ?_⟩
   by_cases hjs_lt : j + s < B.length
-  · have his_lt : i + s < B.length * k := add_lt_of_mod_add_lt (by grind) (by grind) hjs_lt
-    rw [Nat.mod_eq_of_lt (by grind)]
+  · have his_lt : i + s < B.length * k :=
+      add_lt_of_mod_add_lt (by grind) (by grind) hjs_lt
+    rw [Nat.mod_eq_of_lt (by grind : i + s < m)]
     exact bcv_eq_B A B 0 _ _ _ _
       (by omega)
-      (by grind [add_mod_of_lt hjs_lt])
+      (by simp only [mul_zero, tsub_zero]; exact add_mod_of_lt hjs_lt)
       hjs_lt (List.getElem?_append_left hjs_lt)
   · push_neg at hjs_lt
     have his_ge : m ≤ i + s := by
-      have := ge_mul_of_mod_add_ge (by grind) hk_pos hk_lo hjs_lt
-      grind
+      have := ge_mul_of_mod_add_ge (by grind : 0 < B.length)
+        hk_pos hk_lo hjs_lt; grind
     have hmod : (i + s) % m = i + s - m := mod_eq_sub his_ge (by grind)
     have hsub_eq : i + s - m = j + s - B.length := by
       rw [← hm]
@@ -475,15 +536,16 @@ private lemma case_wrap_BB (A B : List (Fin 3)) (offsets : List ℕ)
     have hjs_idx : j + s - B.length < B.length := by grind
     refine bcv_eq_B A B 0 _ _ _ _
       (by omega)
-      (by rw [Nat.mul_zero, Nat.sub_zero, hmod, Nat.mod_eq_of_lt (by grind), hsub_eq])
+      (by simp only [mul_zero, tsub_zero]
+          rw [hmod, Nat.mod_eq_of_lt
+            (by grind : i + s - m < B.length), hsub_eq])
       hjs_idx ?_
-    rw [List.getElem?_append_right (by grind)]
+    rw [List.getElem?_append_right
+      (by grind : B.length ≤ j + s)]
 
-/-! ### Main result of the block coloring infrastructure -/
-
-/-- **Key infrastructure theorem.** If all block-pair checks pass, the block coloring is
-    polychromatic for any m expressible as rA·h + rB·k. This is the main interface
-    used by the Table 1 lemmas below. -/
+/-! ### Main theorem: combine all cases -/
+/-- The main theorem: if all block-pair checks pass, the block coloring is
+    polychromatic for any m expressible as rA·h + rB·k. -/
 theorem blockColor_polychrom
     (A B : List (Fin 3)) (offsets : List ℕ)
     (hA : 0 < A.length) (hBlen : B.length = A.length + 1)
@@ -499,51 +561,55 @@ theorem blockColor_polychrom
   -- Reduce to CaseGoal
   suffices hg : CaseGoal A B offsets h m i by
     obtain ⟨XY, j, hXY_check, hj_bound, hcorr⟩ := hg
-    obtain ⟨s, hs_mem, hs_eq⟩ := checkLinearPolychrom_spec hXY_check hj_bound c
+    obtain ⟨s, hs_mem, hs_eq⟩ :=
+      checkLinearPolychrom_spec hXY_check hj_bound c
     refine ⟨s, hs_mem, ?_⟩
-    have := hcorr s (List.le_max_of_le' 0 hs_mem le_rfl)
+    have := hcorr s (le_foldr_max hs_mem)
     rw [hs_eq] at this; exact Option.some.inj this.symm
   -- Dispatch to case lemmas
   by_cases h_wrap : i + maxOff < m
   · by_cases hA_region : i < A.length * h
     · by_cases h_cross : i + maxOff < A.length * h
-      · exact case_no_wrap_AA A B offsets h k m i hA hmaxOff hAA hm h_wrap h_cross
+      · exact case_no_wrap_AA A B offsets h k m i hA hmaxOff
+          hAA hm h_wrap h_cross
       · push_neg at h_cross
         have hk_pos : 0 < k := by grind
-        exact case_no_wrap_AB A B offsets h k m i hA hBlen hmaxOff hAB hm h_wrap hA_region h_cross
+        exact case_no_wrap_AB A B offsets h k m i hA hBlen hmaxOff
+          hAB hm h_wrap hA_region h_cross
     · push_neg at hA_region
-      exact case_no_wrap_BB A B offsets h k m i hBlen hmaxOff hBB hm h_wrap hA_region
+      exact case_no_wrap_BB A B offsets h k m i hBlen hmaxOff
+        hBB hm h_wrap hA_region
   · push_neg at h_wrap
     by_cases hA_region : i < A.length * h
-    · have hk0 : k = 0 := by rw [hBlen] at hm; nlinarith [hmaxOff]
+    · have hk0 : k = 0 := by
+        by_contra hle; push_neg at hle
+        have : 0 < k := by grind
+        have : B.length ≤ B.length * k :=
+          Nat.le_mul_of_pos_right _ this; grind
       subst hk0; simp only [mul_zero, add_zero] at hm
-      exact case_wrap_A A B offsets h m i hA hmaxOff hAA hm hi h_wrap hA_region
+      exact case_wrap_A A B offsets h m i hA hmaxOff hAA hm
+        hi h_wrap hA_region
     · push_neg at hA_region
-      have hk_pos : 0 < k := by nlinarith [hm, hA_region, hi]
+      have hk_pos : 0 < k := by
+        by_contra hle; push_neg at hle; have : k = 0 := by grind
+        subst this; simp [mul_zero] at hm; grind
       by_cases hh_pos : 0 < h
       · exact case_wrap_BA A B offsets h k m i hA hBlen hmaxOff
           hBA hm hi h_wrap hA_region hh_pos hk_pos
       · have hh0 : h = 0 := by grind
         subst hh0
         simp only [mul_zero, zero_add] at hm
-        exact case_wrap_BB A B offsets k m i hBlen hmaxOff hBB hm hi h_wrap hk_pos
-
-end BlockColorInfra
+        exact case_wrap_BB A B offsets k m i hBlen hmaxOff
+          hBB hm hi h_wrap hk_pos
 
 /-! ## Table 1: Block concatenation colorings (paper §4, Table 1)
 
-Each `table1_*` lemma constructs a concrete 3-polychromatic coloring for a specific
-4-element set using `blockColor_polychrom`. These are intermediate results used in
-subcases (1a) and (1c) of Case 1.
+For each set S below, blocks of length r and r+1 are concatenated to produce
+an S-polychromatic 3-coloring of ℤ_m. The Frobenius coin problem ensures
+m can be so expressed when m ≥ r². Polychromaticity follows from
+`blockColor_polychrom` after checking block-pair boundaries by `decide`.
 
-| Lemma | Set | Block size r | Min m |
-|-------|-----|-------------|-------|
-| `table1_0123` | {0,1,2,3} | 3 | 6 |
-| `table1_0134` | {0,1,3,4} | 6 | 30 |
-| `table1_0235` | {0,2,3,5} | 6 | 30 |
-| `table1_0347` | {0,3,4,7} | 9 | 72 |
-| `table1_0358` | {0,3,5,8} | 9 | 72 |
-| `table1_0145` | {0,1,4,5} | 7 | 42 |
+These are used in subcases (1a) and (1c) of Main Case 1.
 -/
 
 section Table1
@@ -560,9 +626,11 @@ private lemma table1_of_blockColor (A B : List (Fin 3)) (offsets : List ℕ)
     (hm : m ≥ A.length * (A.length - 1))
     (hS : ∀ a : ZMod m, a ∈ S ↔ ∃ s ∈ offsets, (s : ZMod m) = a) :
     HasPolychromColouring (Fin 3) S := by
-  have hA_lt_m : A.length < m := by
-    have : A.length * 2 ≤ A.length * (A.length - 1) := by gcongr; omega
-    omega
+  have hA_lt_m : A.length < m :=
+    calc A.length < A.length * 2 := by omega
+    _ ≤ A.length * (A.length - 1) := by gcongr; omega
+    _ ≤ m := hm
+  have hm_pos : 0 < m := by omega
   haveI : NeZero m := ⟨by omega⟩
   haveI : Fact (1 < m) := ⟨by omega⟩
   obtain ⟨h, k, hm_eq, hhk⟩ := frobenius_consec (by omega : 1 < A.length) hm
@@ -572,44 +640,51 @@ private lemma table1_of_blockColor (A B : List (Fin 3)) (offsets : List ℕ)
   obtain ⟨s, hs_mem, hs_eq⟩ := blockColor_polychrom A B offsets (by omega) hBlen hmaxOff
     hpairs hhk hm_eq' (ZMod.val_lt n) target
   refine ⟨(s : ZMod m), (hS _).mpr ⟨s, hs_mem, rfl⟩, ?_⟩
-  have : s < m := lt_of_le_of_lt (le_trans (List.le_max_of_le' 0 hs_mem le_rfl) hmaxOff) hA_lt_m
+  have : s < m := lt_of_le_of_lt (le_trans (le_foldr_max hs_mem) hmaxOff) hA_lt_m
   rw [ZMod.val_add, ZMod.val_natCast, Nat.mod_eq_of_lt this]
   exact hs_eq
 
 /-- {0,1,2,3}: blocks [0,1,2] (r=3), [0,0,1,2] (r+1=4). Frobenius bound: m ≥ 6. -/
-lemma table1_0123 (hm : m ≥ 6) : HasPolychromColouring (Fin 3) ({0, 1, 2, 3} : Finset (ZMod m)) :=
+lemma table1_0123 (hm : m ≥ 6) :
+    HasPolychromColouring (Fin 3) ({0, 1, 2, 3} : Finset (ZMod m)) :=
   table1_of_blockColor m [0,1,2] [0,0,1,2] [0,1,2,3]
     {0, 1, 2, 3} (by simp) (by simp) (by decide) (by decide) hm
     (by intro a; simp; tauto)
 
 /-- {0,1,3,4}: blocks [0,0,1,2,1,2] (r=6), [0,0,0,1,2,1,2] (r+1=7). Frobenius: m ≥ 30. -/
-lemma table1_0134 (hm : m ≥ 30) : HasPolychromColouring (Fin 3) ({0, 1, 3, 4} : Finset (ZMod m)) :=
+lemma table1_0134 (hm : m ≥ 30) :
+    HasPolychromColouring (Fin 3) ({0, 1, 3, 4} : Finset (ZMod m)) :=
   table1_of_blockColor m [0,0,1,2,1,2] [0,0,0,1,2,1,2] [0,1,3,4]
     {0, 1, 3, 4} (by simp) (by simp) (by decide) (by decide) hm
     (by intro a; simp; tauto)
 
 /-- {0,2,3,5}: blocks [0,0,1,1,2,2] (r=6), [0,0,0,1,1,2,2] (r+1=7). Frobenius: m ≥ 30. -/
-lemma table1_0235 (hm : m ≥ 30) : HasPolychromColouring (Fin 3) ({0, 2, 3, 5} : Finset (ZMod m)) :=
+lemma table1_0235 (hm : m ≥ 30) :
+    HasPolychromColouring (Fin 3) ({0, 2, 3, 5} : Finset (ZMod m)) :=
   table1_of_blockColor m [0,0,1,1,2,2] [0,0,0,1,1,2,2] [0,2,3,5]
     {0, 2, 3, 5} (by simp) (by simp) (by decide) (by decide) hm
     (by intro a; simp; tauto)
 
 /-- {0,3,4,7}: blocks [0,0,0,1,1,1,2,2,2] (r=9), [0,0,0,0,1,1,1,2,2,2] (r+1=10).
     Frobenius: m ≥ 72. -/
-lemma table1_0347 (hm : m ≥ 72) : HasPolychromColouring (Fin 3) ({0, 3, 4, 7} : Finset (ZMod m)) :=
+lemma table1_0347 (hm : m ≥ 72) :
+    HasPolychromColouring (Fin 3) ({0, 3, 4, 7} : Finset (ZMod m)) :=
   table1_of_blockColor m [0,0,0,1,1,1,2,2,2] [0,0,0,0,1,1,1,2,2,2] [0,3,4,7]
     {0, 3, 4, 7} (by simp) (by simp) (by decide) (by decide) hm
     (by intro a; simp; tauto)
 
 /-- {0,3,5,8}: blocks [0,0,0,1,1,1,2,2,2] (r=9), [0,0,0,0,1,1,1,2,2,2] (r+1=10).
     Frobenius: m ≥ 72. -/
-lemma table1_0358 (hm : m ≥ 72) : HasPolychromColouring (Fin 3) ({0, 3, 5, 8} : Finset (ZMod m)) :=
+lemma table1_0358 (hm : m ≥ 72) :
+    HasPolychromColouring (Fin 3) ({0, 3, 5, 8} : Finset (ZMod m)) :=
   table1_of_blockColor m [0,0,0,1,1,1,2,2,2] [0,0,0,0,1,1,1,2,2,2] [0,3,5,8]
     {0, 3, 5, 8} (by simp) (by simp) (by decide) (by decide) hm
     (by intro a; simp; tauto)
 
-/-- {0,1,4,5}: blocks [0,0,0,1,2,1,2] (r=7), [0,0,0,0,1,2,1,2] (r+1=8). Frobenius: m ≥ 42. -/
-lemma table1_0145 (hm : m ≥ 42) : HasPolychromColouring (Fin 3) ({0, 1, 4, 5} : Finset (ZMod m)) :=
+/-- {0,1,4,5}: blocks [0,0,0,1,2,1,2] (r=7), [0,0,0,0,1,2,1,2] (r+1=8).
+    Frobenius: m ≥ 42. -/
+lemma table1_0145 (hm : m ≥ 42) :
+    HasPolychromColouring (Fin 3) ({0, 1, 4, 5} : Finset (ZMod m)) :=
   table1_of_blockColor m [0,0,0,1,2,1,2] [0,0,0,0,1,2,1,2] [0,1,4,5]
     {0, 1, 4, 5} (by simp) (by simp) (by decide) (by decide) hm
     (by intro a; simp; tauto)
@@ -637,7 +712,8 @@ variable (m : ℕ)
 
 -- In this section, we work with the affine transformed set {0, 1, g, g+1}.
 
-/-- **Subcase (1a):** g ∈ {2, 3, 4}. Reduces directly to Table 1 entries. -/
+/-- Subcase (1a): g ∈ {2, 3, 4}.
+    Handled by the table constructions in subcase (1c). -/
 lemma case_one_small_g (g : ℕ) (hm : m ≥ 289) (hg : g ∈ ({2, 3, 4} : Finset ℕ)) :
     HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by
   fin_cases hg <;> push_cast <;> norm_num
@@ -645,11 +721,14 @@ lemma case_one_small_g (g : ℕ) (hm : m ≥ 289) (hg : g ∈ ({2, 3, 4} : Finse
   · exact table1_0134 m (by grind)
   · exact table1_0145 m (by grind)
 
-/-! ### Helper lemmas for subcase (1b)
+/-! ### Helper lemmas for case 1b -/
 
-These are technical arithmetic lemmas used in the proof of `case_one_interval`.
-They are not important on their own.
--/
+/-- Two pairs of consecutive mod-3 values with different phases cover {0,1,2}. -/
+private lemma two_pairs_cover (j₁ j₂ : ℕ) (hne : j₁ % 3 ≠ j₂ % 3)
+    (k : ℕ) (hk : k < 3) :
+    k = j₁ % 3 ∨ k = (j₁ + 1) % 3 ∨
+    k = j₂ % 3 ∨ k = (j₂ + 1) % 3 := by
+  omega
 
 private lemma lt_two' (n : ℕ) (h : n < 2) : n = 0 ∨ n = 1 := by omega
 
@@ -659,8 +738,10 @@ private lemma phase_ne_of_gap {s j₀ jg : ℕ} (hs3 : 3 ∣ s)
     (hgap : (jg + s - j₀) % s = 1 ∨ (jg + s - j₀) % s = 2) :
     j₀ % 3 ≠ jg % 3 := by
   obtain ⟨t, ht⟩ := hs3; subst ht
+  have ht_pos : 0 < t := by omega
+  have h3t_pos : 0 < 3 * t := by omega
   have hqlt : (jg + 3 * t - j₀) / (3 * t) < 2 := by
-    rw [Nat.div_lt_iff_lt_mul (by omega)]; omega
+    rw [Nat.div_lt_iff_lt_mul h3t_pos]; omega
   have hdam := Nat.div_add_mod (jg + 3 * t - j₀) (3 * t)
   rcases hgap with hmod | hmod <;>
     rcases lt_two' _ hqlt with hq | hq <;>
@@ -696,32 +777,38 @@ private lemma idx_in_interval' (s m : ℕ) (hs : 0 < s) (hs_le : s ≤ m)
     have hq1_pos : 0 < q + 1 := by omega
     have hj_lt_r : j < r := by
       rw [Nat.div_lt_iff_lt_mul hq1_pos]; exact hlt
-    have hdam : (q + 1) * j + p % (q + 1) = p := Nat.div_add_mod p (q + 1)
-    have hmod : p % (q + 1) < q + 1 := Nat.mod_lt p hq1_pos
+    have hdam : (q + 1) * j + p % (q + 1) = p :=
+      Nat.div_add_mod p (q + 1)
+    have hmod : p % (q + 1) < q + 1 :=
+      Nat.mod_lt p hq1_pos
     have hle : q * j + j ≤ p := by grind
     have hub : p < q * (j + 1) + (j + 1) := by grind
     refine ⟨by omega, ?_, ?_⟩
     · unfold equiEndpoint
-      rw [min_eq_right (by omega)]
+      rw [min_eq_right (by omega : j ≤ r)]
       change q * j + j ≤ p; exact hle
     · unfold equiEndpoint
-      rw [min_eq_right (by omega)]
+      rw [min_eq_right (by omega : j + 1 ≤ r)]
       change p < q * (j + 1) + (j + 1); exact hub
   · rename_i hge; push_neg at hge
     set d := (p - bd) / q
-    have hdam : q * d + (p - bd) % q = p - bd := Nat.div_add_mod (p - bd) q
-    have hmod : (p - bd) % q < q := Nat.mod_lt _ hq_pos
+    have hdam : q * d + (p - bd) % q = p - bd :=
+      Nat.div_add_mod (p - bd) q
+    have hmod : (p - bd) % q < q :=
+      Nat.mod_lt _ hq_pos
     have hqd_le : q * d ≤ p - bd := by omega
     have hqd_ub : p - bd < q * d + q := by omega
     have hd_lt : d < s - r := by
       rw [Nat.div_lt_iff_lt_mul hq_pos]; omega
     set j := r + d
     have hring_j : q * j + r = bd + q * d := by grind
-    have hring_j1 : q * (j + 1) + r = bd + q * d + q := by grind
+    have hring_j1 :
+        q * (j + 1) + r = bd + q * d + q := by grind
     have hle : q * j + r ≤ p := by omega
     have hub : p < q * (j + 1) + r := by omega
     have hr_le_j : r ≤ j := Nat.le_add_right r d
-    have hr_le_j1 : r ≤ j + 1 := Nat.le_succ_of_le hr_le_j
+    have hr_le_j1 : r ≤ j + 1 :=
+      Nat.le_succ_of_le hr_le_j
     refine ⟨by omega, ?_, ?_⟩
     · unfold equiEndpoint
       rw [min_eq_left hr_le_j]
@@ -730,7 +817,8 @@ private lemma idx_in_interval' (s m : ℕ) (hs : 0 < s) (hs_le : s ≤ m)
       rw [min_eq_left hr_le_j1]
       change p < q * (j + 1) + r; exact hub
 
-private lemma equiEndpoint_diff' (m s j : ℕ) : Finpartition.equiEndpoint m s (j + 1) -
+private lemma equiEndpoint_diff' (m s j : ℕ) :
+    Finpartition.equiEndpoint m s (j + 1) -
       Finpartition.equiEndpoint m s j =
       if j < m % s then m / s + 1 else m / s :=
   Finpartition.card_of_mem_equipartitionToIco_parts_aux
@@ -750,16 +838,20 @@ private lemma gap_exceeds_ilen (m s g : ℕ) (hs : 0 < s)
     have := Nat.le_div_iff_mul_le hs |>.mpr this; omega
 
 open Finpartition in
+open Finpartition in
 private lemma shift_within_two' (m s g : ℕ)
     (h_ub : g < 2 * (m / s))
     (j p : ℕ) (hhi : p < equiEndpoint m s (j + 1)) :
     p + g < equiEndpoint m s (j + 3) := by
-  have hm1 : equiEndpoint m s (j + 2) - equiEndpoint m s (j + 1) ≥ m / s := by
+  have hm1 : equiEndpoint m s (j + 2) -
+      equiEndpoint m s (j + 1) ≥ m / s := by
     rw [equiEndpoint_diff']; split <;> omega
-  have hm2 : equiEndpoint m s (j + 3) - equiEndpoint m s (j + 2) ≥ m / s := by
+  have hm2 : equiEndpoint m s (j + 3) -
+      equiEndpoint m s (j + 2) ≥ m / s := by
     rw [equiEndpoint_diff']; split <;> omega
   have hmono : equiEndpoint m s (j + 1) ≤
-      equiEndpoint m s (j + 2) := equiEndpoint_monotone (by omega)
+      equiEndpoint m s (j + 2) :=
+    equiEndpoint_monotone (by omega)
   omega
 
 open Finpartition in
@@ -772,11 +864,13 @@ private lemma idx_range_from_endpoints' (m s : ℕ)
     (hj_hi : p < equiEndpoint m s (j + 1)) :
     a ≤ j ∧ j < b := by
   constructor
-  · by_contra! h
-    have : equiEndpoint m s (j + 1) ≤ equiEndpoint m s a := equiEndpoint_monotone (by omega)
+  · by_contra h; push_neg at h
+    have : equiEndpoint m s (j + 1) ≤ equiEndpoint m s a :=
+      equiEndpoint_monotone (by omega)
     omega
-  · by_contra! h
-    have : equiEndpoint m s b ≤ equiEndpoint m s j := equiEndpoint_monotone (by omega)
+  · by_contra h; push_neg at h
+    have : equiEndpoint m s b ≤ equiEndpoint m s j :=
+      equiEndpoint_monotone (by omega)
     omega
 
 /-- Gap bound: idx of (v+g)%m differs from idx(v) by 1 or 2 mod s.
@@ -800,69 +894,95 @@ private lemma gap_bound_interval (s g m : ℕ) (hs : 0 < s)
     if p < bd then p / (q + 1) else r + (p - bd) / q
   set j₀ := idx v
   set jg := idx ((v + g) % m)
-  obtain ⟨hj₀_lt', hv_lo', hv_hi'⟩ := idx_in_interval' s m hs hs_le v hv_lt
+  obtain ⟨hj₀_lt', hv_lo', hv_hi'⟩ :=
+    idx_in_interval' s m hs hs_le v hv_lt
   have hj₀_lt : j₀ < s := hj₀_lt'
-  have hv_lo : Finpartition.equiEndpoint m s j₀ ≤ v := hv_lo'
-  have hv_hi : v < Finpartition.equiEndpoint m s (j₀ + 1) := hv_hi'
-  have hvg_lt : (v + g) % m < m := Nat.mod_lt _ (by omega)
-  obtain ⟨hjg_lt', hvg_lo', hvg_hi'⟩ := idx_in_interval' s m hs hs_le ((v + g) % m) hvg_lt
+  have hv_lo : Finpartition.equiEndpoint m s j₀ ≤ v :=
+    hv_lo'
+  have hv_hi : v <
+      Finpartition.equiEndpoint m s (j₀ + 1) := hv_hi'
+  have hvg_lt : (v + g) % m < m :=
+    Nat.mod_lt _ (by omega)
+  obtain ⟨hjg_lt', hvg_lo', hvg_hi'⟩ :=
+    idx_in_interval' s m hs hs_le ((v + g) % m) hvg_lt
   have hjg_lt : jg < s := hjg_lt'
-  have hvg_lo : Finpartition.equiEndpoint m s jg ≤ (v + g) % m := hvg_lo'
-  have hvg_hi : (v + g) % m < Finpartition.equiEndpoint m s (jg + 1) := hvg_hi'
-  have hpast : Finpartition.equiEndpoint m s (j₀ + 1) ≤ v + g := by
+  have hvg_lo : Finpartition.equiEndpoint m s jg ≤
+      (v + g) % m := hvg_lo'
+  have hvg_hi : (v + g) % m <
+      Finpartition.equiEndpoint m s (jg + 1) := hvg_hi'
+  have hpast : Finpartition.equiEndpoint m s (j₀ + 1) ≤
+      v + g := by
     have := gap_exceeds_ilen m s g hs h_lb j₀; omega
   have hwithin : v + g <
-      Finpartition.equiEndpoint m s (j₀ + 3) := shift_within_two' m s g h_ub j₀ v hv_hi
+      Finpartition.equiEndpoint m s (j₀ + 3) :=
+    shift_within_two' m s g h_ub j₀ v hv_hi
   have hg_lt_m : g < m := by
     have hqs : q * s ≤ m := Nat.div_mul_le_self m s
     have : 2 * q ≤ q * s := by nlinarith
     omega
-  have mod_small : ∀ d : ℕ, d = 1 ∨ d = 2 → d % s = 1 ∨ d % s = 2 := by
+  have mod_small : ∀ d : ℕ, d = 1 ∨ d = 2 →
+      d % s = 1 ∨ d % s = 2 := by
     intro d hd; rcases hd with h | h <;> subst h
     · left; exact Nat.mod_eq_of_lt (by omega)
     · right; exact Nat.mod_eq_of_lt (by omega)
-  have mod_shift : ∀ d : ℕ, d = 1 ∨ d = 2 → (s + d) % s = 1 ∨ (s + d) % s = 2 := by
+  have mod_shift : ∀ d : ℕ, d = 1 ∨ d = 2 →
+      (s + d) % s = 1 ∨ (s + d) % s = 2 := by
     intro d hd; rw [Nat.add_comm, Nat.add_mod_right]; exact mod_small d hd
   by_cases hvg_wrap : v + g < m
-  · have hvg_eq : (v + g) % m = v + g := Nat.mod_eq_of_lt hvg_wrap
+  · have hvg_eq : (v + g) % m = v + g :=
+      Nat.mod_eq_of_lt hvg_wrap
     rw [hvg_eq] at hvg_lo hvg_hi
     have hrange : j₀ + 1 ≤ jg ∧ jg < j₀ + 3 := by
       by_cases hj3 : j₀ + 3 ≤ s
-      · exact idx_range_from_endpoints' m s (j₀+1) (j₀+3) (v+g) hpast hwithin jg hvg_lo hvg_hi
-      · have hvg_lt_ep : v + g < Finpartition.equiEndpoint m s s := by
+      · exact idx_range_from_endpoints' m s
+          (j₀+1) (j₀+3) (v+g) hpast hwithin jg hvg_lo hvg_hi
+      · have hvg_lt_ep : v + g <
+            Finpartition.equiEndpoint m s s := by
           grind [Finpartition.equiEndpoint_hi (show s ≠ 0 by omega) (n := m) (k := s)]
-        have := idx_range_from_endpoints' m s (j₀+1) s (v+g) hpast hvg_lt_ep jg hvg_lo hvg_hi
+        have := idx_range_from_endpoints' m s
+          (j₀+1) s (v+g) hpast hvg_lt_ep jg hvg_lo hvg_hi
         omega
     have : jg - j₀ = 1 ∨ jg - j₀ = 2 := by omega
     have : jg + s - j₀ = s + (jg - j₀) := by omega
     rw [this]; exact mod_shift _ ‹jg - j₀ = 1 ∨ _›
   · push_neg at hvg_wrap
     have hvg_eq : (v + g) % m = v + g - m := by
-      rw [Nat.mod_eq_sub_mod (by omega), Nat.mod_eq_of_lt (by omega)]
+      conv_lhs =>
+        rw [← Nat.sub_add_cancel (by omega : m ≤ v + g)]
+      rw [Nat.add_mod_right]
+      exact Nat.mod_eq_of_lt (by omega)
     rw [hvg_eq] at hvg_lo hvg_hi
     have hj0_ge : j₀ ≥ s - 2 := by
-      by_contra! h
+      by_contra h; push_neg at h
       have : Finpartition.equiEndpoint m s (j₀ + 3) ≤
-          Finpartition.equiEndpoint m s s := Finpartition.equiEndpoint_monotone (by omega)
-      have := Finpartition.equiEndpoint_hi (by omega : s ≠ 0) (n := m) (k := s)
+          Finpartition.equiEndpoint m s s :=
+        Finpartition.equiEndpoint_monotone (by omega)
+      have := Finpartition.equiEndpoint_hi
+        (by omega : s ≠ 0) (n := m) (k := s)
       omega
     have hr_lt : r < s := Nat.mod_lt m hs
-    have hep_j3 : Finpartition.equiEndpoint m s (j₀ + 3) = q * (j₀ + 3) + r := by
+    have hep_j3 : Finpartition.equiEndpoint m s
+        (j₀ + 3) = q * (j₀ + 3) + r := by
       unfold Finpartition.equiEndpoint
-      rw [min_eq_left (by omega)]
+      rw [min_eq_left (by omega : r ≤ j₀ + 3)]
     have hm_eq : m = q * s + r := by grind [Nat.div_add_mod m s]
-    have hm_le_ep : m ≤ Finpartition.equiEndpoint m s (j₀ + 3) := by grind
+    have hm_le_ep : m ≤
+        Finpartition.equiEndpoint m s (j₀ + 3) := by grind
     have hep_diff :
         Finpartition.equiEndpoint m s (j₀ + 3) - m =
         q * (j₀ + 3 - s) := by
       rw [hep_j3, hm_eq]; grind [Nat.mul_add]
-    have hvgm_ub : v + g - m < Finpartition.equiEndpoint m s
+    have hvgm_ub : v + g - m <
+        Finpartition.equiEndpoint m s
           (j₀ + 3 - s) := by
-      have : v + g - m < q * (j₀ + 3 - s) := by
+      have hvgm_lt : v + g - m <
+          q * (j₀ + 3 - s) := by
         rw [← hep_diff]; omega
-      have : q * (j₀ + 3 - s) ≤ Finpartition.equiEndpoint m s
+      have : q * (j₀ + 3 - s) ≤
+          Finpartition.equiEndpoint m s
             (j₀ + 3 - s) := by
-        change q * (j₀ + 3 - s) ≤ q * (j₀ + 3 - s) + min r (j₀ + 3 - s)
+        change q * (j₀ + 3 - s) ≤
+          q * (j₀ + 3 - s) + min r (j₀ + 3 - s)
         omega
       omega
     have hrange := idx_range_from_endpoints' m s
@@ -883,7 +1003,8 @@ private def eqp_off (q r : ℕ) (p : ℕ) : ℕ :=
   if p < r * (q + 1) then p % (q + 1)
   else (p - r * (q + 1)) % q
 
-private lemma eqp_idx_m (q r s : ℕ) (hq : 0 < q) (hr : r < s) : eqp_idx q r (s * q + r) = s := by
+private lemma eqp_idx_m (q r s : ℕ) (hq : 0 < q) (hr : r < s) :
+    eqp_idx q r (s * q + r) = s := by
   have hge : ¬(s * q + r < r * (q + 1)) := by nlinarith
   simp only [eqp_idx, if_neg hge]
   have hle : r * (q + 1) ≤ s * q + r := by nlinarith
@@ -892,13 +1013,16 @@ private lemma eqp_idx_m (q r s : ℕ) (hq : 0 < q) (hr : r < s) : eqp_idx q r (s
   rw [hsub, Nat.mul_div_cancel _ hq]; omega
 
 -- General fact: consecutive ℕ quotients differ by 0 or 1
-private lemma div_step (a b : ℕ) (hb : 0 < b) : (a + 1) / b = a / b ∨ (a + 1) / b = a / b + 1 := by
-  have hle : a / b ≤ (a + 1) / b := Nat.div_le_div_right (Nat.le_succ a)
+private lemma div_step (a b : ℕ) (hb : 0 < b) :
+    (a + 1) / b = a / b ∨ (a + 1) / b = a / b + 1 := by
+  have hle : a / b ≤ (a + 1) / b :=
+    Nat.div_le_div_right (Nat.le_succ a)
   suffices h : (a + 1) / b ≤ a / b + 1 by omega
   have h1 := Nat.div_add_mod a b
   have hmod := Nat.mod_lt a hb
   have hub : a + 1 ≤ b * (a / b + 1) := by grind
-  calc (a + 1) / b ≤ b * (a / b + 1) / b := Nat.div_le_div_right hub
+  calc (a + 1) / b
+      ≤ b * (a / b + 1) / b := Nat.div_le_div_right hub
     _ = a / b + 1 := Nat.mul_div_cancel_left _ hb
 
 private lemma eqp_idx_step (q r p : ℕ) (hq : 0 < q) :
@@ -919,7 +1043,8 @@ private lemma eqp_idx_step (q r p : ℕ) (hq : 0 < q) :
     have hidx_p : p / (q + 1) = r - 1 := by
       have := div_step p (q + 1) (by omega); omega
     rw [hpeq, Nat.sub_self, Nat.zero_div, hidx_p]; omega
-  · have hsub : p + 1 - r * (q + 1) = (p - r * (q + 1)) + 1 := by
+  · have hsub :
+        p + 1 - r * (q + 1) = (p - r * (q + 1)) + 1 := by
       omega
     rw [hsub]
     have := div_step (p - r * (q + 1)) q hq; omega
@@ -955,7 +1080,8 @@ private lemma eqp_off_succ_same (q r p : ℕ) (hq : 0 < q)
     grind
   · omega
   · exfalso
-    have h3 : eqp_idx q r (p + 1) = r + (p + 1 - r * (q + 1)) / q := by
+    have h3 : eqp_idx q r (p + 1) =
+        r + (p + 1 - r * (q + 1)) / q := by
       unfold eqp_idx; rw [if_neg h1]
     have h4 : eqp_idx q r p = p / (q + 1) := by
       unfold eqp_idx; rw [if_pos h2]
@@ -965,12 +1091,15 @@ private lemma eqp_off_succ_same (q r p : ℕ) (hq : 0 < q)
       rw [h3]; exact Nat.le_add_right r _
     grind
   · rw [if_neg h1, if_neg h2]
-    have hsub : p + 1 - r * (q + 1) = (p - r * (q + 1)) + 1 := by omega
+    have hsub : p + 1 - r * (q + 1) =
+        (p - r * (q + 1)) + 1 := by omega
     rw [hsub]
     apply mod_step (p - r * (q + 1)) q
-    have h3 : eqp_idx q r (p + 1) = r + (p + 1 - r * (q + 1)) / q := by
+    have h3 : eqp_idx q r (p + 1) =
+        r + (p + 1 - r * (q + 1)) / q := by
       unfold eqp_idx; rw [if_neg h1]
-    have h4 : eqp_idx q r p = r + (p - r * (q + 1)) / q := by
+    have h4 : eqp_idx q r p =
+        r + (p - r * (q + 1)) / q := by
       unfold eqp_idx; rw [if_neg h2]
     rw [h3, h4, hsub] at h; omega
 
@@ -994,12 +1123,15 @@ private lemma eqp_off_succ_new (q r p : ℕ) (hq : 0 < q)
     have : p + 1 = r * (q + 1) := by omega
     simp [this]
   · rw [if_neg h1]
-    have hsub : p + 1 - r * (q + 1) = (p - r * (q + 1)) + 1 := by omega
+    have hsub : p + 1 - r * (q + 1) =
+        (p - r * (q + 1)) + 1 := by omega
     rw [hsub]
     apply mod_zero_step (p - r * (q + 1)) q hq
-    have h3 : eqp_idx q r (p + 1) = r + (p + 1 - r * (q + 1)) / q := by
+    have h3 : eqp_idx q r (p + 1) =
+        r + (p + 1 - r * (q + 1)) / q := by
       unfold eqp_idx; rw [if_neg h1]
-    have h4 : eqp_idx q r p = r + (p - r * (q + 1)) / q := by
+    have h4 : eqp_idx q r p =
+        r + (p - r * (q + 1)) / q := by
       unfold eqp_idx; rw [if_neg h2]
     rw [h3, h4, hsub] at h
     have := div_step (p - r * (q + 1)) q hq
@@ -1014,9 +1146,12 @@ private lemma gap_mod_cases_gen (s j₀ jg d : ℕ)
   rw [hmod] at hdiv
   have hq_lt : (jg + s - j₀) / s < 2 := by
     rw [Nat.div_lt_iff_lt_mul (by omega)]; omega
-  rcases Nat.eq_zero_or_pos ((jg + s - j₀) / s) with h | h <;> grind
+  rcases Nat.eq_zero_or_pos ((jg + s - j₀) / s) with h | h
+  · grind
+  · grind
 
-private lemma equiEndpoint_diff_ge (m s j : ℕ) : m / s ≤ Finpartition.equiEndpoint m s (j + 1) -
+private lemma equiEndpoint_diff_ge (m s j : ℕ) :
+    m / s ≤ Finpartition.equiEndpoint m s (j + 1) -
         Finpartition.equiEndpoint m s j := by
   grind [Finpartition.equiEndpoint]
 
@@ -1030,25 +1165,30 @@ private lemma straddle1_gap2 (s g m : ℕ)
     (hvg_lo : equiEndpoint m s jg ≤ (v + g) % m)
     (hvg_hi : (v + g) % m < equiEndpoint m s (jg + 1))
     (hstrad : equiEndpoint m s (j₀ + 1) ≤ v + 1)
-    (hgap : (jg + s - j₀) % s = 1 ∨ (jg + s - j₀) % s = 2) :
+    (hgap : (jg + s - j₀) % s = 1 ∨
+      (jg + s - j₀) % s = 2) :
     (jg + s - j₀) % s = 2 := by
   by_contra hne
   have hgap1 : (jg + s - j₀) % s = 1 := by tauto
   have hv_eq : v + 1 = equiEndpoint m s (j₀ + 1) := by
     omega
-  have hjg_cases := gap_mod_cases_gen s j₀ jg 1 hj₀_lt hjg_lt hgap1
+  have hjg_cases := gap_mod_cases_gen s j₀ jg 1 hj₀_lt hjg_lt
+    hgap1
   have hq_pos : 0 < m / s := by
     grind
   have hg_lt_m : g < m := by
     have := Nat.div_mul_le_self m s; nlinarith
-  have hep_s : equiEndpoint m s s = m := equiEndpoint_hi (by omega)
+  have hep_s : equiEndpoint m s s = m :=
+    equiEndpoint_hi (by omega)
   by_cases hj₀_lt_s : j₀ + 1 < s
   · have hjg_val : jg = j₀ + 1 := by omega
     have hilen := gap_exceeds_ilen m s g hs h_lb (j₀ + 1)
     have hmono : equiEndpoint m s (j₀ + 1) ≤
-        equiEndpoint m s (j₀ + 1 + 1) := equiEndpoint_monotone (by omega)
+        equiEndpoint m s (j₀ + 1 + 1) :=
+      equiEndpoint_monotone (by omega)
     have hsac := Nat.sub_add_cancel hmono
-    have hvg_ge : v + g ≥ equiEndpoint m s (j₀ + 1 + 1) := by omega
+    have hvg_ge : v + g ≥
+        equiEndpoint m s (j₀ + 1 + 1) := by omega
     by_cases hwrap : v + g < m
     · have : (v + g) % m = v + g := Nat.mod_eq_of_lt hwrap
       rw [hjg_val] at hvg_hi
@@ -1056,16 +1196,20 @@ private lemma straddle1_gap2 (s g m : ℕ)
     · push_neg at hwrap
       rw [hjg_val] at hvg_lo
       have hvg_mod : (v + g) % m = v + g - m := by
-        rw [Nat.mod_eq_sub_mod hwrap, Nat.mod_eq_of_lt (by omega)]
+        rw [Nat.mod_eq_sub_mod hwrap]; exact Nat.mod_eq_of_lt (by omega)
       rw [hvg_mod] at hvg_lo
       omega
   · have hj₀_eq : j₀ = s - 1 := by omega
     have hjg_val : jg = 0 := by omega
-    rw [hj₀_eq, Nat.sub_add_cancel (by omega), hep_s] at hv_eq
+    rw [hj₀_eq] at hv_eq
+    have hep_s1 : equiEndpoint m s (s - 1 + 1) = m := by
+      rw [Nat.sub_add_cancel (by omega : 1 ≤ s)]; exact hep_s
+    rw [hep_s1] at hv_eq
     have hv_val : v = m - 1 := by omega
     have hg_pos : 0 < g := by
       have := gap_exceeds_ilen m s g hs h_lb 0
-      have := equiEndpoint_strictMono (by omega : s ≠ 0) hs_le one_pos
+      have := equiEndpoint_strictMono
+        (by omega : s ≠ 0) hs_le one_pos
       omega
     have hvg_mod : (v + g) % m = g - 1 := by
       have : m - 1 + g = m + (g - 1) := by omega
@@ -1073,7 +1217,8 @@ private lemma straddle1_gap2 (s g m : ℕ)
       exact Nat.mod_eq_of_lt (by omega)
     rw [hjg_val, hvg_mod] at hvg_hi
     simp only [Nat.zero_add] at hvg_hi
-    have hep1 : equiEndpoint m s 1 ≤ (m + s - 1) / s := by
+    have hep1 : equiEndpoint m s 1 ≤
+        (m + s - 1) / s := by
       rw [equiEndpoint]
       simp only [Nat.mul_one]
       by_cases hr : m % s = 0
@@ -1093,20 +1238,25 @@ private lemma straddle2_gap1 (s g m : ℕ)
     (hv_lo : equiEndpoint m s j₀ ≤ v)
     (hv_hi : v < equiEndpoint m s (j₀ + 1))
     (hvg_hi : (v + g) % m < equiEndpoint m s (jg + 1))
-    (hstrad : equiEndpoint m s (jg + 1) ≤ (v + g) % m + 1)
-    (hgap : (jg + s - j₀) % s = 1 ∨ (jg + s - j₀) % s = 2) :
+    (hstrad : equiEndpoint m s (jg + 1) ≤
+      (v + g) % m + 1)
+    (hgap : (jg + s - j₀) % s = 1 ∨
+      (jg + s - j₀) % s = 2) :
     (jg + s - j₀) % s = 1 := by
   by_contra hne
   have hgap2 : (jg + s - j₀) % s = 2 := by tauto
-  have hvg_eq : (v + g) % m + 1 = equiEndpoint m s (jg + 1) := by omega
+  have hvg_eq : (v + g) % m + 1 =
+      equiEndpoint m s (jg + 1) := by omega
   have hq_pos : 0 < m / s := by
     grind
   have hg_lt_m : g < m := by
     have := Nat.div_mul_le_self m s; nlinarith
-  have hjg_cases := gap_mod_cases_gen s j₀ jg 2 hj₀_lt hjg_lt hgap2
+  have hjg_cases := gap_mod_cases_gen s j₀ jg 2 hj₀_lt hjg_lt
+    hgap2
   have hep0 : equiEndpoint m s 0 = 0 := by
     simp [equiEndpoint]
-  have hep_s : equiEndpoint m s s = m := equiEndpoint_hi (by omega)
+  have hep_s : equiEndpoint m s s = m :=
+    equiEndpoint_hi (by omega)
   by_cases hj_nowrap : j₀ + 2 < s
   · have hjg_val : jg = j₀ + 2 := by omega
     rw [hjg_val] at hvg_eq
@@ -1124,20 +1274,25 @@ private lemma straddle2_gap1 (s g m : ℕ)
       omega
     · push_neg at hwrap
       have : (v + g) % m = v + g - m := by
-        rw [Nat.mod_eq_sub_mod hwrap, Nat.mod_eq_of_lt (by omega)]
+        rw [Nat.mod_eq_sub_mod hwrap]
+        exact Nat.mod_eq_of_lt (by omega)
       omega
   · have hjg_val : jg = j₀ + 2 - s := by omega
     have hpos_wrap : m ≤ v + g := by
-      by_contra! h
+      by_contra h; push_neg at h
       have : (v + g) % m = v + g := Nat.mod_eq_of_lt h
-      have : equiEndpoint m s (jg + 1) ≤ equiEndpoint m s j₀ := equiEndpoint_monotone (by omega)
+      have : equiEndpoint m s (jg + 1) ≤
+          equiEndpoint m s j₀ :=
+        equiEndpoint_monotone (by omega)
       have : 0 < g := by
         have := gap_exceeds_ilen m s g hs h_lb 0
-        have := equiEndpoint_strictMono (by omega : s ≠ 0) hs_le one_pos
+        have := equiEndpoint_strictMono
+          (by omega : s ≠ 0) hs_le one_pos
         omega
       omega
     have hvg_mod : (v + g) % m = v + g - m := by
-      rw [Nat.mod_eq_sub_mod hpos_wrap, Nat.mod_eq_of_lt (by omega)]
+      rw [Nat.mod_eq_sub_mod hpos_wrap]
+      exact Nat.mod_eq_of_lt (by omega)
     by_cases hj₀_eq : j₀ = s - 2
     · have hjg0 : jg = 0 := by omega
       rw [hjg0] at hvg_eq
@@ -1146,22 +1301,34 @@ private lemma straddle2_gap1 (s g m : ℕ)
       have : s - 2 + 1 = s - 1 := by omega
       rw [this] at hv_hi
       have hd1 := equiEndpoint_diff_ge m s (s - 1)
-      rw [Nat.sub_add_cancel (by omega), hep_s] at hd1
-      have hep_s1_le : equiEndpoint m s (s - 1) ≤ m :=
-        le_trans (equiEndpoint_monotone (by omega)) hep_s.le
+      rw [Nat.sub_add_cancel (by omega : 1 ≤ s), hep_s]
+        at hd1
+      have hep_s1_le :
+          equiEndpoint m s (s - 1) ≤ m := by
+        calc equiEndpoint m s (s - 1)
+            ≤ equiEndpoint m s s :=
+              equiEndpoint_monotone (by omega)
+          _ = m := hep_s
       have hsac_m := Nat.sub_add_cancel hep_s1_le
       have hd2 := equiEndpoint_diff_ge m s 0
-      rw [hep0, Nat.zero_add] at hd2
+      rw [hep0] at hd2
+      simp only [Nat.zero_add] at hd2
       omega
     · have hj₀_eq2 : j₀ = s - 1 := by omega
       have hjg1 : jg = 1 := by omega
       rw [hjg1] at hvg_eq
       rw [hj₀_eq2] at hv_hi
-      rw [Nat.sub_add_cancel (by omega), hep_s] at hv_hi
+      have hep_s1 :
+          equiEndpoint m s (s - 1 + 1) = m := by
+        rw [Nat.sub_add_cancel (by omega : 1 ≤ s)]
+        exact hep_s
+      rw [hep_s1] at hv_hi
       have hd1 := equiEndpoint_diff_ge m s 0
-      rw [hep0, Nat.zero_add] at hd1
+      rw [hep0] at hd1
+      simp only [Nat.zero_add] at hd1
       have hd2 := equiEndpoint_diff_ge m s 1
-      have hmono12 : equiEndpoint m s 1 ≤ equiEndpoint m s (1 + 1) := by omega
+      have hmono12 : equiEndpoint m s 1 ≤
+          equiEndpoint m s (1 + 1) := by omega
       have hsac12 := Nat.sub_add_cancel hmono12
       omega
 
@@ -1184,9 +1351,11 @@ private lemma non_straddle_witness (q r p : ℕ)
     (j : ℕ) (hj : j = eqp_idx q r p)
     (t : ℕ) (hpair : t = j % 3 ∨ t = (j + 1) % 3) :
     ∃ d ∈ ({0, 1} : Finset ℕ),
-      (eqp_idx q r ((p + d) % m) + eqp_off q r ((p + d) % m) % 2) % 3 = t := by
+      (eqp_idx q r ((p + d) % m) +
+        eqp_off q r ((p + d) % m) % 2) % 3 = t := by
   have hoff := eqp_off_succ_same q r p hq_pos hsame
-  have : (j + (eqp_off q r p) % 2) % 3 = t ∨ (j + ((eqp_off q r p) + 1) % 2) % 3 = t := by omega
+  have : (j + (eqp_off q r p) % 2) % 3 = t ∨
+      (j + ((eqp_off q r p) + 1) % 2) % 3 = t := by omega
   rcases this with h | h
   · exact ⟨0, by simp, by
       simp only [Nat.add_zero, Nat.mod_eq_of_lt hp, ← hj]
@@ -1202,7 +1371,8 @@ private lemma straddle_boundary_color (q r s p : ℕ)
     (hp : p < m)
     (hstep : eqp_idx q r (p + 1) = eqp_idx q r p + 1)
     (j : ℕ) (hj : j = eqp_idx q r p) :
-    (eqp_idx q r ((p + 1) % m) + eqp_off q r ((p + 1) % m) % 2) % 3 = (j + 1) % 3 := by
+    (eqp_idx q r ((p + 1) % m) +
+      eqp_off q r ((p + 1) % m) % 2) % 3 = (j + 1) % 3 := by
   by_cases h : p + 1 < m
   · rw [Nat.mod_eq_of_lt h]
     have hoff := eqp_off_succ_new q r p hq_pos (by omega)
@@ -1217,15 +1387,47 @@ private lemma straddle_boundary_color (q r s p : ℕ)
     have hjs : j + 1 = s := by rw [hj]; omega
     grind
 
-private lemma vg_mod_shift (v g d : ℕ) : (v + (g + d)) % m = ((v + g) % m + d) % m := by
+private lemma vg_mod_shift (v g d : ℕ) :
+    (v + (g + d)) % m = ((v + g) % m + d) % m := by
   grind [Nat.add_mod (v + g) d m, Nat.add_mod ((v + g) % m) d m,
     Nat.mod_mod_of_dvd _ (dvd_refl m)]
+
+private lemma gap2_jg_mod3 (s j₀ jg : ℕ) (hs3 : 3 ∣ s)
+    (hj₀ : j₀ < s) (hjg : jg < s)
+    (hgap2 : (jg + s - j₀) % s = 2) :
+    (jg + 1) % 3 = j₀ % 3 := by
+  rcases gap_mod_cases_gen s j₀ jg 2 hj₀ hjg hgap2 with h | h <;> grind
+
+private lemma gap1_j0_mod3 (s j₀ jg : ℕ) (hs3 : 3 ∣ s)
+    (hj₀ : j₀ < s) (hjg : jg < s)
+    (hgap1 : (jg + s - j₀) % s = 1) :
+    (j₀ + 1) % 3 = jg % 3 := by
+  rcases gap_mod_cases_gen s j₀ jg 1 hj₀ hjg hgap1 with h | h <;> grind
 
 private lemma mod3_witness {s k : ℕ} (hs : s < 3) (hk : k < 3) :
     ((k + 3 - s) % 3 = 0 → s = k) ∧
     ((k + 3 - s) % 3 = 1 → (s + 1) % 3 = k) ∧
     ((k + 3 - s) % 3 = 2 → (s + 2) % 3 = k) := by grind
 
+/- Aristotle alternative for `endgame_witness` (1 lines vs 5 original, -4).
+   Full proof: `aristotle_results/result_endgame_witness.lean`
+
+    ((k + 3 - s) % 3 = 0 → s = k) ∧
+    ((k + 3 - s) % 3 = 1 → (s + 1) % 3 = k) ∧
+    ((k + 3 - s) % 3 = 2 → (s + 2) % 3 = k) := by admit
+
+private lemma endgame_witness {g : ℕ} {c : ℕ → ℕ}
+    {v s : ℕ} {k : Fin 3} (hs : s < 3)
+    (a₀ a₁ a₂ : ℕ)
+    (ha₀ : a₀ ∈ ({0, 1, g, g + 1} : Finset ℕ))
+    (ha₁ : a₁ ∈ ({0, 1, g, g + 1} : Finset ℕ))
+    (ha₂ : a₂ ∈ ({0, 1, g, g + 1} : Finset ℕ))
+    (hc₀ : c (v + a₀) = s)
+    (hc₁ : c (v + a₁) = (s + 1) % 3)
+    (hc₂ : c (v + a₂) = (s + 2) % 3) :
+    ∃ a ∈ ({0, 1, g, g + 1} : Finset ℕ), c (v + a) = k.val := by
+      grind
+-/
 private lemma endgame_witness {g : ℕ} {c : ℕ → ℕ}
     {v s : ℕ} {k : Fin 3} (hs : s < 3)
     (a₀ a₁ a₂ : ℕ)
@@ -1243,6 +1445,24 @@ private lemma endgame_witness {g : ℕ} {c : ℕ → ℕ}
   exacts [⟨a₀, ha₀, hc₀ ▸ h1 h⟩, ⟨a₁, ha₁, hc₁ ▸ h2 h⟩, ⟨a₂, ha₂, hc₂ ▸ h3 h⟩]
 
 /-- Lift a ℕ-level coloring witness for {0,1,g,g+1} to ZMod m. -/
+/- Aristotle alternative for `lift_coloring_witness` (7 lines vs 11 original, -4).
+   Full proof: `aristotle_results/result_lift_coloring_witness.lean`
+
+private lemma lift_coloring_witness {m g : ℕ} [NeZero m] [Fact (1 < m)]
+    (hg_lt : g + 1 < m) {c : ℕ → ℕ} (hc_lt : ∀ p, c p < 3)
+    (hc_period : ∀ p, c (p % m) = c p)
+    {n : ZMod m} {k : Fin 3}
+    (h : ∃ a ∈ ({0, 1, g, g + 1} : Finset ℕ), c (n.val + a) = k.val) :
+    ∃ s ∈ ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)),
+      (⟨c (n + s).val, hc_lt _⟩ : Fin 3) = k := by
+        rcases h with ⟨ a, ha, hk ⟩ ; use a; simp_all +decide [ Fin.ext_iff ] ;
+        convert hk using 1;
+        -- Apply the periodicity property of $c$ to rewrite the goal.
+        have h_periodic : c (n.val + a) = c ((n.val + a) % m) := by
+          rw [ hc_period ];
+        simp +decide [ ← ZMod.val_natCast, h_periodic ];
+        rcases ha with ( rfl | rfl | rfl | rfl ) <;> norm_num
+-/
 private lemma lift_coloring_witness {m g : ℕ} [NeZero m] [Fact (1 < m)]
     (hg_lt : g + 1 < m) {c : ℕ → ℕ} (hc_lt : ∀ p, c p < 3)
     (hc_period : ∀ p, c (p % m) = c p)
@@ -1262,15 +1482,18 @@ private lemma lift_coloring_witness {m g : ℕ} [NeZero m] [Fact (1 < m)]
          rw [ZMod.val_add, ZMod.val_natCast, Nat.mod_eq_of_lt ha_lt]
        rw [this, hc_period, hca]⟩
 
-/-- **Subcase (1b): interval coloring strategy.**
+/-- Subcase (1b): interval coloring strategy.
     Let s be the smallest multiple of 3 such that g > ⌈m/s⌉. Split Z_m into s
     intervals of lengths ⌊m/s⌋ and ⌈m/s⌉, colored in a repeating 01/12/20
     pattern (repeated s/3 times). Since ⌈m/s⌉ < g < 2⌊m/s⌋, any translate of
     {0,1,g,g+1} where the pairs {0,1} and {g,g+1} lie in different intervals gets
-    all three colors. This is the workhorse subcase, handling most values of g. -/
+    all three colors. If one pair straddles two consecutive intervals, it gets only the
+    single color common to these two intervals, but the other pair lies fully inside
+    a third interval which is colored with the remaining two colors. -/
 lemma case_one_interval (s g : ℕ) (hs : 0 < s) (hs3 : 3 ∣ s)
     (h_lb : (m + s - 1) / s < g) (h_ub : g < 2 * (m / s)) :
-    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by
+    HasPolychromColouring (Fin 3)
+      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by
   set q := m / s
   set r := m % s
   have hm_eq : m = s * q + r := (Nat.div_add_mod m s).symm
@@ -1295,16 +1518,23 @@ lemma case_one_interval (s g : ℕ) (hs : 0 < s) (hs3 : 3 ∣ s)
     lift_coloring_witness hg1_lt_m hc_lt3 hc_period ?_⟩
   set v := n.val
   have hv_lt : v < m := ZMod.val_lt n
+  -- c(p) ∈ {idx(p%m)%3, (idx(p%m)+1)%3}
+  have hc_phase : ∀ p, c p = idx (p % m) % 3 ∨
+      c p = (idx (p % m) + 1) % 3 := by
+    intro p; simp only [c]
+    have : off (p % m) % 2 = 0 ∨ off (p % m) % 2 = 1 := by omega
+    rcases this with h | h <;> simp [h]
   -- Gap bound: idx((v+g)%m) differs from idx(v) by 1 or 2 mod s
   set j₀ := idx v with hj₀_def
   set jg := idx ((v + g) % m) with hjg_def
   have hs3_le : 3 ≤ s := Nat.le_of_dvd hs hs3
-  have hgap := gap_bound_interval s g m hs hs3_le hs_le h_lb h_ub v hv_lt
+  have hgap := gap_bound_interval s g m hs hs3_le hs_le
+    h_lb h_ub v hv_lt
   -- idx ranges
   have hidx_lt : ∀ p, p < m → idx p < s := by
     intro p hp; simp only [idx]; split
     · have : p / (q + 1) < r := by
-        rw [Nat.div_lt_iff_lt_mul (by omega)]
+        rw [Nat.div_lt_iff_lt_mul (by omega : 0 < q + 1)]
         exact ‹_›
       omega
     · rename_i hge; push_neg at hge
@@ -1317,12 +1547,15 @@ lemma case_one_interval (s g : ℕ) (hs : 0 < s) (hs3 : 3 ∣ s)
         omega
       omega
   have hj₀_lt : j₀ < s := hidx_lt v hv_lt
-  have hjg_lt : jg < s := hidx_lt ((v + g) % m) (Nat.mod_lt _ (by omega))
+  have hjg_lt : jg < s :=
+    hidx_lt ((v + g) % m) (Nat.mod_lt _ (by omega))
   -- Phase difference: j₀ % 3 ≠ jg % 3
-  have hphase : j₀ % 3 ≠ jg % 3 := phase_ne_of_gap hs3 hj₀_lt hjg_lt hgap
+  have hphase : j₀ % 3 ≠ jg % 3 :=
+    phase_ne_of_gap hs3 hj₀_lt hjg_lt hgap
   -- Interval bounds
   have hiv := idx_in_interval' s m hs hs_le v hv_lt
-  have hivg := idx_in_interval' s m hs hs_le ((v + g) % m) (Nat.mod_lt _ (by omega))
+  have hivg := idx_in_interval' s m hs hs_le
+    ((v + g) % m) (Nat.mod_lt _ (by omega))
   have hv_lo := hiv.2.1; have hv_hi := hiv.2.2
   have hvg_lo := hivg.2.1; have hvg_hi := hivg.2.2
   -- Bridge: eqp_idx step → equiEndpoint straddle condition
@@ -1334,20 +1567,27 @@ lemma case_one_interval (s g : ℕ) (hs : 0 < s) (hs3 : 3 ∣ s)
     by_cases hp1 : p + 1 < m
     · have hiv_p := idx_in_interval' s m hs hs_le (p + 1) hp1
       simp only at hiv_p
-      change eqp_idx q r (p + 1) < s ∧ equiEndpoint m s (eqp_idx q r (p + 1)) ≤ p + 1 ∧ _ at hiv_p
-      rw [hstep_p] at hiv_p
-      exact hiv_p.2.1
+      change eqp_idx q r (p + 1) < s ∧
+        equiEndpoint m s (eqp_idx q r (p + 1)) ≤ p + 1 ∧ _ at hiv_p
+      rw [hstep_p] at hiv_p; exact hiv_p.2.1
     · have hpm : p + 1 = m := by omega
-      rw [hpm]; exact (equiEndpoint_monotone (by omega)).trans (equiEndpoint_hi (by omega)).le
+      rw [hpm]
+      calc equiEndpoint m s (eqp_idx q r p + 1)
+          ≤ equiEndpoint m s s :=
+            equiEndpoint_monotone (by omega)
+        _ = m := equiEndpoint_hi (by omega)
+  have hs3_le : 3 ≤ s := Nat.le_of_dvd hs hs3
   -- Step 1: which pair covers k?
   have : (k.val = j₀ % 3 ∨ k.val = (j₀ + 1) % 3) ∨
       (k.val = jg % 3 ∨ k.val = (jg + 1) % 3) := by omega
-  rcases this with hk1 | hk2
+  rcases this
+    with hk1 | hk2
   · -- Pair 1 covers k: k ∈ {j₀%3, (j₀+1)%3}
     rcases eqp_idx_step q r v hq_pos with h1_same | h1_step
     · -- Pair 1 non-straddle
       have hv1_lt : v + 1 < m := by
-        rcases eqp_idx_succ_lt_m m q r s v hq_pos hr_lt hm_eq hv_lt with h | h
+        rcases eqp_idx_succ_lt_m m q r s v hq_pos hr_lt hm_eq
+          hv_lt with h | h
         · exact h
         · rw [h1_same] at h
           have : j₀ = s := h; omega
@@ -1357,19 +1597,23 @@ lemma case_one_interval (s g : ℕ) (hs : 0 < s) (hs3 : 3 ∣ s)
         Finset.mem_singleton] at hd_mem ⊢; omega, hd_eq⟩
     · -- Pair 1 straddles → gap = 2
       open Finpartition in
-      have hstrad1 : equiEndpoint m s (j₀ + 1) ≤ v + 1 := endpoint_bridge v hv_lt hj₀_lt h1_step
+      have hstrad1 : equiEndpoint m s (j₀ + 1) ≤ v + 1 :=
+        endpoint_bridge v hv_lt hj₀_lt h1_step
       have hgap2 := straddle1_gap2 s g m hs hs3_le hs_le h_lb
         h_ub v j₀ jg hv_lt hj₀_lt hjg_lt hv_hi hvg_lo
         hvg_hi hstrad1 hgap
-      have hjg1_eq : (jg + 1) % 3 = j₀ % 3 := by
-        grind [gap_mod_cases_gen]
+      have hjg1_eq := gap2_jg_mod3 s j₀ jg hs3 hj₀_lt hjg_lt
+        hgap2
       rcases hk1 with hk_eq | hk_eq
       · -- k = j₀%3 = (jg+1)%3: pair 2 must be non-straddle
-        rcases eqp_idx_step q r ((v + g) % m) hq_pos with h2_same | h2_step
+        rcases eqp_idx_step q r ((v + g) % m) hq_pos
+          with h2_same | h2_step
         · -- Pair 2 non-straddle → witness a = g+d
-          have hvg_lt : (v + g) % m < m := Nat.mod_lt _ (by omega)
+          have hvg_lt : (v + g) % m < m :=
+            Nat.mod_lt _ (by omega)
           have hvg1_lt : (v + g) % m + 1 < m := by
-            rcases eqp_idx_succ_lt_m m q r s ((v + g) % m) hq_pos hr_lt hm_eq hvg_lt with h | h
+            rcases eqp_idx_succ_lt_m m q r s ((v + g) % m) hq_pos
+              hr_lt hm_eq hvg_lt with h | h
             · exact h
             · rw [h2_same] at h
               have : jg = s := h; omega
@@ -1377,28 +1621,36 @@ lemma case_one_interval (s g : ℕ) (hs : 0 < s) (hs3 : 3 ∣ s)
             ((v + g) % m) hq_pos hvg_lt hvg1_lt h2_same jg rfl
             k.val (Or.inr (hk_eq ▸ hjg1_eq.symm))
           refine ⟨g + d, ?_, ?_⟩
-          · simp only [Finset.mem_insert, Finset.mem_singleton] at hd_mem ⊢; omega
-          · change (idx ((v + (g + d)) % m) + off ((v + (g + d)) % m) % 2) % 3 = k.val
+          · simp only [Finset.mem_insert, Finset.mem_singleton]
+              at hd_mem ⊢; omega
+          · change (idx ((v + (g + d)) % m) +
+                off ((v + (g + d)) % m) % 2) % 3 = k.val
             rw [vg_mod_shift m v g d]; exact hd_eq
         · -- Pair 2 straddles → contradiction: gap = 1
           open Finpartition in
-          have hstrad2 : equiEndpoint m s (jg + 1) ≤ (v + g) % m + 1 :=
-            endpoint_bridge ((v + g) % m) (Nat.mod_lt _ (by omega)) hjg_lt h2_step
+          have hstrad2 : equiEndpoint m s (jg + 1) ≤
+              (v + g) % m + 1 :=
+            endpoint_bridge ((v + g) % m)
+              (Nat.mod_lt _ (by omega)) hjg_lt h2_step
           have hgap1 := straddle2_gap1 s g m hs hs3_le hs_le
             h_lb h_ub v j₀ jg hv_lt hj₀_lt hjg_lt hv_lo hv_hi
             hvg_hi hstrad2 hgap
           omega
       · -- k = (j₀+1)%3: witness a = 1
         refine ⟨1, by simp, ?_⟩
-        change (eqp_idx q r ((v + 1) % m) + eqp_off q r ((v + 1) % m) % 2) % 3 = k.val
-        rw [straddle_boundary_color m q r s v hq_pos hr_lt hs3 hm_eq hv_lt h1_step j₀ rfl]
+        change (eqp_idx q r ((v + 1) % m) +
+            eqp_off q r ((v + 1) % m) % 2) % 3 = k.val
+        rw [straddle_boundary_color m q r s v hq_pos hr_lt
+          hs3 hm_eq hv_lt h1_step j₀ rfl]
         exact hk_eq.symm
   · -- Pair 2 covers k: k ∈ {jg%3, (jg+1)%3}
-    rcases eqp_idx_step q r ((v + g) % m) hq_pos with h2_same | h2_step
+    rcases eqp_idx_step q r ((v + g) % m) hq_pos
+      with h2_same | h2_step
     · -- Pair 2 non-straddle
       have hvg_lt : (v + g) % m < m := Nat.mod_lt _ (by omega)
       have hvg1_lt : (v + g) % m + 1 < m := by
-        rcases eqp_idx_succ_lt_m m q r s ((v + g) % m) hq_pos hr_lt hm_eq hvg_lt with h | h
+        rcases eqp_idx_succ_lt_m m q r s ((v + g) % m) hq_pos
+          hr_lt hm_eq hvg_lt with h | h
         · exact h
         · rw [h2_same] at h
           have : jg = s := h; omega
@@ -1406,25 +1658,29 @@ lemma case_one_interval (s g : ℕ) (hs : 0 < s) (hs3 : 3 ∣ s)
         ((v + g) % m) hq_pos hvg_lt hvg1_lt h2_same jg rfl
         k.val hk2
       refine ⟨g + d, ?_, ?_⟩
-      · simp only [Finset.mem_insert, Finset.mem_singleton] at hd_mem ⊢; omega
-      · change (idx ((v + (g + d)) % m) + off ((v + (g + d)) % m) % 2) % 3 = k.val
+      · simp only [Finset.mem_insert, Finset.mem_singleton]
+          at hd_mem ⊢; omega
+      · change (idx ((v + (g + d)) % m) +
+              off ((v + (g + d)) % m) % 2) % 3 = k.val
         rw [vg_mod_shift m v g d]; exact hd_eq
     · -- Pair 2 straddles → gap = 1
       have hvg_lt : (v + g) % m < m := Nat.mod_lt _ (by omega)
       open Finpartition in
       have hstrad2 : equiEndpoint m s (jg + 1) ≤
-          (v + g) % m + 1 := endpoint_bridge ((v + g) % m) hvg_lt hjg_lt h2_step
+          (v + g) % m + 1 :=
+        endpoint_bridge ((v + g) % m) hvg_lt hjg_lt h2_step
       have hgap1 := straddle2_gap1 s g m hs hs3_le hs_le h_lb
         h_ub v j₀ jg hv_lt hj₀_lt hjg_lt hv_lo hv_hi
         hvg_hi hstrad2 hgap
-      have hj01_eq : (j₀ + 1) % 3 = jg % 3 := by
-        grind [gap_mod_cases_gen]
+      have hj01_eq := gap1_j0_mod3 s j₀ jg hs3 hj₀_lt hjg_lt
+        hgap1
       rcases hk2 with hk_eq | hk_eq
       · -- k = jg%3 = (j₀+1)%3: pair 1 non-straddle
         rcases eqp_idx_step q r v hq_pos with h1_same | h1_step
         · -- Pair 1 non-straddle → witness a = d
           have hv1_lt : v + 1 < m := by
-            rcases eqp_idx_succ_lt_m m q r s v hq_pos hr_lt hm_eq hv_lt with h | h
+            rcases eqp_idx_succ_lt_m m q r s v hq_pos hr_lt
+              hm_eq hv_lt with h | h
             · exact h
             · rw [h1_same] at h
               have : j₀ = s := h; omega
@@ -1435,23 +1691,26 @@ lemma case_one_interval (s g : ℕ) (hs : 0 < s) (hs3 : 3 ∣ s)
             Finset.mem_singleton] at hd_mem ⊢; omega, hd_eq⟩
         · -- Pair 1 straddles → contradiction: gap = 2
           open Finpartition in
-          have hstrad1 : equiEndpoint m s (j₀ + 1) ≤ v + 1 := endpoint_bridge v hv_lt hj₀_lt h1_step
+          have hstrad1 : equiEndpoint m s (j₀ + 1) ≤ v + 1 :=
+            endpoint_bridge v hv_lt hj₀_lt h1_step
           have hgap2 := straddle1_gap2 s g m hs hs3_le hs_le
             h_lb h_ub v j₀ jg hv_lt hj₀_lt hjg_lt hv_hi
             hvg_lo hvg_hi hstrad1 hgap
           omega
       · -- k = (jg+1)%3: witness a = g+1
         refine ⟨g + 1, by simp, ?_⟩
-        change (idx ((v + (g + 1)) % m) + off ((v + (g + 1)) % m) % 2) % 3 = k.val
+        change (idx ((v + (g + 1)) % m) +
+            off ((v + (g + 1)) % m) % 2) % 3 = k.val
         rw [vg_mod_shift m v g 1]
-        change (eqp_idx q r (((v + g) % m + 1) % m) + eqp_off q r (((v + g) % m + 1) % m) % 2) % 3 =
+        change (eqp_idx q r (((v + g) % m + 1) % m) +
+            eqp_off q r (((v + g) % m + 1) % m) % 2) % 3 =
           k.val
         rw [straddle_boundary_color m q r s ((v + g) % m)
           hq_pos hr_lt hs3 hm_eq hvg_lt h2_step jg rfl]
         exact hk_eq.symm
 
-/-- **Key lemma (Lemma 12(iv)).** Multiplication by a unit in ZMod m is an additive
-    automorphism, so it preserves HasPolychromColouring. Used throughout Case 1. -/
+/-- Multiplication by a unit in ZMod m is an additive automorphism,
+    so it preserves HasPolychromColouring. This is Lemma 12(iv). -/
 lemma hasPolychromColouring_mul_unit (u : (ZMod m)ˣ) (S : Finset (ZMod m)) :
     HasPolychromColouring (Fin 3) (S.image (u.val * ·)) ↔
     HasPolychromColouring (Fin 3) S := by
@@ -1462,25 +1721,22 @@ lemma hasPolychromColouring_mul_unit (u : (ZMod m)ˣ) (S : Finset (ZMod m)) :
 
 /-! ### Subcase (1c): per-residue lemmas (paper §4.1, case 3 ∤ m)
 
-Each lemma below reduces `{0, 1, g, g+1}` to a translate of a Table 1 set via
+Each lemma reduces `{0, 1, g, g+1}` to a translate of a Table 1 set via
 multiplication by 3 (which is an automorphism of `ZMod m` when `3 ∤ m`).
-The six individual `case_one_res_*` lemmas are routine; the important interface
-is `case_one_residues` which dispatches to them.
+The six cases correspond to `m mod 3` and the value of `g` relative to `m/3`.
 -/
-
-section Case1c
 
 /-- m = 3g - 2: ×3 maps {0,1,g,g+1} to {0,3,3g,3g+3} ≡ {0,2,3,5}. -/
 lemma case_one_res_3g_sub_2 (g : ℕ) (hm : m ≥ 289)
     (hg : m = 3 * g - 2) :
-    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
+    HasPolychromColouring (Fin 3)
+      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
         Finset (ZMod m)) := by
   obtain ⟨u, hu⟩ := ZMod.isUnit_prime_of_not_dvd Nat.prime_three (by grind : ¬3 ∣ m)
   rw [← hasPolychromColouring_mul_unit m u]
   have h3g_mod : (3 : ZMod m) * (g : ZMod m) = 2 := by
     have : ((3 * g : ℕ) : ZMod m) = (m + 2 : ℕ) := by congr 1; grind
-    push_cast [ZMod.natCast_self] at this
-    grind
+    push_cast [ZMod.natCast_self] at this; grind
   have h3g1_mod : (3 : ZMod m) * ((g : ZMod m) + 1) = 5 := by grind
   simpa [hu, Nat.cast_ofNat, image_insert, mul_zero, mul_one, h3g_mod, image_singleton,
     h3g1_mod, insert_comm] using table1_0235 m (by grind)
@@ -1493,8 +1749,7 @@ lemma case_one_res_3g_sub_1 (g : ℕ) (hm : m ≥ 289)
   rw [← hasPolychromColouring_mul_unit m u]
   have h3g_mod : (3 : ZMod m) * g = 1 := by
     have : ((3 * g : ℕ) : ZMod m) = (m + 1 : ℕ) := by congr 1; grind
-    push_cast [ZMod.natCast_self] at this
-    grind
+    push_cast [ZMod.natCast_self] at this; grind
   have h3g1_mod : (3 : ZMod m) * ((g : ZMod m) + 1) = 4 := by grind
   simpa [hu, Nat.cast_ofNat, image_insert, mul_zero, mul_one, h3g_mod,
     image_singleton, h3g1_mod, insert_comm] using table1_0134 m (by grind)
@@ -1507,8 +1762,7 @@ lemma case_one_res_3g_add_1 (g : ℕ) (hm : m ≥ 289)
   rw [← hasPolychromColouring_mul_unit m u]
   have h3g_mod : (3 : ZMod m) * g = -1 := by
     have : ((3 * g + 1 : ℕ) : ZMod m) = (m : ℕ) := by rw [hg]
-    push_cast [ZMod.natCast_self] at this
-    grind
+    push_cast [ZMod.natCast_self] at this; grind
   have h3g1_mod : (3 : ZMod m) * ((g : ZMod m) + 1) = 2 := by grind
   have : {0, (3 : ZMod m), -1, 2} = (-1 : ZMod m) +ᵥ ({0, 1, 3, 4} : Finset (ZMod m)) := by
     simp only [vadd_finset_insert, vadd_finset_singleton, vadd_eq_add]
@@ -1523,8 +1777,7 @@ lemma case_one_res_3g_add_2 (g : ℕ) (hm : m ≥ 289)
   rw [← hasPolychromColouring_mul_unit m u]
   have h3g_mod : (3 : ZMod m) * g = -2 := by
     have : ((3 * g + 2 : ℕ) : ZMod m) = (m : ℕ) := by rw [hg]
-    push_cast [ZMod.natCast_self] at this
-    grind
+    push_cast [ZMod.natCast_self] at this; grind
   have h3g1_mod : (3 : ZMod m) * ((g : ZMod m) + 1) = 1 := by grind
   have : {0, (3 : ZMod m), -2, 1} = (-2 : ZMod m) +ᵥ ({0, 2, 3, 5} : Finset (ZMod m)) := by
     simp only [vadd_finset_insert, vadd_finset_singleton, vadd_eq_add]
@@ -1539,8 +1792,7 @@ lemma case_one_res_3g_add_4 (g : ℕ) (hm : m ≥ 289)
   rw [← hasPolychromColouring_mul_unit m u]
   have h3g_mod : (3 : ZMod m) * g = -4 := by
     have : ((3 * g + 4 : ℕ) : ZMod m) = (m : ℕ) := by rw [hg]
-    push_cast [ZMod.natCast_self] at this
-    grind
+    push_cast [ZMod.natCast_self] at this; grind
   have h3g1_mod : (3 : ZMod m) * ((g : ZMod m) + 1) = -1 := by grind
   have : {0, (3 : ZMod m), -4, -1} = (-4 : ZMod m) +ᵥ ({0, 3, 4, 7} : Finset (ZMod m)) := by
     simp only [vadd_finset_insert, vadd_finset_singleton, vadd_eq_add]
@@ -1555,15 +1807,14 @@ lemma case_one_res_3g_add_5 (g : ℕ) (hm : m ≥ 289)
   rw [← hasPolychromColouring_mul_unit m u]
   have h3g_mod : (3 : ZMod m) * g = -5 := by
     have : ((3 * g + 5 : ℕ) : ZMod m) = (m : ℕ) := by rw [hg]
-    push_cast [ZMod.natCast_self] at this
-    grind
+    push_cast [ZMod.natCast_self] at this; grind
   have h3g1_mod : (3 : ZMod m) * ((g : ZMod m) + 1) = -2 := by grind
   have : {0, (3 : ZMod m), -5, -2} = (-5 : ZMod m) +ᵥ ({0, 3, 5, 8} : Finset (ZMod m)) := by
     simp only [vadd_finset_insert, vadd_finset_singleton, vadd_eq_add]
     grind
   simpa [hu, h3g_mod, h3g1_mod, this] using table1_0358 m (by grind)
 
-/-- **Subcase (1c) assembled:** dispatches to the six per-residue lemmas above.
+/-- Subcase (1c) assembled: dispatches to the six per-residue lemmas above.
     Covers the case `3 ∤ m` with `2⌊m/6⌋ ≤ g ≤ ⌈m/3⌉` (paper §4.1). -/
 lemma case_one_residues (g : ℕ) (hm : m ≥ 289) (h_res : m % 3 ≠ 0)
     (h_range : 2 * (m / 6) ≤ g ∧ g ≤ (m + 2) / 3) :
@@ -1579,24 +1830,44 @@ lemma case_one_residues (g : ℕ) (hm : m ≥ 289) (h_res : m % 3 ≠ 0)
   · exact case_one_res_3g_add_4 _ g hm rfl
   · exact case_one_res_3g_add_5 _ g hm rfl
 
-end Case1c
-
 /-! ### Subcase (1d): 3 ∣ m, split by g mod 3 (paper §4.1, case 3 ∣ m)
 
-When `3 ∣ m`, multiplication by 3 is not available. Instead, explicit periodic
-colorings are constructed. The three individual lemmas (`case_one_div_g_not_three`,
-`case_one_div_3g`, `case_one_div_3g3`) are routine; `case_one_divisible` dispatches
-to them.
+When `3 ∣ m`, multiplication by 3 is not available. Instead:
+- If `g ≢ 0 (mod 3)`: the uniform coloring `n ↦ n mod 3` works directly.
+- If `g ≡ 0 (mod 3)` and `m = 3g`: a diagonal coloring `n ↦ (n mod 3 + n/g) mod 3`.
+- If `g ≡ 0 (mod 3)` and `m = 3g+3`: a reversed diagonal coloring of period `g+1`.
 -/
-
-section Case1d
 
 /-- (1d), g ≢ 0 (mod 3): the periodic coloring 012012...012 works because
     each translate of {0,1,g,g+1} hits all 3 residue classes mod 3. -/
+/- Aristotle alternative for `case_one_div_g_not_three` (13 lines vs 14 original, -1).
+   Full proof: `aristotle_results/result_case_one_div_g_not_three.lean`
+
 lemma case_one_div_g_not_three (g : ℕ)
     (h_div : m = 3 * g ∨ m = 3 * g + 3)
     (hg3 : g % 3 ≠ 0) :
-    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
+    HasPolychromColouring (Fin 3)
+      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
+        Finset (ZMod m)) := by
+          -- Define the coloring function χ based on chromosome membership.
+          set χ : ZMod m → Fin 3 := fun n => if n.val % 3 = 0 then 0 else if n.val % 3 = 1 then 1 else 2;
+          use χ; intro n k; simp [χ];
+          rcases h_div with ( rfl | rfl ) <;> norm_num [ ZMod.val_add, Nat.add_mod ] at *;
+          · have h_cases_n : (n + 1).val % 3 = (n.val + 1) % 3 ∧ (n + g).val % 3 = (n.val + g) % 3 ∧ (n + (g + 1)).val % 3 = (n.val + g + 1) % 3 := by
+              cases g <;> simp_all +decide [ ZMod.val_add ];
+              exact ⟨ rfl, rfl, rfl ⟩;
+            grind +ring;
+          · -- By considering all possible values of $n.val \mod 3$ and $g \mod 3$, we can show that the if-then-else expressions cover all cases for $k$.
+            have h_cases : ∀ n : ZMod (3 * g + 3), ∀ g : ℕ, g % 3 ≠ 0 → (n.val % 3 = 0 ∨ n.val % 3 = 1 ∨ n.val % 3 = 2) ∧ (g % 3 = 1 ∨ g % 3 = 2) := by
+              grind +ring;
+            rcases h_cases n g hg3 with ⟨ hn | hn | hn, hg | hg ⟩ <;> fin_cases k <;> simp +decide [ hn, hg ] at hg3 ⊢;
+            all_goals simp +decide [ ZMod.val ] ;
+-/
+lemma case_one_div_g_not_three (g : ℕ)
+    (h_div : m = 3 * g ∨ m = 3 * g + 3)
+    (hg3 : g % 3 ≠ 0) :
+    HasPolychromColouring (Fin 3)
+      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
         Finset (ZMod m)) := by
   have h3_dvd : 3 ∣ m := by rcases h_div with rfl | rfl <;> grind
   haveI : NeZero m := ⟨by grind⟩
@@ -1604,7 +1875,8 @@ lemma case_one_div_g_not_three (g : ℕ)
   simp only [Finset.image_insert, Finset.image_singleton,
     map_zero, map_one, map_add, map_natCast]
   have hg12 : g % 3 = 1 ∨ g % 3 = 2 := by grind
-  suffices ({0, 1, (g : ZMod 3), (g : ZMod 3) + 1} : Finset (ZMod 3)) = Finset.univ by
+  suffices ({0, 1, (g : ZMod 3), (g : ZMod 3) + 1} :
+      Finset (ZMod 3)) = Finset.univ by
     rw [this]; exact hasPolychromColouring_univ
   rcases hg12 with h | h <;> {
     have : (g : ZMod 3) = ↑(g % 3 : ℕ) := by
@@ -1615,7 +1887,8 @@ lemma case_one_div_g_not_three (g : ℕ)
 /-- (1d), m = 3g, g ≡ 0 (mod 3): diagonal coloring `n ↦ (n%3 + n/g) % 3`. -/
 lemma case_one_div_3g (g : ℕ) (hm_eq : m = 3 * g)
     (hg3 : 3 ∣ g) (hg : 0 < g) :
-    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
+    HasPolychromColouring (Fin 3)
+      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
         Finset (ZMod m)) := by
   haveI : NeZero m := ⟨by grind⟩
   haveI : Fact (1 < m) := ⟨by grind⟩
@@ -1625,8 +1898,9 @@ lemma case_one_div_3g (g : ℕ) (hm_eq : m = 3 * g)
   have hc_period : ∀ p, c (p % m) = c p := by
     intro p; simp only [c, hm_eq]
     rw [Nat.mod_mod_of_dvd p (dvd_mul_right 3 g)]
-    have h2 : p = p % (3 * g) + 3 * (p / (3 * g)) * g := by
-      grind [Nat.mod_add_div p (3 * g)]
+    have h1 : (3 * (p / (3 * g))) * g = 3 * g * (p / (3 * g)) := by grind
+    have h2 : p = p % (3 * g) + (3 * (p / (3 * g))) * g := by
+      rw [h1]; exact (Nat.mod_add_div p (3 * g)).symm
     have h3 : p / g = p % (3 * g) / g + 3 * (p / (3 * g)) := by
       conv_lhs => rw [h2]; exact Nat.add_mul_div_right _ _ hg
     conv_rhs => rw [h3]
@@ -1650,25 +1924,99 @@ lemma case_one_div_3g (g : ℕ) (hm_eq : m = 3 * g)
       rw [this, color_at (q + 1) (r + 1) (by grind)]
     exact endgame_witness (Nat.mod_lt _ (by grind)) 0 g (g + 1)
       (by simp) (by simp) (by simp)
-      hcv (by grind) (by grind)
+      hcv (by grind)
+        (by grind)
   · push_neg at hr_lt_gm1
     have hr_eq : r = g - 1 := by grind
     have hcv : c v = (2 + q) % 3 := by grind
     have hcv1 : c (v + 1) = (q + 1) % 3 := by
       have : v + 1 = g * (q + 1) + 0 := by grind
-      rw [this, color_at (q + 1) 0 hg]
-      grind
+      rw [this, color_at (q + 1) 0 hg]; grind
     have hcvg : c (v + g) = (2 + (q + 1)) % 3 := by
       have : v + g = g * (q + 1) + (g - 1) := by grind
-      rw [this]
-      grind
+      rw [this]; grind
     exact endgame_witness (Nat.mod_lt _ (by grind)) 0 g 1
       (by simp) (by simp) (by simp)
       hcv (by grind) (by grind)
 
 /-- (1d), m = 3g+3, g ≡ 0 (mod 3): reversed diagonal coloring of period `g+1`. -/
+/- Aristotle alternative for `case_one_div_3g3` (40 lines vs 53 original, -13).
+   Full proof: `aristotle_results/result_case_one_div_3g3.lean`
+
+    ((r + 1) % 3 + (3 - q % 3)) % 3 =
+      ((r % 3 + (3 - q % 3)) % 3 + 1) % 3 := by admit
+
+    (r % 3 + (3 - (q + 1) % 3)) % 3 =
+      ((r % 3 + (3 - q % 3)) % 3 + 2) % 3 := by admit
+
+    ((k + 3 - s) % 3 = 0 → s = k) ∧
+    ((k + 3 - s) % 3 = 1 → (s + 1) % 3 = k) ∧
+    ((k + 3 - s) % 3 = 2 → (s + 2) % 3 = k) := by admit
+
+    {v s : ℕ} {k : Fin 3} (hs : s < 3)
+    (a₀ a₁ a₂ : ℕ)
+    (ha₀ : a₀ ∈ ({0, 1, g, g + 1} : Finset ℕ))
+    (ha₁ : a₁ ∈ ({0, 1, g, g + 1} : Finset ℕ))
+    (ha₂ : a₂ ∈ ({0, 1, g, g + 1} : Finset ℕ))
+    (hc₀ : c (v + a₀) = s)
+    (hc₁ : c (v + a₁) = (s + 1) % 3)
+    (hc₂ : c (v + a₂) = (s + 2) % 3) :
+    ∃ a ∈ ({0, 1, g, g + 1} : Finset ℕ), c (v + a) = k.val := by admit
+
+    (hg_lt : g + 1 < m) {c : ℕ → ℕ} (hc_lt : ∀ p, c p < 3)
+    (hc_period : ∀ p, c (p % m) = c p)
+    {n : ZMod m} {k : Fin 3}
+    (h : ∃ a ∈ ({0, 1, g, g + 1} : Finset ℕ), c (n.val + a) = k.val) :
+    ∃ s ∈ ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)),
+      (⟨c (n + s).val, hc_lt _⟩ : Fin 3) = k := by admit
+
 lemma case_one_div_3g3 (g : ℕ) (hm_eq : m = 3 * g + 3) (hg3 : 3 ∣ g) (hg : 0 < g) :
-    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by
+    HasPolychromColouring (Fin 3)
+      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by
+        -- We'll use the fact that if the graph is a union of disjoint cycles, then it has a polychromatic coloring.
+        have h_coloring : ∃ c : ℕ → ℕ, (∀ p, c p < 3) ∧ (∀ p, c (p % m) = c p) ∧ ∀ n ∈ Finset.range m, ∀ k : Fin 3, ∃ a ∈ ({0, 1, g, g + 1} : Finset ℕ), c (n + a) = k.val := by
+          obtain ⟨ k, rfl ⟩ := hg3; simp_all +decide [ Nat.add_mod, Nat.mul_mod ] ;
+          refine' ⟨ fun n => ( n + n / ( 3 * k + 1 ) ) % 3, _, _, _ ⟩ <;> norm_num [ Nat.add_mod, Nat.mod_lt ];
+          · intro p; rw [ ← Nat.mod_add_div p ( 3 * ( 3 * k ) + 3 ) ] ; norm_num [ Nat.add_div, Nat.mul_div_assoc, Nat.mul_mod, Nat.add_mod ] ; ring;
+            norm_num [ show 3 % ( 1 + k * 3 ) = 3 by rw [ Nat.mod_eq_of_lt ] ; linarith ] ; ring;
+            norm_num [ show k * ( p / ( 3 + k * 9 ) ) * 9 + p / ( 3 + k * 9 ) * 3 = ( 1 + k * 3 ) * ( p / ( 3 + k * 9 ) * 3 ) by ring, Nat.add_mod, Nat.mul_mod ];
+            split_ifs <;> norm_num ; linarith [ Nat.mod_lt ( p % ( 3 + k * 9 ) ) ( by linarith : 0 < 1 + k * 3 ) ] ;
+          · -- Let's consider the possible values of $n$ modulo $3$.
+            intro n hn k_1
+            by_cases hn0 : n % 3 = 0 ∨ n % 3 = 1 ∨ n % 3 = 2;
+            · fin_cases k_1 <;> simp_all +decide [ Nat.add_div ] ;
+              · split_ifs <;> simp_all +decide [ Nat.div_eq_of_lt, Nat.mod_eq_of_lt ] ; omega;
+                · omega;
+                · omega;
+                · grind;
+              · split_ifs <;> simp_all +decide [ Nat.div_eq_of_lt, Nat.mod_eq_of_lt ] ; omega;
+                · grind +ring;
+                · omega;
+                · -- Since $n \% (3 * k + 1) < 1$, we have $n = q * (3 * k + 1)$ for some integer $q$.
+                  obtain ⟨q, hq⟩ : ∃ q, n = q * (3 * k + 1) := by
+                    exact exists_eq_mul_left_of_dvd ( Nat.dvd_of_mod_eq_zero ( by omega ) )
+                  generalize_proofs at *; (
+                  norm_num [ hq, Nat.add_mod, Nat.mul_mod, Nat.mod_eq_of_lt ( by linarith : 3 * k + 1 > 1 ) ] at * ; omega;);
+              · split_ifs <;> simp_all +decide [ Nat.div_eq_of_lt, Nat.mod_eq_of_lt ] ; omega;
+                · omega;
+                · grind;
+                · grind;
+            · grind
+        generalize_proofs at *; (
+        obtain ⟨c, hc⟩ := h_coloring
+        use fun n => ⟨c n.val, hc.1 n.val⟩
+        intro n k
+        obtain ⟨a, ha₁, ha₂⟩ := hc.2.2 n.val (Finset.mem_range.mpr (by
+        convert n.val_lt
+        generalize_proofs at *; (
+        exact ⟨ by linarith ⟩))) k
+        generalize_proofs at *; (
+        use a; simp_all +decide [ Fin.ext_iff ] ; (
+        haveI := Fact.mk ( by linarith : 1 < m ) ; erw [ ZMod.val_add ] ; aesop;)))
+-/
+lemma case_one_div_3g3 (g : ℕ) (hm_eq : m = 3 * g + 3) (hg3 : 3 ∣ g) (hg : 0 < g) :
+    HasPolychromColouring (Fin 3)
+      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by
   haveI : NeZero m := ⟨by grind⟩
   haveI : Fact (1 < m) := ⟨by grind⟩
   obtain ⟨t, ht⟩ := hg3
@@ -1680,7 +2028,7 @@ lemma case_one_div_3g3 (g : ℕ) (hm_eq : m = 3 * g + 3) (hg3 : 3 ∣ g) (hg : 0
     have hm3h : m = 3 * h := by grind
     intro p; simp only [c, hm3h]
     have hp_eq : p = h * (3 * (p / (3 * h))) + p % (3 * h) := by
-      grind [Nat.mod_add_div p (3 * h)]
+      grind [(Nat.mod_add_div p (3 * h)).symm]
     conv_rhs => rw [hp_eq]
     grind [Nat.mul_add_mod, Nat.add_mul_div_left]
   refine ⟨fun x => ⟨c x.val, hc_lt3 _⟩, fun n k =>
@@ -1696,13 +2044,12 @@ lemma case_one_div_3g3 (g : ℕ) (hm_eq : m = 3 * g + 3) (hg3 : 3 ∣ g) (hg : 0
   by_cases hrg : r = g
   · have hcv : c v = (3 - q % 3) % 3 := by grind
     have hcvg : c (v + g) = (2 + (3 - (q + 1) % 3)) % 3 := by
-      have : v + g = h * (q + 1) + (g - 1) := by grind
-      rw [this, color_at (q + 1) (g - 1) (by grind)]
-      grind
+      have h1 : v + g = h * (q + 1) + (g - 1) := by grind
+      have h2 : 3 * t - 1 = 3 * (t - 1) + 2 := by grind
+      rw [h1, color_at (q + 1) (g - 1) (by grind), ht, h2]; simp
     have hcv1 : c (v + 1) = (3 - (q + 1) % 3) % 3 := by
       have : v + 1 = h * (q + 1) + 0 := by grind
-      rw [this, color_at (q + 1) 0 (by grind)]
-      grind
+      rw [this, color_at (q + 1) 0 (by grind)]; grind
     exact endgame_witness (Nat.mod_lt _ (by grind)) 0 g 1
       (by simp) (by simp) (by simp)
       hcv (by grind) (by grind)
@@ -1715,14 +2062,16 @@ lemma case_one_div_3g3 (g : ℕ) (hm_eq : m = 3 * g + 3) (hg3 : 3 ∣ g) (hg : 0
     exact endgame_witness (Nat.mod_lt _ (by grind)) 0 1 (g + 1)
       (by simp) (by simp) (by simp) rfl
       (by rw [hcv1]
-          change ((r + 1) % 3 + (3 - q % 3)) % 3 = ((r % 3 + (3 - q % 3)) % 3 + 1) % 3
+          change ((r + 1) % 3 + (3 - q % 3)) % 3 =
+            ((r % 3 + (3 - q % 3)) % 3 + 1) % 3
           omega)
       (by have : v + (g + 1) = v + g + 1 := by ring
           rw [this, hcvg1]
-          change (r % 3 + (3 - (q + 1) % 3)) % 3 = ((r % 3 + (3 - q % 3)) % 3 + 2) % 3
+          change (r % 3 + (3 - (q + 1) % 3)) % 3 =
+            ((r % 3 + (3 - q % 3)) % 3 + 2) % 3
           omega)
 
-/-- **Subcase (1d) assembled:** dispatches on `g % 3` and `m ∈ {3g, 3g+3}` (paper §4.1). -/
+/-- Subcase (1d) assembled: dispatches on `g % 3` and `m ∈ {3g, 3g+3}` (paper §4.1). -/
 lemma case_one_divisible (g : ℕ) (hm : m ≥ 289) (h_div : m = 3 * g ∨ m = 3 * g + 3) :
     HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by
   by_cases hg3 : g % 3 = 0
@@ -1731,16 +2080,183 @@ lemma case_one_divisible (g : ℕ) (hm : m ≥ 289) (h_div : m = 3 * g ∨ m = 3
     · exact case_one_div_3g3 m g h (Nat.dvd_of_mod_eq_zero hg3) (by grind)
   · exact case_one_div_g_not_three m g h_div hg3
 
-end Case1d
+/-- Combined dispatch: applies subcases (1a)–(1d) for 2 ≤ g ≤ m/2 and m ≥ 289.
+    Let s be the smallest multiple of 3 such that g > ⌈m/s⌉.
+    - (1a): g ∈ {2,3,4}, handled by Table 1 entries
+    - (1b): 5 ≤ g < 2⌊m/s⌋, handled by the interval coloring
+    - (1c): 2⌊m/s⌋ ≤ g ≤ ⌈m/(s-3)⌉ with 3 ∤ m (paper shows s = 6 here),
+            handled by multiplying by 3 and reducing to Table 1
+    - (1d): 2⌊m/s⌋ ≤ g ≤ ⌈m/(s-3)⌉ with 3 ∣ m (paper shows s = 6 here),
+            handled by explicit periodic colorings -/
+/- Aristotle alternative for `case_one_dispatch` (17 body + 32 helpers = 49 vs 50 original, -1).
+   Full proof: `aristotle_results/result_case_one_dispatch.lean`
 
-/-! ### Combined dispatch for Case 1 -/
+    HasPolychromColouring (Fin 3) ({0, 1, 2, 3} : Finset (ZMod m)) := by admit
 
-/-- **Case 1 combined dispatch:** applies subcases (1a)–(1d) for 2 ≤ g ≤ m/2 and m ≥ 289.
-    This is the main lemma for the single-cycle case, assuming the set has already been
-    reduced to the form {0, 1, g, g+1}. -/
+    HasPolychromColouring (Fin 3) ({0, 1, 3, 4} : Finset (ZMod m)) := by admit
+
+    HasPolychromColouring (Fin 3) ({0, 2, 3, 5} : Finset (ZMod m)) := by admit
+
+    HasPolychromColouring (Fin 3) ({0, 3, 4, 7} : Finset (ZMod m)) := by admit
+
+    HasPolychromColouring (Fin 3) ({0, 3, 5, 8} : Finset (ZMod m)) := by admit
+
+    HasPolychromColouring (Fin 3) ({0, 1, 4, 5} : Finset (ZMod m)) := by admit
+
+    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by admit
+
+    (h_lb : (m + s - 1) / s < g) (h_ub : g < 2 * (m / s)) :
+    HasPolychromColouring (Fin 3)
+      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by admit
+
+    HasPolychromColouring (Fin 3) (S.image (u.val * ·)) ↔
+    HasPolychromColouring (Fin 3) S := by admit
+
+    (hg : m = 3 * g - 2) :
+    HasPolychromColouring (Fin 3)
+      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
+        Finset (ZMod m)) := by admit
+
+    (hg : m = 3 * g - 1) :
+    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by admit
+
+    (hg : m = 3 * g + 1) :
+    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by admit
+
+    (hg : m = 3 * g + 2) :
+    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by admit
+
+    (hg : m = 3 * g + 4) :
+    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by admit
+
+    (hg : m = 3 * g + 5) :
+    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by admit
+
+    (h_range : 2 * (m / 6) ≤ g ∧ g ≤ (m + 2) / 3) :
+    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by admit
+
+    (h_div : m = 3 * g ∨ m = 3 * g + 3)
+    (hg3 : g % 3 ≠ 0) :
+    HasPolychromColouring (Fin 3)
+      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
+        Finset (ZMod m)) := by admit
+
+    ((r + 1) % 3 + (3 - q % 3)) % 3 =
+      ((r % 3 + (3 - q % 3)) % 3 + 1) % 3 := by admit
+
+    (r % 3 + (3 - (q + 1) % 3)) % 3 =
+      ((r % 3 + (3 - q % 3)) % 3 + 2) % 3 := by admit
+
+    ((k + 3 - s) % 3 = 0 → s = k) ∧
+    ((k + 3 - s) % 3 = 1 → (s + 1) % 3 = k) ∧
+    ((k + 3 - s) % 3 = 2 → (s + 2) % 3 = k) := by admit
+
+    {v s : ℕ} {k : Fin 3} (hs : s < 3)
+    (a₀ a₁ a₂ : ℕ)
+    (ha₀ : a₀ ∈ ({0, 1, g, g + 1} : Finset ℕ))
+    (ha₁ : a₁ ∈ ({0, 1, g, g + 1} : Finset ℕ))
+    (ha₂ : a₂ ∈ ({0, 1, g, g + 1} : Finset ℕ))
+    (hc₀ : c (v + a₀) = s)
+    (hc₁ : c (v + a₁) = (s + 1) % 3)
+    (hc₂ : c (v + a₂) = (s + 2) % 3) :
+    ∃ a ∈ ({0, 1, g, g + 1} : Finset ℕ), c (v + a) = k.val := by admit
+
+    (hg_lt : g + 1 < m) {c : ℕ → ℕ} (hc_lt : ∀ p, c p < 3)
+    (hc_period : ∀ p, c (p % m) = c p)
+    {n : ZMod m} {k : Fin 3}
+    (h : ∃ a ∈ ({0, 1, g, g + 1} : Finset ℕ), c (n.val + a) = k.val) :
+    ∃ s ∈ ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)),
+      (⟨c (n + s).val, hc_lt _⟩ : Fin 3) = k := by admit
+
+    (hg3 : 3 ∣ g) (hg : 0 < g) :
+    HasPolychromColouring (Fin 3)
+      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
+        Finset (ZMod m)) := by admit
+
+    HasPolychromColouring (Fin 3)
+      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by admit
+
+    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by admit
+
+noncomputable section AristotleLemmas
+
+/-
+If $m$ is close to $3g$ (specifically $3g-2 \le m \le 3g+5$), then the set $\{0, 1, g, g+1\}$ has a polychromatic colouring.
+-/
+lemma case_one_middle (g : ℕ) (hm : m ≥ 289) (h_approx : 3 * g - 2 ≤ m ∧ m ≤ 3 * g + 5) :
+    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by
+      by_cases hm3g : m = 3 * g ∨ m = 3 * g + 3;
+      · exact?;
+      · by_cases hm3g_sub2 : m = 3 * g - 2 ∨ m = 3 * g - 1 ∨ m = 3 * g + 1 ∨ m = 3 * g + 2 ∨ m = 3 * g + 4 ∨ m = 3 * g + 5;
+        · rcases hm3g_sub2 with ( rfl | rfl | rfl | rfl | rfl | rfl );
+          exact?;
+          · exact?;
+          · exact?;
+          · exact?;
+          · exact?;
+          · exact?;
+        · omega
+
+/-
+For $5 \le g$ and $3g+6 \le m$, there exists a multiple of 3, $s$, such that $(m+s-1)/s < g < 2(m/s)$.
+-/
+
+lemma case_one_s_exists_refined (g : ℕ) (hm : m ≥ 289) (hg5 : 5 ≤ g) (hg_upper : 3 * g + 6 ≤ m) :
+    ∃ s, 0 < s ∧ 3 ∣ s ∧ (m + s - 1) / s < g ∧ g < 2 * (m / s) := by
+      -- Let's choose k as the smallest integer greater than (m-1)/(3g-3).
+      obtain ⟨k, hk⟩ : ∃ k : ℕ, (m - 1) < 3 * k * (g - 1) ∧ 3 * k * (g - 1) ≤ m + 3 * (g - 1) - 1 := by
+        rcases g with ( _ | _ | g ) <;> norm_num at *;
+        exact ⟨ ( m - 1 ) / ( 3 * ( g + 1 ) ) + 1, by linarith [ Nat.div_add_mod ( m - 1 ) ( 3 * ( g + 1 ) ), Nat.mod_lt ( m - 1 ) ( by linarith : 0 < 3 * ( g + 1 ) ) ], by rw [ Nat.le_sub_iff_add_le ] <;> nlinarith [ Nat.div_mul_le_self ( m - 1 ) ( 3 * ( g + 1 ) ), Nat.sub_add_cancel ( by linarith : 1 ≤ m ) ] ⟩;
+      use 3 * k; rcases k with ( _ | _ | k ) <;> simp_all +arith +decide;
+      · omega;
+      · rw [ Nat.div_lt_iff_lt_mul <| by positivity ] ; rcases g with ( _ | _ | g ) <;> simp_all +decide [ Nat.mul_succ ] ; (
+        constructor <;> try linarith [ Nat.sub_add_cancel ( by linarith : 1 ≤ m ) ] ; ; rcases k with ( _ | _ | k ) <;> norm_num at * ; omega;
+        · omega;
+        · nlinarith [ Nat.div_add_mod m ( 3 * ( k + 1 + 1 ) + 6 ), Nat.mod_lt m ( by linarith : 0 < ( 3 * ( k + 1 + 1 ) + 6 ) ) ] ;)
+
+/-
+For $g \ge 5$ and $2g \le m \le 3g-3$, using $s=3$ works.
+-/
+
+lemma case_one_s_three (g : ℕ) (hm : m ≥ 289) (hg5 : 5 ≤ g) (h_range : 2 * g ≤ m ∧ m ≤ 3 * g - 3) :
+    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by
+      -- Apply `case_one_interval` with $s=3$.
+      apply case_one_interval;
+      rotate_right;
+      exact 3;
+      · norm_num;
+      · norm_num;
+      · omega;
+      · omega
+
+
 lemma case_one_dispatch (g : ℕ) (hm : m ≥ 289) (hg_ge : 2 ≤ g)
     (hg_le : g ≤ m / 2) :
-    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
+    HasPolychromColouring (Fin 3)
+      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
+        Finset (ZMod m)) := by
+          by_cases hg : g ≤ 4;
+          · apply case_one_small_g m g hm (by
+            grind);
+          · by_cases h_case2a : m ≤ 3 * g - 3;
+            · have h_case2a : 2 * g ≤ m ∧ m ≤ 3 * g - 3 := by
+                omega;
+              apply_rules [ case_one_s_three ];
+              linarith;
+            · by_cases h_case2b : 3 * g - 2 ≤ m ∧ m ≤ 3 * g + 5;
+              · exact?;
+              · -- Since $m \ge 3g + 6$, we can use `case_one_s_exists_refined` to find an $s$ such that $0 < s$, $3 \mid s$, $(m+s-1)/s < g < 2(m/s)$.
+                obtain ⟨s, hs_pos, hs_div, hs_lt_g, hs_gt_g⟩ : ∃ s, 0 < s ∧ 3 ∣ s ∧ (m + s - 1) / s < g ∧ g < 2 * (m / s) := by
+                  apply case_one_s_exists_refined;
+                  · linarith;
+                  · linarith;
+                  · omega;
+                apply_rules [ case_one_interval ]
+-/
+lemma case_one_dispatch (g : ℕ) (hm : m ≥ 289) (hg_ge : 2 ≤ g)
+    (hg_le : g ≤ m / 2) :
+    HasPolychromColouring (Fin 3)
+      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} :
         Finset (ZMod m)) := by
   -- (1a): small g
   by_cases hg4 : g ≤ 4
@@ -1758,7 +2274,8 @@ lemma case_one_dispatch (g : ℕ) (hm : m ≥ 289) (hg_ge : 2 ≤ g)
         · exact case_one_residues m g hm h3 ⟨hg_lb6, hg_ub3⟩
       · -- g > ⌈m/3⌉: (1b) with s = 3
         push_neg at hg_ub3
-        exact case_one_interval m 3 g (by grind) ⟨1, rfl⟩ (by grind) (by grind : g < 2 * (m / 3))
+        exact case_one_interval m 3 g (by grind) ⟨1, rfl⟩
+          (by grind) (by grind : g < 2 * (m / 3))
     · -- g < 2⌊m/6⌋: (1b), find appropriate s
       push_neg at hg_lb6
       -- s is the smallest multiple of 3 with g > ⌈m/s⌉.
@@ -1772,17 +2289,18 @@ lemma case_one_dispatch (g : ℕ) (hm : m ≥ 289) (hg_ge : 2 ≤ g)
         set q := (m - 1) / (3 * (g - 1))
         have hq_lb : q * (3 * (g - 1)) ≤ m - 1 := Nat.div_mul_le_self _ _
         have hq2 : q ≥ 2 := by
-          by_contra! hlt
+          by_contra hlt; push_neg at hlt
           exact absurd ((Nat.div_lt_iff_lt_mul h3g1).mp hlt) (by grind)
         have hq_ub : m - 1 < 3 * (g - 1) * (q + 1) := Nat.lt_mul_div_succ _ h3g1
         have hm_lb : m ≥ q * (3 * (g - 1)) + 1 := by grind
-        exact case_one_interval m (3 * (q + 1)) g (by grind) ⟨q + 1, rfl⟩ (by -- ⌈m/s⌉ < g
-            rw [Nat.div_lt_iff_lt_mul (by grind)]
+        exact case_one_interval m (3 * (q + 1)) g (by grind) ⟨q + 1, rfl⟩
+          (by -- ⌈m/s⌉ < g
+            rw [Nat.div_lt_iff_lt_mul (by grind : 0 < 3 * (q + 1))]
             have : g * (3 * (q + 1)) = (g - 1 + 1) * (3 * (q + 1)) := by grind
             grind)
           (by -- g < 2⌊m/s⌋
             suffices h : (g + 2) / 2 ≤ m / (3 * (q + 1)) by grind
-            rw [Nat.le_div_iff_mul_le (by grind)]
+            rw [Nat.le_div_iff_mul_le (by grind : 0 < 3 * (q + 1))]
             suffices (g + 2) * (3 * (q + 1)) ≤ 2 * m by
               have := Nat.div_mul_le_self (g + 2) 2; nlinarith
             by_cases hg10 : g ≥ 10
@@ -1791,12 +2309,13 @@ lemma case_one_dispatch (g : ℕ) (hm : m ≥ 289) (hg_ge : 2 ≤ g)
             · have : g = 5 ∨ g = 6 ∨ g = 7 ∨ g = 8 ∨ g = 9 := by grind
               rcases this with rfl | rfl | rfl | rfl | rfl <;> grind)
 
-/-! ### WLOG and aggregation lemmas for Case 1 -/
-
-/-- Auxiliary: WLOG g ≤ m/2, since {0,1,m-g,m-g+1} = (-g) +ᵥ {0,1,g,g+1}. -/
-lemma case_one_complement (g : ℕ) (hg : g < m) : HasPolychromColouring (Fin 3)
+/-- WLOG g ≤ m/2: in ZMod m, {0,1,m-g,m-g+1} = (-g) +ᵥ {0,1,g,g+1},
+    so HasPolychromColouring is preserved. -/
+lemma case_one_complement (g : ℕ) (hg : g < m) :
+    HasPolychromColouring (Fin 3)
       ({0, 1, (↑(m - g) : ZMod m), (↑(m - g) : ZMod m) + 1} : Finset (ZMod m)) ↔
-    HasPolychromColouring (Fin 3) ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by
+    HasPolychromColouring (Fin 3)
+      ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)) := by
   have key : (↑(m - g) : ZMod m) = -(↑g : ZMod m) := by
     rw [Nat.cast_sub hg.le, ZMod.natCast_self, zero_sub]
   have hset : ({0, 1, -(↑g : ZMod m), -(↑g : ZMod m) + 1} : Finset (ZMod m)) =
@@ -1809,19 +2328,76 @@ lemma case_one_complement (g : ℕ) (hg : g < m) : HasPolychromColouring (Fin 3)
 private lemma isUnit_intCast_of_natAbs_coprime {n : ℕ} {b : ℤ}
     (h : Nat.gcd b.natAbs n = 1) :
     IsUnit (Int.cast b : ZMod n) := by
-  have hu : IsUnit (b.natAbs : ZMod n) := (ZMod.isUnit_iff_coprime _ _).mpr h
+  have hu : IsUnit (b.natAbs : ZMod n) :=
+    (ZMod.isUnit_iff_coprime _ _).mpr h
   rcases Int.natAbs_eq b with hb | hb
   · have : (Int.cast b : ZMod n) = ↑b.natAbs := by rw [hb]; simp
     rwa [this]
   · have : (Int.cast b : ZMod n) = -↑b.natAbs := by rw [hb]; simp
     rw [this]; exact hu.neg
 
-/-- **Key reduction for Case 1.** When gcd(b, m) = 1, finds the gap parameter g
-    such that zmod_set m a b = (image of {0,1,g,g+1} under ×b). -/
+/-- When gcd(b, m) = 1, there exists 2 ≤ g ≤ m - 2 with gb ≡ b - a (mod m),
+    and zmod_set m a b = (image of {0,1,g,g+1} under ×b). -/
+/- Aristotle alternative for `exists_g_of_coprime` (39 lines vs 49 original, -10).
+   Full proof: `aristotle_results/result_exists_g_of_coprime.lean`
+
+  ({0, b - a, b, 2 * b - a} : Finset ℤ).image Int.cast
+
+    (h : Nat.gcd b.natAbs n = 1) :
+    IsUnit (Int.cast b : ZMod n) := by admit
+
 lemma exists_g_of_coprime (a b : ℤ) (hd : Nat.gcd b.natAbs m = 1)
     (hm : 0 < m) (hcard : (zmod_set m a b).card = 4) :
-    ∃ g : ℕ, 2 ≤ g ∧ g ≤ m - 2 ∧ zmod_set m a b =
-        ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)).image ((b : ZMod m) * ·) := by
+    ∃ g : ℕ, 2 ≤ g ∧ g ≤ m - 2 ∧
+      zmod_set m a b =
+        ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)).image
+          ((b : ZMod m) * ·) := by
+            -- Since $g$ is a unit in $\mathbb{Z}/m\mathbb{Z}$, we can choose $g$ such that $g \equiv 2 \pmod{m}$.
+            obtain ⟨g, hg⟩ : ∃ g : ZMod m, g ≠ 0 ∧ g ≠ 1 ∧ zmod_set m a b = Finset.image (fun x : ZMod m => x * b) {0, 1, g, g + 1} := by
+              -- Since $g$ is a unit in $\mathbb{Z}/m\mathbb{Z}$, we can choose $g$ such that $g \equiv 2 \pmod{m}$ and $g \neq 0, 1$.
+              obtain ⟨g, hg⟩ : ∃ g : ZMod m, g ≠ 0 ∧ g ≠ 1 ∧ Finset.image (fun x : ℤ => x : ℤ → ZMod m) {0, b - a, b, 2 * b - a} = Finset.image (fun x : ZMod m => x * b) {0, 1, g, g + 1} := by
+                -- Since $b - a$ is a unit in $\mathbb{Z}/m\mathbb{Z}$, we can write $b - a = k \cdot b$ for some $k \in \mathbb{Z}/m\mathbb{Z}$.
+                obtain ⟨k, hk⟩ : ∃ k : ZMod m, b - a = k * b := by
+                  have h_unit : IsUnit (b : ZMod m) := by
+                    have h_unit : ∃ x : ℤ, b * x ≡ 1 [ZMOD m] := by
+                      -- By Bezout's identity, since gcd(b, m) = 1, there exist integers x and y such that b*x + m*y = 1.
+                      obtain ⟨x, y, h_bezout⟩ : ∃ x y : ℤ, b * x + m * y = 1 := by
+                        have := Int.gcd_eq_gcd_ab b m;
+                        exact ⟨ _, _, this.symm.trans ( mod_cast hd ) ⟩;
+                      exact ⟨ x, Int.modEq_iff_dvd.mpr ⟨ y, by linarith ⟩ ⟩;
+                    obtain ⟨ x, hx ⟩ := h_unit; exact isUnit_iff_exists_inv.mpr ⟨ x, by simpa [ ← ZMod.intCast_eq_intCast_iff ] using hx ⟩ ;
+                  exact ⟨ ( b - a ) * h_unit.unit.inv, by simp +decide [ mul_assoc, h_unit.unit.inv_mul ] ⟩;
+                refine' ⟨ k, _, _, _ ⟩ <;> simp_all +decide [ Finset.ext_iff ];
+                · contrapose! hcard; simp_all +decide [ zmod_set ] ;
+                  exact ne_of_lt ( lt_of_le_of_lt ( Finset.card_insert_le _ _ ) ( lt_of_le_of_lt ( add_le_add_right ( Finset.card_insert_le _ _ ) _ ) ( by norm_num ) ) );
+                · intro h; simp_all +decide [ sub_eq_iff_eq_add ] ;
+                  unfold zmod_set at hcard; simp_all +decide [ Finset.card_image_of_injective, Function.Injective ] ;
+                  exact hcard.not_lt ( lt_of_le_of_lt ( Finset.card_insert_le _ _ ) ( lt_of_le_of_lt ( add_le_add_right ( Finset.card_insert_le _ _ ) _ ) ( by norm_num ) ) );
+                · grind +ring;
+              unfold zmod_set; aesop;
+            -- Since $g$ is a unit in $\mathbb{Z}/m\mathbb{Z}$, we can choose $g$ such that $2 \leq g \leq m-2$.
+            obtain ⟨g', hg'⟩ : ∃ g' : ℕ, 2 ≤ g' ∧ g' < m ∧ g = g' := by
+              refine' ⟨ g.val, _, _, _ ⟩ <;> rcases m with ( _ | _ | m ) <;> simp_all +decide [ ZMod ];
+              any_goals fin_cases g ; trivial;
+              · fin_cases g ; simp_all +decide [ Fin.eq_zero ];
+              · contrapose! hg; rcases g with ( _ | _ | g ) <;> simp_all +decide ;
+                rcases g with ( _ | _ | g ) <;> tauto;
+              · grind;
+              · exact ZMod.val_lt g;
+              · exact Eq.symm ( Fin.ext ( Nat.mod_eq_of_lt ( show g.val < m + 1 + 1 from g.val_lt ) ) );
+            -- Since $g \neq m-1$, we have $g' \leq m-2$.
+            have hg'_le : g' ≤ m - 2 := by
+              by_contra hg'_gt; push_neg at hg'_gt; (
+              norm_num [ show g' = m - 1 by omega ] at * ; simp_all +decide [ Nat.cast_sub hm ] ;
+              exact hcard.not_lt ( lt_of_le_of_lt ( Finset.card_insert_le _ _ ) ( lt_of_le_of_lt ( add_le_add_right ( Finset.card_insert_le _ _ ) _ ) ( by norm_num ) ) ));
+            exact ⟨ g', hg'.1, hg'_le, by simpa [ mul_comm, hg'.2.2 ] using hg.2.2 ⟩
+-/
+lemma exists_g_of_coprime (a b : ℤ) (hd : Nat.gcd b.natAbs m = 1)
+    (hm : 0 < m) (hcard : (zmod_set m a b).card = 4) :
+    ∃ g : ℕ, 2 ≤ g ∧ g ≤ m - 2 ∧
+      zmod_set m a b =
+        ({0, 1, (g : ZMod m), (g : ZMod m) + 1} : Finset (ZMod m)).image
+          ((b : ZMod m) * ·) := by
   have hm4 : 4 ≤ m := by
     haveI : NeZero m := ⟨by grind⟩
     calc 4 = (zmod_set m a b).card := hcard.symm
@@ -1837,7 +2413,8 @@ lemma exists_g_of_coprime (a b : ℤ) (hd : Nat.gcd b.natAbs m = 1)
     rw [← mul_assoc, ZMod.mul_inv_of_unit _ hub, one_mul]
   have hbg'1 : bz * (g' + 1) = 2 * bz - az := by
     rw [mul_add, mul_one, hbg']; ring
-  have hset : zmod_set m a b = ({0, 1, g', g' + 1} : Finset (ZMod m)).image (bz * ·) := by
+  have hset : zmod_set m a b =
+      ({0, 1, g', g' + 1} : Finset (ZMod m)).image (bz * ·) := by
     simp only [zmod_set, Finset.image_insert, Finset.image_singleton]
     simp only [mul_zero, mul_one, hbg', hbg'1]
     grind
@@ -1847,7 +2424,7 @@ lemma exists_g_of_coprime (a b : ℤ) (hd : Nat.gcd b.natAbs m = 1)
   have hcard4 : ({0, 1, g', g' + 1} : Finset (ZMod m)).card = 4 := by
     rwa [hset, Finset.card_image_of_injective _ hinj] at hcard
   refine ⟨g'.val, ?_, ?_, ?_⟩
-  · by_contra! hlt
+  · by_contra hlt; push_neg at hlt
     have hcases : g'.val = 0 ∨ g'.val = 1 := by grind
     rcases hcases with h | h
     · have hg'0 : g' = 0 := by rw [← hval, h, Nat.cast_zero]
@@ -1859,7 +2436,7 @@ lemma exists_g_of_coprime (a b : ℤ) (hd : Nat.gcd b.natAbs m = 1)
         rw [hg'1]; intro x; simp [Finset.mem_insert, Finset.mem_singleton]
       grind [Finset.card_le_card hsub,
         Finset.card_le_three (a := (0 : ZMod m)) (b := 1) (c := (1 : ZMod m) + 1)]
-  · by_contra! hgt
+  · by_contra hgt; push_neg at hgt
     have hval_lt := ZMod.val_lt g'
     have hgm1 : g'.val = m - 1 := by grind
     have hg'p1 : g' + 1 = 0 := by
@@ -1868,12 +2445,13 @@ lemma exists_g_of_coprime (a b : ℤ) (hd : Nat.gcd b.natAbs m = 1)
     have hsub : ({0, 1, g', g' + 1} : Finset (ZMod m)) ⊆ {0, 1, g'} := by grind
     grind [Finset.card_le_card hsub,
       Finset.card_le_three (a := (0 : ZMod m)) (b := 1) (c := g')]
-  · conv at hset => rhs; rw [← hval]
+  · conv at hset => rhs; rw [hval.symm]
     exact hset
 
-/-- **Main Case 1 (Single Cycle).** Aggregates all subcases (1a)–(1d).
-    Reduces to {0,1,g,g+1} via `exists_g_of_coprime`, applies WLOG g ≤ m/2,
-    then dispatches via `case_one_dispatch`. -/
+/-- Aggregation of Main Case 1.
+    Reduces to {0,1,g,g+1} via exists_g_of_coprime and hasPolychromColouring_mul_unit,
+    applies WLOG g ≤ m/2 via case_one_complement,
+    then dispatches via case_one_dispatch. -/
 lemma main_case_one (a b : ℤ) (hm : m ≥ 289)
     (hcard : (zmod_set m a b).card = 4)
     (h_gcd : Nat.gcd b.natAbs m = 1 ∨ Nat.gcd (b - a).natAbs m = 1) :
@@ -1914,7 +2492,8 @@ consecutive positions within each cycle.
 The proof splits into subcases based on the parity of $d_1$ and $e_1$:
 - **(2a) $e_1$ even:**
   Each cycle uses two alternating colors; adjacent cycles skip different colors.
-- **(2b) $d_1$ even, $e_1$ odd:** Similar but with special "degenerate" handling for odd lengths.
+- **(2b) $d_1$ even, $e_1$ odd:**
+  Similar but with special "degenerate" handling for odd lengths.
 - **(2c) Both odd, $e_1 \le 17$:** Shifted periodic colorings.
 - **(2d) Both odd, $e_1 \ge 19$:** Rotating patterns based on a 3-interval partition.
 -/
@@ -1923,22 +2502,19 @@ section Case2_MultipleCycles
 
 variable (m : ℕ) (a b : ℤ)
 
-/-! ### Arithmetic helpers for cycle decomposition
-
-These lemmas set up the orbit map infrastructure. They are not important individually
-but are used throughout Case 2.
--/
+-- In this section, we work directly with `zmod_set` using cycle decompositions.
+-- We inline d1 = gcd(b, m) and e1 = m / d1.
 
 private lemma intCast_2ba_eq :
     ((2 * b - a : ℤ) : ZMod m) = ((b - a : ℤ) : ZMod m) + ((b : ℤ) : ZMod m) := by
   push_cast; ring
 
-private lemma ZMod.val_add_one {n : ℕ} [NeZero n] (x : ZMod n) : (x + 1).val = (x.val + 1) % n := by
-  rw [ZMod.val_add, ZMod.val_one_eq_one_mod, Nat.add_mod_mod]
-
-private lemma zmod_val_add_one (d : ℕ) [NeZero d] (_hd : d ≥ 2) (i : ZMod d) :
+private lemma zmod_val_add_one (d : ℕ) [NeZero d] (hd : d ≥ 2) (i : ZMod d) :
     (i + 1).val = if i.val + 1 < d then i.val + 1 else 0 := by
-  rw [ZMod.val_add_one]; split_ifs with h
+  have hival : (i + 1).val = (i.val + 1) % d := by
+    rw [ZMod.val_add]; congr 1
+    haveI : Fact (1 < d) := ⟨by grind⟩; simp [ZMod.val_one]
+  rw [hival]; split_ifs with h
   · exact Nat.mod_eq_of_lt h
   · grind [Nat.mod_self]
 
@@ -2011,12 +2587,17 @@ private lemma color_covers_even (d₁ e₁ : ℕ) [NeZero d₁] [NeZero e₁]
     · exact Or.inl h
     · exact Or.inr (Or.inl h)
 
+private lemma ZMod.val_add_one {n : ℕ} [NeZero n] (x : ZMod n) :
+    (x + 1).val = (x.val + 1) % n := by
+  rw [ZMod.val_add, ZMod.val_one_eq_one_mod, Nat.add_mod_mod]
+
 /--
 The orbit map $\phi : \mathbb{Z}_{d_1} \times \mathbb{Z}_{e_1} \to \mathbb{Z}_m$ defined by
 $\phi(i, j) = i(b-a) + jb \pmod m$. This map is a bijection when $\gcd(b-a, b, m) = 1$.
 It provides the coordinate system used to analyze the "Multiple Cycles" case.
 -/
-private def orbitMap (m : ℕ) (a b : ℤ) (d₁ e₁ : ℕ) : ZMod d₁ × ZMod e₁ → ZMod m :=
+private def orbitMap (m : ℕ) (a b : ℤ) (d₁ e₁ : ℕ) :
+    ZMod d₁ × ZMod e₁ → ZMod m :=
   fun p => (p.1.val : ZMod m) * ↑(b - a) + (p.2.val : ZMod m) * ↑b
 
 private lemma addOrderOf_b_eq {m : ℕ} {b : ℤ} {d₁ : ℕ} (hm : 0 < m)
@@ -2040,8 +2621,10 @@ private lemma ba_coprime_d1 {m : ℕ} {a b : ℤ} {d₁ : ℕ}
     (hd1_dvd : d₁ ∣ m)
     (h_gcd_coprime : d₁.gcd (Nat.gcd (b - a).natAbs m) = 1) :
     Nat.Coprime (b - a).natAbs d₁ :=
-  Nat.dvd_one.mp (h_gcd_coprime ▸ Nat.dvd_gcd (Nat.gcd_dvd_right _ _)
-      (Nat.dvd_gcd (Nat.gcd_dvd_left _ _) (dvd_trans (Nat.gcd_dvd_right _ _) hd1_dvd)))
+  Nat.dvd_one.mp (h_gcd_coprime ▸
+    Nat.dvd_gcd (Nat.gcd_dvd_right _ _)
+      (Nat.dvd_gcd (Nat.gcd_dvd_left _ _)
+        (dvd_trans (Nat.gcd_dvd_right _ _) hd1_dvd)))
 
 private lemma orbitMap_i_eq {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
     [NeZero m] [NeZero d₁]
@@ -2049,7 +2632,8 @@ private lemma orbitMap_i_eq {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
     (hb_zero : (b : ZMod d₁) = 0)
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
     {i₁ i₂ : ZMod d₁} {j₁ j₂ : ZMod e₁}
-    (heq : orbitMap m a b d₁ e₁ (i₁, j₁) = orbitMap m a b d₁ e₁ (i₂, j₂)) :
+    (heq : orbitMap m a b d₁ e₁ (i₁, j₁) =
+           orbitMap m a b d₁ e₁ (i₂, j₂)) :
     i₁ = i₂ := by
   simp only [orbitMap] at heq
   have := congr_arg (ZMod.castHom hd1_dvd (ZMod d₁)) heq
@@ -2057,6 +2641,22 @@ private lemma orbitMap_i_eq {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
   simp only [hb_zero, mul_zero, add_zero, ZMod.natCast_val, ZMod.cast_id] at this
   exact hba_unit.mul_right_cancel this
 
+/- Aristotle alternative for `orbitMap_j_eq` (7 lines vs 10 original, -3).
+   Full proof: `aristotle_results/result_new_orbitMap_j_eq.lean`
+
+private lemma orbitMap_j_eq {m : ℕ} {b : ℤ} {e₁ : ℕ} [NeZero e₁]
+    (hord : addOrderOf (b : ZMod m) = e₁)
+    {j₁ j₂ : ZMod e₁}
+    (hj_smul : (j₁.val : ℕ) • (b : ZMod m) = (j₂.val : ℕ) • (b : ZMod m)) :
+    j₁ = j₂ := by
+      -- Since $j₁.val • b = j₂.val • b$, we have $(j₁.val - j₂.val) • b = 0$.
+      have h_diff_smul : (j₁.val - j₂.val : ℤ) • (b : ZMod m) = 0 := by
+        simp_all +decide [ sub_smul ];
+      -- Since $e₁$ is the order of $b$, we have that $e₁$ divides $(j₁.val - j₂.val)$.
+      have h_div : (e₁ : ℤ) ∣ (j₁.val - j₂.val : ℤ) := by
+        have := hord ▸ addOrderOf_dvd_iff_zsmul_eq_zero.mpr h_diff_smul; aesop;
+      simp_all +decide [ ← ZMod.intCast_zmod_eq_zero_iff_dvd, sub_eq_zero ]
+-/
 private lemma orbitMap_j_eq {m : ℕ} {b : ℤ} {e₁ : ℕ} [NeZero e₁]
     (hord : addOrderOf (b : ZMod m) = e₁)
     {j₁ j₂ : ZMod e₁}
@@ -2073,6 +2673,42 @@ private lemma orbitMap_j_eq {m : ℕ} {b : ℤ} {e₁ : ℕ} [NeZero e₁]
       grind [j₁.val_lt (n := e₁), j₂.val_lt (n := e₁)])
     exact ZMod.val_injective _ (by grind)
 
+/- Aristotle alternative for `orbitMap_injective` (7 lines vs 8 original, -1).
+   Full proof: `aristotle_results/result_new_orbitMap_injective.lean`
+
+private def orbitMap (m : ℕ) (a b : ℤ) (d₁ e₁ : ℕ) :
+    ZMod d₁ × ZMod e₁ → ZMod m :=
+  fun p => (p.1.val : ZMod m) * ↑(b - a) + (p.2.val : ZMod m) * ↑b
+
+    [NeZero m] [NeZero d₁]
+    (hd1_dvd : d₁ ∣ m)
+    (hb_zero : (b : ZMod d₁) = 0)
+    (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
+    {i₁ i₂ : ZMod d₁} {j₁ j₂ : ZMod e₁}
+    (heq : orbitMap m a b d₁ e₁ (i₁, j₁) =
+           orbitMap m a b d₁ e₁ (i₂, j₂)) :
+    i₁ = i₂ := by admit
+
+    (hord : addOrderOf (b : ZMod m) = e₁)
+    {j₁ j₂ : ZMod e₁}
+    (hj_smul : (j₁.val : ℕ) • (b : ZMod m) = (j₂.val : ℕ) • (b : ZMod m)) :
+    j₁ = j₂ := by admit
+
+private lemma orbitMap_injective {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
+    [NeZero m] [NeZero d₁] [NeZero e₁]
+    (hd1_dvd : d₁ ∣ m)
+    (hb_zero : (b : ZMod d₁) = 0)
+    (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
+    (hord : addOrderOf (b : ZMod m) = e₁) :
+    Function.Injective (orbitMap m a b d₁ e₁) := by
+      intro x y hxy
+      have h_i : x.1 = y.1 := by
+        apply orbitMap_i_eq hd1_dvd hb_zero hba_unit hxy
+      have h_j : x.2 = y.2 := by
+        apply orbitMap_j_eq hord;
+        unfold orbitMap at hxy; aesop;
+      aesop
+-/
 private lemma orbitMap_injective {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
     [NeZero m] [NeZero d₁] [NeZero e₁]
     (hd1_dvd : d₁ ∣ m)
@@ -2105,7 +2741,8 @@ private lemma orbitMap_shift_b {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
     [NeZero e₁]
     (he1_b_zero : e₁ • (b : ZMod m) = 0) :
     ∀ p : ZMod d₁ × ZMod e₁,
-      orbitMap m a b d₁ e₁ p + (b : ZMod m) = orbitMap m a b d₁ e₁ (p.1, p.2 + 1) := by
+      orbitMap m a b d₁ e₁ p + (b : ZMod m) =
+        orbitMap m a b d₁ e₁ (p.1, p.2 + 1) := by
   intro ⟨i, j⟩
   simp only [orbitMap]
   by_cases hj : j.val + 1 < e₁
@@ -2123,7 +2760,8 @@ private lemma orbitMap_shift_b {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
 private lemma orbitMap_shift_ba {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero d₁]
     (i : ZMod d₁) (j : ZMod e₁)
     (hi : i.val + 1 < d₁) :
-    orbitMap m a b d₁ e₁ (i, j) + ((b - a : ℤ) : ZMod m) = orbitMap m a b d₁ e₁ (i + 1, j) := by
+    orbitMap m a b d₁ e₁ (i, j) + ((b - a : ℤ) : ZMod m) =
+      orbitMap m a b d₁ e₁ (i + 1, j) := by
   simp only [orbitMap]
   have : (i + 1).val = i.val + 1 := by rw [ZMod.val_add_one]; exact Nat.mod_eq_of_lt hi
   rw [this]; push_cast; ring
@@ -2135,7 +2773,8 @@ private lemma orbitMap_cycle_index {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
     (hb_zero : (b : ZMod d₁) = 0)
     (u : (ZMod d₁)ˣ) (hu : ↑u = ((b - a : ℤ) : ZMod d₁))
     (i : ZMod d₁) (j : ZMod e₁) :
-    ZMod.castHom hd1_dvd (ZMod d₁) (orbitMap m a b d₁ e₁ (i, j)) * u⁻¹ = i := by
+    ZMod.castHom hd1_dvd (ZMod d₁) (orbitMap m a b d₁ e₁ (i, j)) *
+      u⁻¹ = i := by
   simp only [orbitMap]
   rw [map_add, map_mul, map_mul, map_natCast, map_intCast, map_natCast,
     map_intCast, hb_zero, mul_zero, add_zero, mul_assoc,
@@ -2172,12 +2811,9 @@ private lemma equiv_symm_fst_eq {d₁ e₁ : ℕ} {γ : Type*}
   have h := hα (Φ.symm x).1 (Φ.symm x).2
   rw [Equiv.apply_symm_apply] at h; exact h.symm
 
-/-! ### Orbit coloring framework -/
-
-/-- **Key infrastructure for Case 2.** Polychromaticity from an orbit coloring:
-    given an orbit equivalence Φ with shift properties and a coloring f,
-    if f covers all colors at any translate, then f ∘ Φ.symm is polychromatic.
-    All four Case 2 subcases use this as their final step. -/
+/-- Polychromaticity from an orbit coloring.
+    Given an orbit equivalence Φ with shift properties and a coloring f,
+    if f covers all colors at any translate, then f ∘ Φ.symm is polychromatic. -/
 private lemma orbit_coloring_polychrom {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
     [NeZero m] [NeZero d₁] [NeZero e₁]
     (Φ : ZMod d₁ × ZMod e₁ ≃ ZMod m)
@@ -2201,7 +2837,8 @@ private lemma orbit_coloring_polychrom {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
   have hχ_n : χ n = f (i, j) := rfl
   have hχ_nb : χ (n + ↑b) = f (i, j + 1) := congr_arg f (hΦ_add_b n)
   have hi_shift : (Φ.symm (n + ↑(b - a))).1 = i + 1 := hΦ_cycle_shift n
-  have hχ_nba : χ (n + ↑(b - a)) = f (i + 1, j') := congr_arg f (Prod.ext hi_shift rfl)
+  have hχ_nba : χ (n + ↑(b - a)) = f (i + 1, j') :=
+    congr_arg f (Prod.ext hi_shift rfl)
   have hχ_n2ba : χ (n + ↑(2 * b - a)) = f (i + 1, j' + 1) := by
     have : (n : ZMod m) + ↑(2 * b - a) = (n + ↑(b - a)) + ↑b := by
       rw [intCast_2ba_eq, add_assoc]
@@ -2216,10 +2853,13 @@ private lemma orbit_coloring_polychrom {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
   · exact ⟨↑(b - a), by simp, by rw [hχ_nba, h]⟩
   · exact ⟨↑(2 * b - a), by simp, by rw [hχ_n2ba, h]⟩
 
-/-! ### Subcase (2a): e₁ even -/
-
-/-- **Subcase (2a).** $e_1$ is even. Each cycle uses two alternating colors;
-    adjacent cycles skip different colors. The simplest of the four subcases. -/
+/--
+Case 2a: $e_1$ is even.
+The cycles are colored with alternating 01 and 02 patterns.
+Because $e_1$ is even, the patterns alternate perfectly without any degenerate positions.
+Adjacent cycles are assigned different "missing" colors to ensure all 3 colors are covered
+by any translate of the set.
+-/
 lemma case_two_e1_even (hm : m ≥ 289)
     (h_gcd_coprime : (Nat.gcd b.natAbs m).gcd (Nat.gcd (b - a).natAbs m) = 1)
     (h_min : min (Nat.gcd b.natAbs m) (Nat.gcd (b - a).natAbs m) > 1)
@@ -2230,8 +2870,8 @@ lemma case_two_e1_even (hm : m ≥ 289)
   have hd₁_dvd : d₁ ∣ m := Nat.gcd_dvd_right _ _
   have hm_eq : m = d₁ * e₁ := (Nat.mul_div_cancel' hd₁_dvd).symm
   have he₁_ge2 : e₁ ≥ 2 := by
-    have : 0 < e₁ := Nat.div_pos (Nat.le_of_dvd (by grind) hd₁_dvd) (by grind)
-    grind
+    have : 0 < e₁ := Nat.div_pos (Nat.le_of_dvd (by grind) hd₁_dvd)
+      (Nat.pos_of_ne_zero (by intro h; simp [h] at h_min)); grind
   haveI : NeZero m := ⟨by grind⟩
   haveI : NeZero d₁ := ⟨by grind⟩
   haveI : NeZero e₁ := ⟨by grind⟩
@@ -2239,7 +2879,8 @@ lemma case_two_e1_even (hm : m ≥ 289)
   have hba_unit : IsUnit (Int.cast (b - a) : ZMod d₁) :=
     isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 hd₁_dvd h_gcd_coprime)
   -- addOrderOf b in ZMod m is e₁
-  have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind) rfl
+  have hord : addOrderOf (b : ZMod m) = e₁ :=
+    addOrderOf_b_eq (by grind) rfl
   have he1_b : e₁ • (b : ZMod m) = 0 := hord ▸ addOrderOf_nsmul_eq_zero _
   -- Define the cycle map φ = orbitMap and derive bijectivity from shared infrastructure
   let φ := orbitMap m a b d₁ e₁
@@ -2247,24 +2888,28 @@ lemma case_two_e1_even (hm : m ≥ 289)
       φ (i, j + 1) = φ (i, j) + ↑b := by
     intro i j; exact (orbitMap_shift_b he1_b (i, j)).symm
   -- φ is bijective (from shared orbitMap infrastructure)
-  let Φ := Equiv.ofBijective φ (orbitMap_bijective hm_eq hd₁_dvd hb_zero hba_unit hord)
+  let Φ := Equiv.ofBijective φ
+    (orbitMap_bijective hm_eq hd₁_dvd hb_zero hba_unit hord)
   -- Cycle index function α : ZMod m → ZMod d₁
   obtain ⟨u_ba, hu_ba⟩ := hba_unit
   let α : ZMod m → ZMod d₁ :=
     fun x => ZMod.castHom hd₁_dvd (ZMod d₁) x * u_ba⁻¹
-  have hα_ba : ∀ x, α (x + ↑(b - a)) = α x + 1 := cycle_index_shift_ba hd₁_dvd u_ba hu_ba
+  have hα_ba : ∀ x, α (x + ↑(b - a)) = α x + 1 :=
+    cycle_index_shift_ba hd₁_dvd u_ba hu_ba
   have hα_φ : ∀ i : ZMod d₁, ∀ j : ZMod e₁, α (φ (i, j)) = i :=
     orbitMap_cycle_index hd₁_dvd hb_zero u_ba hu_ba
   have hΦ_add_b := equiv_symm_shift_b Φ hφ_add_b
   have hΦ_cycle := equiv_symm_fst_eq Φ α hα_φ
   have hd₁_ge2 : d₁ ≥ 2 := by grind
-  have hparity : ∀ j : ZMod e₁, j.val % 2 ≠ (j + 1).val % 2 := parity_flip_even e₁ he1_even he₁_ge2
-  exact orbit_coloring_polychrom Φ hΦ_add_b
-    (fun x => by rw [hΦ_cycle, hα_ba, ← hΦ_cycle])
-    (cycle_coloring d₁ e₁)
+  have hparity : ∀ j : ZMod e₁, j.val % 2 ≠ (j + 1).val % 2 :=
+    parity_flip_even e₁ he1_even he₁_ge2
+  have hΦ_cycle_shift : ∀ x : ZMod m,
+      (Φ.symm (x + ↑(b - a))).1 = (Φ.symm x).1 + 1 := fun x => by
+    rw [hΦ_cycle, hα_ba, ← hΦ_cycle]
+  exact orbit_coloring_polychrom Φ hΦ_add_b hΦ_cycle_shift (cycle_coloring d₁ e₁)
     (fun n k => color_covers_even d₁ e₁ hd₁_ge2 hparity _ _ _ k)
 
-/-! ### Subcase (2b) construction: d₁ even, e₁ odd
+/-! #### Case (2b): d₁ even, e₁ odd
 
 The coloring assigns each even cycle the pattern `01010…011` and each odd cycle
 the pattern `22020…020`. The degenerate pairs `{1,1}` and `{2,2}` occur at
@@ -2362,18 +3007,23 @@ private lemma case2b_coverage_gen (d₁ e₁ : ℕ) [NeZero d₁] [NeZero e₁]
     have hi1 : (i + 1).val % 2 = 1 := by grind
     fin_cases k
     · -- k = 0: by contradiction via degenerate position argument
-      by_contra! h_not
+      by_contra h_not
+      push_neg at h_not
       have hev1 : case2b_coloring d₁ e₁ (i, j₁) = 1 :=
-        case2b_fin3_eq_one (fun h => h_not.1 h.symm) (case2b_even_ne_two d₁ e₁ i j₁ hi)
+        case2b_fin3_eq_one (fun h => h_not.1 h.symm)
+          (case2b_even_ne_two d₁ e₁ i j₁ hi)
       have hev2 : case2b_coloring d₁ e₁ (i, j₁ + 1) = 1 :=
-        case2b_fin3_eq_one (fun h => h_not.2.1 h.symm) (case2b_even_ne_two d₁ e₁ i (j₁ + 1) hi)
+        case2b_fin3_eq_one (fun h => h_not.2.1 h.symm)
+          (case2b_even_ne_two d₁ e₁ i (j₁ + 1) hi)
       have hod1 : case2b_coloring d₁ e₁ (i + 1, j₂) = 2 :=
-        case2b_fin3_eq_two (fun h => h_not.2.2.1 h.symm) (case2b_odd_ne_one d₁ e₁ (i + 1) j₂ hi1)
+        case2b_fin3_eq_two (fun h => h_not.2.2.1 h.symm)
+          (case2b_odd_ne_one d₁ e₁ (i + 1) j₂ hi1)
       have hod2 : case2b_coloring d₁ e₁ (i + 1, j₂ + 1) = 2 :=
         case2b_fin3_eq_two (fun h => h_not.2.2.2 h.symm)
           (case2b_odd_ne_one d₁ e₁ (i + 1) (j₂ + 1) hi1)
       have hj1_eq := case2b_even_degenerate_pos d₁ e₁ he₁ i j₁ hi hev1 hev2
-      have hj2_eq := case2b_odd_degenerate_pos d₁ e₁ he₁_odd he₁ (i + 1) j₂ hi1 hod1 hod2
+      have hj2_eq := case2b_odd_degenerate_pos d₁ e₁ he₁_odd he₁
+        (i + 1) j₂ hi1 hod1 hod2
       exact absurd hj1_eq (h_compat' hj2_eq)
     · -- k = 1: appears in even row
       rcases case2b_even_has_one d₁ e₁ he₁_ge2 i j₁ hi with h | h
@@ -2388,13 +3038,17 @@ private lemma case2b_coverage_gen (d₁ e₁ : ℕ) [NeZero d₁] [NeZero e₁]
     have hi1 : (i + 1).val % 2 = 0 := by grind
     fin_cases k
     · -- k = 0: by contradiction
-      by_contra! h_not
+      by_contra h_not
+      push_neg at h_not
       have hod1 : case2b_coloring d₁ e₁ (i, j₁) = 2 :=
-        case2b_fin3_eq_two (fun h => h_not.1 h.symm) (case2b_odd_ne_one d₁ e₁ i j₁ hi)
+        case2b_fin3_eq_two (fun h => h_not.1 h.symm)
+          (case2b_odd_ne_one d₁ e₁ i j₁ hi)
       have hod2 : case2b_coloring d₁ e₁ (i, j₁ + 1) = 2 :=
-        case2b_fin3_eq_two (fun h => h_not.2.1 h.symm) (case2b_odd_ne_one d₁ e₁ i (j₁ + 1) hi)
+        case2b_fin3_eq_two (fun h => h_not.2.1 h.symm)
+          (case2b_odd_ne_one d₁ e₁ i (j₁ + 1) hi)
       have hev1 : case2b_coloring d₁ e₁ (i + 1, j₂) = 1 :=
-        case2b_fin3_eq_one (fun h => h_not.2.2.1 h.symm) (case2b_even_ne_two d₁ e₁ (i + 1) j₂ hi1)
+        case2b_fin3_eq_one (fun h => h_not.2.2.1 h.symm)
+          (case2b_even_ne_two d₁ e₁ (i + 1) j₂ hi1)
       have hev2 : case2b_coloring d₁ e₁ (i + 1, j₂ + 1) = 1 :=
         case2b_fin3_eq_one (fun h => h_not.2.2.2 h.symm)
           (case2b_even_ne_two d₁ e₁ (i + 1) (j₂ + 1) hi1)
@@ -2410,11 +3064,14 @@ private lemma case2b_coverage_gen (d₁ e₁ : ℕ) [NeZero d₁] [NeZero e₁]
       · exact Or.inl h.symm
       · exact Or.inr (Or.inl h.symm)
 
-/-! ### Subcase (2b) main lemma -/
-
-/-- **Subcase (2b).** $d_1$ is even and $e_1$ is odd.
-    Alternating patterns with a "degenerate" position fixup at different positions
-    for even and odd cycles, ensuring they do not overlap across adjacent cycles. -/
+/--
+Case 2b: $d_1$ is even and $e_1$ is odd.
+Even cycles use the pattern `0101...011`, and odd cycles use `22020...020`.
+Because $e_1$ is odd, a perfect alternating pattern would have one "degenerate" pair
+at the boundary ($e_1 - 1, 0$). The strategy here places these degenerate pairs
+at different positions for even and odd cycles so that they do not overlap
+when the set $S$ spans two adjacent cycles.
+-/
 lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
     (h_gcd_coprime : (Nat.gcd b.natAbs m).gcd (Nat.gcd (b - a).natAbs m) = 1)
     (h_min : min (Nat.gcd b.natAbs m) (Nat.gcd (b - a).natAbs m) > 1)
@@ -2427,9 +3084,10 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
   have hd₁_pos : 0 < d₁ := Nat.pos_of_ne_zero (by intro h; simp [h] at h_min)
   have hm_eq : m = d₁ * e₁ := (Nat.mul_div_cancel' hd₁_dvd).symm
   -- e₁ ≥ 3: e₁ is odd and e₁ = 1 would give d₁ = m, contradicting gcd(d₁,d₂) = 1
-  have he₁_pos : 0 < e₁ := Nat.div_pos (Nat.le_of_dvd (by grind) hd₁_dvd) hd₁_pos
+  have he₁_pos : 0 < e₁ :=
+    Nat.div_pos (Nat.le_of_dvd (by grind) hd₁_dvd) hd₁_pos
   have he₁_ge3 : e₁ ≥ 3 := by
-    by_contra! h
+    by_contra h; push_neg at h
     rcases (by grind : e₁ = 1 ∨ e₁ = 2) with he | he
     · have hba_dvd_d₁ : Nat.gcd (b - a).natAbs m ∣ d₁ := by
         rw [hm_eq, he, mul_one]; exact Nat.gcd_dvd_right _ _
@@ -2446,7 +3104,8 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
   have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind) rfl
   have he1_b : e₁ • (b : ZMod m) = 0 := hord ▸ addOrderOf_nsmul_eq_zero _
   -- b/d₁ is coprime to e₁ (needed for compatibility argument)
-  have hd₁_dvd_b : (d₁ : ℤ) ∣ b := (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp hb_zero
+  have hd₁_dvd_b : (d₁ : ℤ) ∣ b :=
+    (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp hb_zero
   obtain ⟨q, hq⟩ := hd₁_dvd_b
   have hq_cop : Nat.Coprime q.natAbs e₁ := by
     have : q.natAbs = b.natAbs / d₁ := by
@@ -2454,7 +3113,8 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
     rw [this]; exact Nat.coprime_div_gcd_div_gcd hd₁_pos
   -- Define the cycle map φ = orbitMap and derive bijectivity from shared infrastructure
   let φ := orbitMap m a b d₁ e₁
-  let Φ := Equiv.ofBijective φ (orbitMap_bijective hm_eq hd₁_dvd hb_zero hba_unit hord)
+  let Φ := Equiv.ofBijective φ
+    (orbitMap_bijective hm_eq hd₁_dvd hb_zero hba_unit hord)
   have hφ_add_b : ∀ i : ZMod d₁, ∀ j : ZMod e₁,
       φ (i, j + 1) = φ (i, j) + ↑b := by
     intro i j; exact (orbitMap_shift_b he1_b (i, j)).symm
@@ -2462,7 +3122,8 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
   obtain ⟨u_ba, hu_ba⟩ := hba_unit
   let α : ZMod m → ZMod d₁ :=
     fun x => ZMod.castHom hd₁_dvd (ZMod d₁) x * u_ba⁻¹
-  have hα_ba : ∀ x, α (x + ↑(b - a)) = α x + 1 := cycle_index_shift_ba hd₁_dvd u_ba hu_ba
+  have hα_ba : ∀ x, α (x + ↑(b - a)) = α x + 1 :=
+    cycle_index_shift_ba hd₁_dvd u_ba hu_ba
   have hα_φ : ∀ i : ZMod d₁, ∀ j : ZMod e₁, α (φ (i, j)) = i :=
     orbitMap_cycle_index hd₁_dvd hb_zero u_ba hu_ba
   have hΦ_add_b := equiv_symm_shift_b Φ hφ_add_b
@@ -2492,7 +3153,8 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
     apply isUnit_intCast_of_natAbs_coprime
     -- gcd(b.natAbs, d₂) = 1: since d₂ coprime to d₁, and b = d₁*q with gcd(q,e₁)=1
     rw [hq, Int.natAbs_mul, Int.natAbs_natCast]
-    exact Nat.Coprime.mul_left h_gcd_coprime (hq_cop.coprime_dvd_right hd₂_dvd_e₁)
+    exact Nat.Coprime.mul_left h_gcd_coprime
+      (hq_cop.coprime_dvd_right hd₂_dvd_e₁)
   -- Degenerate positions can't coincide: use d₂ | (j-j') from projection
   -- π(n+(b-a)) = π(n) since π(b-a)=0, combined with π(φ(i,j))=j.val*π(b)
   -- gives d₂ | (j.val - j'.val). Then d₂ | e₁ and d₂ > 1, so e₁-2 and 0
@@ -2503,15 +3165,14 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
     intro j₁ j₂ heq hj₁ hj₂
     have hval_eq := hπ_b_unit.mul_right_cancel heq
     rw [hj₁, hj₂, Nat.cast_zero] at hval_eq
-    have hd₂_dvd_diff : d₂ ∣ (e₁ - 2) := (ZMod.natCast_eq_zero_iff _ _).mp hval_eq.symm
+    have hd₂_dvd_diff : d₂ ∣ (e₁ - 2) :=
+      (ZMod.natCast_eq_zero_iff _ _).mp hval_eq.symm
     have hd₂_dvd_2 : d₂ ∣ 2 := by
-      have := Nat.dvd_sub hd₂_dvd_e₁ hd₂_dvd_diff
-      have : e₁ - (e₁ - 2) = 2 := by grind
-      grind
-    obtain ⟨k, hk⟩ := hd₂_dvd_e₁
-    obtain ⟨l, hl⟩ := he1_odd
-    have := Nat.le_of_dvd (by grind) hd₂_dvd_2
-    grind
+      have h := Nat.dvd_sub hd₂_dvd_e₁ hd₂_dvd_diff
+      have h2 : e₁ - (e₁ - 2) = 2 := by grind
+      rwa [h2] at h
+    have hd₂_eq2 : d₂ = 2 := by have := Nat.le_of_dvd (by grind) hd₂_dvd_2; grind
+    obtain ⟨k, hk⟩ := hd₂_dvd_e₁; obtain ⟨l, hl⟩ := he1_odd; grind
   -- Define coloring and prove polychromaticity via orbit helper
   have hΦ_cycle_shift : ∀ x : ZMod m,
       (Φ.symm (x + ↑(b - a))).1 = (Φ.symm x).1 + 1 := fun x => by
@@ -2520,15 +3181,21 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
   have hπ_eq : ∀ n : ZMod m, π (n + ↑(b - a)) = π n := fun n => by
     simp only [π, map_add, map_intCast]
     rw [(ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mpr hd₂_dvd_ba, add_zero]
-  exact orbit_coloring_polychrom Φ hΦ_add_b hΦ_cycle_shift (case2b_coloring d₁ e₁) (fun n k => by
+  exact orbit_coloring_polychrom Φ hΦ_add_b hΦ_cycle_shift (case2b_coloring d₁ e₁)
+    (fun n k => by
       set p := Φ.symm n; set j := p.2
       set j' := (Φ.symm (n + ↑(b - a))).2
+      -- π(n) and π(n+(b-a)) give the same ZMod d₂ value
+      have hπ_eq : π (n + ↑(b - a)) = π n := by
+        simp only [π, map_add, map_intCast]
+        rw [(ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mpr hd₂_dvd_ba, add_zero]
       have hπn : π n = (j.val : ZMod d₂) * π (↑b) := by
         have : n = Φ p := (Equiv.apply_symm_apply Φ n).symm
         conv_lhs => rw [this]; exact hπ_φ p.1 j
       have hπn' : π n = (j'.val : ZMod d₂) * π (↑b) := by
         rw [← hπ_eq]
-        have : n + ↑(b - a) = Φ (Φ.symm (n + ↑(b - a))) := (Equiv.apply_symm_apply Φ _).symm
+        have : n + ↑(b - a) = Φ (Φ.symm (n + ↑(b - a))) :=
+          (Equiv.apply_symm_apply Φ _).symm
         conv_lhs => rw [this]; exact hπ_φ _ j'
       have hπ_jj' := hπn.symm.trans hπn'
       exact case2b_coverage_gen d₁ e₁ hd1_even he1_odd he₁_ge3 _ j j'
@@ -2545,6 +3212,20 @@ private def case2c_pattern (d₁ k₀ i : ℕ) : Fin 3 :=
   else if k₀ % 3 = 2 then 2 else 1
 
 -- General coverage: if (j₁ + p₁) % 3 ≠ (j₂ + p₂) % 3, all 3 colors appear.
+/- Aristotle alternative for `cover_mod3_general` (2 lines vs 3 original, -1).
+   Full proof: `aristotle_results/result_cover_mod3_general.lean`
+
+private lemma cover_mod3_general (p₁ p₂ : Fin 3)
+    (j₁ j₂ : ℕ)
+    (hne : (j₁ + p₁.val) % 3 ≠ (j₂ + p₂.val) % 3)
+    (k : Fin 3) :
+    k = ⟨(j₁ + p₁.val) % 3, Nat.mod_lt _ (by omega)⟩ ∨
+    k = ⟨(j₁ + 1 + p₁.val) % 3, Nat.mod_lt _ (by omega)⟩ ∨
+    k = ⟨(j₂ + p₂.val) % 3, Nat.mod_lt _ (by omega)⟩ ∨
+    k = ⟨(j₂ + 1 + p₂.val) % 3, Nat.mod_lt _ (by omega)⟩ := by
+      fin_cases k <;> simp +decide [ Fin.ext_iff ] at * <;> omega
+      skip
+-/
 private lemma cover_mod3_general (p₁ p₂ : Fin 3)
     (j₁ j₂ : ℕ)
     (hne : (j₁ + p₁.val) % 3 ≠ (j₂ + p₂.val) % 3)
@@ -2553,7 +3234,7 @@ private lemma cover_mod3_general (p₁ p₂ : Fin 3)
     k = ⟨(j₁ + 1 + p₁.val) % 3, Nat.mod_lt _ (by grind)⟩ ∨
     k = ⟨(j₂ + p₂.val) % 3, Nat.mod_lt _ (by grind)⟩ ∨
     k = ⟨(j₂ + 1 + p₂.val) % 3, Nat.mod_lt _ (by grind)⟩ := by
-  by_contra! hall
+  by_contra hall; push_neg at hall
   obtain ⟨h1, h2, h3, h4⟩ := hall
   grind [Fin.ext_iff]
 
@@ -2573,12 +3254,10 @@ private lemma case2c_wrap_hyp (d₁ k₀ j : ℕ) (hd₁ : d₁ ≥ 3)
   obtain ⟨k, hk⟩ := hd₁_odd; subst hk
   grind [case2c_pattern]
 
-/-! ### Subcase (2d): d₁, e₁ both odd, e₁ ≥ 19
+/-! ### Case (2d): d₁, e₁ both odd, e₁ ≥ 19
 
-The most technically involved subcase. The base pattern on C₀ uses three
-alternating bicolor intervals of sizes u, v, w. Each subsequent cycle is a
-rotation of C₀. The many private lemmas below are technical helpers for
-verifying the rotation property; the important result is `case2d_coloring_works`.
+The base pattern on C₀ uses three alternating bicolor intervals of sizes u, v, w.
+Each subsequent cycle is a rotation of C₀. The rotation amount must be in [u, e₁-u].
 -/
 
 /-- Partition parameter: first interval size for case 2d.
@@ -2593,7 +3272,8 @@ private def case2d_v (e₁ : ℕ) : ℕ :=
   if e₁ % 3 = 1 then e₁ / 3 + 1 else e₁ / 3
 
 
-private lemma case2d_uv_le {e₁ : ℕ} (hge : e₁ ≥ 19) : case2d_u e₁ + case2d_v e₁ ≤ e₁ := by
+private lemma case2d_uv_le {e₁ : ℕ} (hge : e₁ ≥ 19) :
+    case2d_u e₁ + case2d_v e₁ ≤ e₁ := by
   grind [case2d_u, case2d_v]
 
 /-- The base pattern: three alternating bicolor intervals on {0,...,e₁-1}.
@@ -2625,12 +3305,25 @@ private def intervalColors : Fin 3 → Finset (Fin 3)
   | 2 => {0, 2}
 
 /-- Any two distinct interval color pairs union to {0, 1, 2}. -/
+/- Aristotle alternative for `intervalColors_union_covers` (1 lines vs 2 original, -1).
+   Full proof: `aristotle_results/result_intervalColors_union_covers.lean`
+
+private def intervalColors : Fin 3 → Finset (Fin 3)
+  | 0 => {0, 1}
+  | 1 => {1, 2}
+  | 2 => {0, 2}
+
+private lemma intervalColors_union_covers {i₁ i₂ : Fin 3} (h : i₁ ≠ i₂) :
+    ∀ k : Fin 3, k ∈ intervalColors i₁ ∨ k ∈ intervalColors i₂ := by
+      native_decide +revert
+-/
 private lemma intervalColors_union_covers {i₁ i₂ : Fin 3} (h : i₁ ≠ i₂) :
     ∀ k : Fin 3, k ∈ intervalColors i₁ ∨ k ∈ intervalColors i₂ := by
   intro k; fin_cases i₁ <;> fin_cases i₂ <;> fin_cases k <;>
     simp_all [intervalColors, Finset.mem_insert, Finset.mem_singleton]
 
-/-- Consecutive positions (j, j+1) within the same interval produce both colors of that interval. -/
+/-- Consecutive positions (j, j+1) within the same interval produce
+    both colors of that interval. -/
 private lemma basePattern_consec_same_interval {e₁ j : ℕ}
     (hsame : whichInterval e₁ j = whichInterval e₁ (j + 1)) :
     {basePattern e₁ j, basePattern e₁ (j + 1)} = intervalColors (whichInterval e₁ j) := by
@@ -2646,7 +3339,8 @@ private lemma basePattern_consec_same_interval {e₁ j : ℕ}
 private lemma basePattern_consec_boundary {e₁ j : ℕ}
     (he : Odd e₁) (hge : e₁ ≥ 19) (hj : j < e₁)
     (hdiff : whichInterval e₁ j ≠ whichInterval e₁ ((j + 1) % e₁)) :
-    {basePattern e₁ j, basePattern e₁ ((j + 1) % e₁)} = intervalColors (whichInterval e₁ j) := by
+    {basePattern e₁ j, basePattern e₁ ((j + 1) % e₁)} =
+      intervalColors (whichInterval e₁ j) := by
   obtain ⟨ku, hku⟩ : Odd (case2d_u e₁) := by obtain ⟨k, hk⟩ := he; grind [case2d_u]
   obtain ⟨kv, hkv⟩ : Odd (case2d_v e₁) := by obtain ⟨k, hk⟩ := he; grind [case2d_v]
   obtain ⟨kw, hkw⟩ : Odd (e₁ - case2d_u e₁ - case2d_v e₁) := by
@@ -2668,7 +3362,8 @@ private lemma basePattern_consec_boundary {e₁ j : ℕ}
     interval pair of whichInterval(j). -/
 private lemma basePattern_consec_pair {e₁ j : ℕ}
     (he : Odd e₁) (hge : e₁ ≥ 19) (hj : j < e₁) :
-    intervalColors (whichInterval e₁ j) ⊆ {basePattern e₁ j, basePattern e₁ ((j + 1) % e₁)} := by
+    intervalColors (whichInterval e₁ j) ⊆
+      {basePattern e₁ j, basePattern e₁ ((j + 1) % e₁)} := by
   by_cases hsame : whichInterval e₁ j = whichInterval e₁ ((j + 1) % e₁)
   · -- Same interval: j+1 < e₁ (otherwise wrap changes interval)
     have hj1 : j + 1 < e₁ := by
@@ -2712,10 +3407,86 @@ private lemma rotation_changes_interval {e₁ j : ℕ}
 
 /-- Key polychromaticity lemma: if the base pattern is rotated by r ∈ [u, e₁-u],
     then at every position j, the 2×2 block covers all 3 colors. -/
+/- Aristotle alternative for `basePattern_rotation_covers` (15 lines vs 19 original, -4).
+   Full proof: `aristotle_results/result_basePattern_rotation_covers.lean`
+
+private def case2d_u (e₁ : ℕ) : ℕ := e₁ / 3 + e₁ % 3
+
+  if e₁ % 3 = 1 then e₁ / 3 + 1 else e₁ / 3
+
+    Odd (e₁ - case2d_u e₁ - case2d_v e₁) := by admit
+
+    case2d_u e₁ + case2d_v e₁ ≤ e₁ := by admit
+
+    e₁ - (case2d_u e₁ + case2d_v e₁) ≤ case2d_u e₁ := by admit
+
+private def basePattern (e₁ : ℕ) (j : ℕ) : Fin 3 :=
+  let u := case2d_u e₁
+  let v := case2d_v e₁
+  if j < u then
+    if j % 2 = 0 then 0 else 1
+  else if j < u + v then
+    if (j - u) % 2 = 0 then 1 else 2
+  else
+    if (j - u - v) % 2 = 0 then 2 else 0
+
+private def whichInterval (e₁ j : ℕ) : Fin 3 :=
+  let u := case2d_u e₁
+  let v := case2d_v e₁
+  if j < u then 0
+  else if j < u + v then 1
+  else 2
+
+  | 0 => {0, 1}
+  | 1 => {1, 2}
+  | 2 => {0, 2}
+
+    ∀ k : Fin 3, k ∈ intervalColors i₁ ∨ k ∈ intervalColors i₂ := by admit
+
+    (hsame : whichInterval e₁ j = whichInterval e₁ (j + 1)) :
+    {basePattern e₁ j, basePattern e₁ (j + 1)} = intervalColors (whichInterval e₁ j) := by admit
+
+    (he : Odd e₁) (hge : e₁ ≥ 19) (hj : j < e₁)
+    (hdiff : whichInterval e₁ j ≠ whichInterval e₁ ((j + 1) % e₁)) :
+    {basePattern e₁ j, basePattern e₁ ((j + 1) % e₁)} =
+      intervalColors (whichInterval e₁ j) := by admit
+
+    (he : Odd e₁) (hge : e₁ ≥ 19) (hj : j < e₁) :
+    intervalColors (whichInterval e₁ j) ⊆
+      {basePattern e₁ j, basePattern e₁ ((j + 1) % e₁)} := by admit
+
+    (hge : e₁ ≥ 19) (hj : j < e₁)
+    {r : ℕ} (hr_lo : case2d_u e₁ ≤ r) (hr_hi : r ≤ e₁ - case2d_u e₁) :
+    whichInterval e₁ j ≠ whichInterval e₁ ((j + r) % e₁) := by admit
+
 private lemma basePattern_rotation_covers {e₁ j : ℕ} (he : Odd e₁) (hge : e₁ ≥ 19)
     {r : ℕ} (hr_lo : case2d_u e₁ ≤ r) (hr_hi : r ≤ e₁ - case2d_u e₁)
     (hj : j < e₁) :
-    ∀ k : Fin 3, k ∈ ({basePattern e₁ j, basePattern e₁ ((j + 1) % e₁),
+    ∀ k : Fin 3, k ∈
+      ({basePattern e₁ j, basePattern e₁ ((j + 1) % e₁),
+        basePattern e₁ ((j + r) % e₁),
+        basePattern e₁ ((j + r + 1) % e₁)} : Finset (Fin 3)) := by
+          -- By definition of $basePattern$, we know that $basePattern e₁ j$ and $basePattern e₁ ((j + 1) % e₁)$ cover all three colors.
+          have h_basePattern_j : intervalColors (whichInterval e₁ j) ⊆ {basePattern e₁ j, basePattern e₁ ((j + 1) % e₁)} := by
+            exact basePattern_consec_pair he hge hj
+          have h_basePattern_r : intervalColors (whichInterval e₁ ((j + r) % e₁)) ⊆ {basePattern e₁ ((j + r) % e₁), basePattern e₁ ((j + r + 1) % e₁)} := by
+            convert basePattern_consec_pair he hge _ using 1;
+            · norm_num [ add_assoc, Nat.mod_eq_of_lt hj ];
+            · exact Nat.mod_lt _ ( by linarith )
+          have h_union : intervalColors (whichInterval e₁ j) ∪ intervalColors (whichInterval e₁ ((j + r) % e₁)) = Finset.univ := by
+            have h_union : whichInterval e₁ j ≠ whichInterval e₁ ((j + r) % e₁) := by
+              apply rotation_changes_interval hge hj hr_lo hr_hi;
+            have h_union : ∀ i₁ i₂ : Fin 3, i₁ ≠ i₂ → intervalColors i₁ ∪ intervalColors i₂ = Finset.univ := by
+              native_decide +revert;
+            exact h_union _ _ ‹_›;
+          intro k; replace h_union := Finset.ext_iff.mp h_union k; simp_all +decide [ Finset.subset_iff ] ;
+          grind +ring
+-/
+private lemma basePattern_rotation_covers {e₁ j : ℕ} (he : Odd e₁) (hge : e₁ ≥ 19)
+    {r : ℕ} (hr_lo : case2d_u e₁ ≤ r) (hr_hi : r ≤ e₁ - case2d_u e₁)
+    (hj : j < e₁) :
+    ∀ k : Fin 3, k ∈
+      ({basePattern e₁ j, basePattern e₁ ((j + 1) % e₁),
         basePattern e₁ ((j + r) % e₁),
         basePattern e₁ ((j + r + 1) % e₁)} : Finset (Fin 3)) := by
   intro k
@@ -2725,7 +3496,8 @@ private lemma basePattern_rotation_covers {e₁ j : ℕ} (he : Odd e₁) (hge : 
   have hjr : (j + r) % e₁ < e₁ := Nat.mod_lt _ he₁_pos
   have h2 := basePattern_consec_pair he hge hjr
   -- Rewrite ((j + r) % e₁ + 1) % e₁ = (j + r + 1) % e₁
-  have hmod : ((j + r) % e₁ + 1) % e₁ = (j + r + 1) % e₁ := Nat.mod_add_mod (j + r) e₁ 1
+  have hmod : ((j + r) % e₁ + 1) % e₁ = (j + r + 1) % e₁ :=
+    Nat.mod_add_mod (j + r) e₁ 1
   rw [hmod] at h2
   have hcov := intervalColors_union_covers hI k
   simp only [Finset.mem_insert, Finset.mem_singleton]
@@ -2772,6 +3544,13 @@ private lemma case2d_wrap_shift {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
   simp only [nsmul_eq_mul] at hφq ⊢
   exact hφq.symm
 
+/- Aristotle alternative for `case2d_shift_ba_wrap` (13 lines vs 23 original, -10).
+   Full proof: `aristotle_results/result_case2d_shift_ba_wrap.lean`
+
+private def orbitMap (m : ℕ) (a b : ℤ) (d₁ e₁ : ℕ) :
+    ZMod d₁ × ZMod e₁ → ZMod m :=
+  fun p => (p.1.val : ZMod m) * ↑(b - a) + (p.2.val : ZMod m) * ↑b
+
 private lemma case2d_shift_ba_wrap {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
     [NeZero e₁] [NeZero d₁]
     (he1_b_zero : e₁ • (b : ZMod m) = 0)
@@ -2779,7 +3558,31 @@ private lemma case2d_shift_ba_wrap {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
     (hk₀ : (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m))
     (i : ZMod d₁) (hi : i.val = d₁ - 1) :
     ∀ (j : ZMod e₁),
-      orbitMap m a b d₁ e₁ (i, j) + ((b - a : ℤ) : ZMod m) = orbitMap m a b d₁ e₁ (0, j + k₀) := by
+      orbitMap m a b d₁ e₁ (i, j) + ((b - a : ℤ) : ZMod m) =
+        orbitMap m a b d₁ e₁ (0, j + k₀) := by
+          -- Substitute $i.val = d₁ - 1$ into the orbit map expression.
+          have h_orbit_map_subst : ∀ j : ZMod e₁, orbitMap m a b d₁ e₁ (i, j) = (d₁ - 1) * (b - a) + j.val * b := by
+            -- Substitute $i.val = d₁ - 1$ into the orbit map expression and simplify.
+            intros j
+            simp [orbitMap, hi];
+            rw [ Nat.cast_pred ( NeZero.pos d₁ ) ];
+          simp_all +decide [ sub_mul, add_mul, Finset.sum_add_distrib ];
+          intro j; rw [ show orbitMap m a b d₁ e₁ ( 0, j + k₀ ) = ( ( j + k₀ ).val : ZMod m ) * ( b : ZMod m ) by unfold orbitMap; simp +decide ] ; ring;
+          cases e₁ <;> simp_all +decide [ ZMod.val_add ] ; ring;
+          rw [ Nat.mod_def ] ; ring;
+          rw [ Nat.cast_sub ] <;> norm_num ; ring;
+          · grind;
+          · nlinarith [ Nat.div_mul_le_self ( j.val + k₀.val ) ( 1 + ‹_› ), show j.val < ‹_› + 1 from j.val_lt, show k₀.val < ‹_› + 1 from k₀.val_lt ]
+-/
+private lemma case2d_shift_ba_wrap {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
+    [NeZero e₁] [NeZero d₁]
+    (he1_b_zero : e₁ • (b : ZMod m) = 0)
+    (k₀ : ZMod e₁)
+    (hk₀ : (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m))
+    (i : ZMod d₁) (hi : i.val = d₁ - 1) :
+    ∀ (j : ZMod e₁),
+      orbitMap m a b d₁ e₁ (i, j) + ((b - a : ℤ) : ZMod m) =
+        orbitMap m a b d₁ e₁ (0, j + k₀) := by
   intro j
   simp only [orbitMap, ZMod.val_zero, Nat.cast_zero, zero_mul, zero_add]
   have hpred : (d₁ - 1 + 1 : ℕ) = d₁ := Nat.succ_pred (NeZero.ne d₁)
@@ -2806,6 +3609,49 @@ private lemma case2d_shift_ba_wrap {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
 
 /-- Given d₁ ≥ 3 values each in [u, e₁-u] can sum to any target mod e₁,
     since the range has width ≥ e₁/3 and d₁ ≥ 3. -/
+/- Aristotle alternative for `case2d_rotation_sum_exists` (31 lines vs 80 original, -49).
+   Full proof: `aristotle_results/result_case2d_rotation_sum_exists.lean`
+
+private def case2d_u (e₁ : ℕ) : ℕ := e₁ / 3 + e₁ % 3
+
+private lemma case2d_rotation_sum_exists {e₁ d₁ : ℕ} [NeZero d₁]
+    (hd1_ge : d₁ ≥ 5) (he1_ge : e₁ ≥ 19) (he1_odd : Odd e₁)
+    (target : ℕ) :
+    ∃ vals : ZMod d₁ → ℕ,
+      (∀ i, case2d_u e₁ ≤ vals i ∧ vals i ≤ e₁ - case2d_u e₁) ∧
+      (Finset.univ.sum vals) % e₁ = target % e₁ := by
+        -- Since the range is symmetric around the midpoint, we can adjust the elements to reach any residue.
+        have h_symm : ∀ r : ℕ, r < e₁ → ∃ vals : ZMod d₁ → ℕ, (∀ i, case2d_u e₁ ≤ vals i ∧ vals i ≤ e₁ - case2d_u e₁) ∧ (Finset.sum Finset.univ vals) % e₁ = r % e₁ := by
+          intro r hr
+          obtain ⟨k, hk⟩ : ∃ k : ℕ, (case2d_u e₁ * d₁ + k * 1) % e₁ = r % e₁ ∧ k ≤ (e₁ - 2 * case2d_u e₁) * d₁ := by
+            -- Since $e₁$ is odd and $case2d_u e₁$ is an integer, we can find $k$ such that $(case2d_u e₁ * d₁ + k) \equiv r \pmod{e₁}$.
+            obtain ⟨k, hk⟩ : ∃ k : ℕ, (case2d_u e₁ * d₁ + k) % e₁ = r % e₁ ∧ k < e₁ := by
+              use ( r + e₁ - ( case2d_u e₁ * d₁ ) % e₁ ) % e₁;
+              norm_num [ Nat.add_mod ];
+              exact ⟨ by simp +decide [ add_tsub_cancel_of_le ( show case2d_u e₁ * d₁ % e₁ ≤ r + e₁ from by linarith [ Nat.zero_le ( case2d_u e₁ * d₁ % e₁ ), Nat.mod_lt ( case2d_u e₁ * d₁ ) ( by linarith : 0 < e₁ ) ] ) ], Nat.mod_lt _ ( by linarith ) ⟩;
+            refine' ⟨ k, by simpa using hk.1, _ ⟩;
+            unfold case2d_u at *;
+            rw [ tsub_mul ];
+            exact le_tsub_of_add_le_left ( by nlinarith [ Nat.div_add_mod e₁ 3, Nat.mod_lt e₁ zero_lt_three, show e₁ / 3 + e₁ % 3 ≤ e₁ / 2 from by omega ] );
+          -- We can distribute $k$ units among the elements of $vals$.
+          obtain ⟨vals, hvals⟩ : ∃ vals : ZMod d₁ → ℕ, (∀ i, vals i ≤ e₁ - 2 * case2d_u e₁) ∧ (Finset.sum Finset.univ vals) = k := by
+            -- We can distribute $k$ units among the elements of $vals$ by setting $vals i = k / d₁$ for all $i$ and then adjusting the remaining units to reach exactly $k$.
+            obtain ⟨q, r, hr⟩ : ∃ q r : ℕ, k = q * d₁ + r ∧ r < d₁ := by
+              exact ⟨ k / d₁, k % d₁, by rw [ Nat.div_add_mod' ], Nat.mod_lt _ <| NeZero.pos d₁ ⟩;
+            use fun i => q + if i.val < r then 1 else 0;
+            -- Show that each element in the sum is less than or equal to $e₁ - 2 * case2d_u e₁$.
+            have h_le : ∀ i : ZMod d₁, q + (if i.val < r then 1 else 0) ≤ e₁ - 2 * case2d_u e₁ := by
+              intro i; split_ifs <;> nlinarith;
+            simp_all +decide [ Finset.sum_add_distrib ];
+            rw [ mul_comm, show ( Finset.univ.filter fun x : ZMod d₁ => x.val < r ) = Finset.image ( fun x : ℕ => x : ℕ → ZMod d₁ ) ( Finset.range r ) from ?_, Finset.card_image_of_injOn ] <;> norm_num [ Function.Injective ];
+            · exact fun x hx y hy hxy => Nat.mod_eq_of_lt ( show x < d₁ from lt_of_lt_of_le hx.out ( by linarith ) ) ▸ Nat.mod_eq_of_lt ( show y < d₁ from lt_of_lt_of_le hy.out ( by linarith ) ) ▸ by simpa [ ZMod.natCast_eq_natCast_iff' ] using hxy;
+            · ext x; simp [Finset.mem_image];
+              exact ⟨ fun hx => ⟨ x.val, hx, by erw [ ZMod.natCast_zmod_val ] ⟩, by rintro ⟨ a, ha, rfl ⟩ ; exact by simpa [ ZMod.val_cast_of_lt ( show a < d₁ from by linarith ) ] using ha ⟩;
+          use fun i => case2d_u e₁ + vals i;
+          simp_all +decide [ Finset.sum_add_distrib ];
+          exact ⟨ fun i => by linarith [ hvals.1 i, Nat.sub_add_cancel ( show 2 * case2d_u e₁ ≤ e₁ from by { unfold case2d_u; omega } ), Nat.sub_add_cancel ( show case2d_u e₁ ≤ e₁ from by { unfold case2d_u; omega } ) ], by simpa only [ mul_comm ] using hk.1 ⟩;
+        exact h_symm ( target % e₁ ) ( Nat.mod_lt _ ( by linarith ) ) |> fun ⟨ vals, hvals₁, hvals₂ ⟩ => ⟨ vals, hvals₁, by simpa [ Nat.mod_mod ] using hvals₂ ⟩
+-/
 private lemma case2d_rotation_sum_exists {e₁ d₁ : ℕ} [NeZero d₁]
     (hd1_ge : d₁ ≥ 5) (he1_ge : e₁ ≥ 19) (he1_odd : Odd e₁)
     (target : ℕ) :
@@ -2817,7 +3663,8 @@ private lemma case2d_rotation_sum_exists {e₁ d₁ : ℕ} [NeZero d₁]
   have hdw' : d₁ * (e₁ - 2 * case2d_u e₁) ≥ e₁ := by
     change d₁ * (e₁ - 2 * (e₁ / 3 + e₁ % 3)) ≥ e₁
     obtain ⟨k, hk⟩ := he1_odd; subst hk
-    have h5w : 5 * ((2 * k + 1) - 2 * ((2 * k + 1) / 3 + (2 * k + 1) % 3)) ≥ 2 * k + 1 := by grind
+    have h5w : 5 * ((2 * k + 1) - 2 * ((2 * k + 1) / 3 + (2 * k + 1) % 3)) ≥
+        2 * k + 1 := by grind
     exact le_trans h5w (by gcongr)
   set u := case2d_u e₁
   set w := e₁ - 2 * u
@@ -2829,7 +3676,7 @@ private lemma case2d_rotation_sum_exists {e₁ d₁ : ℕ} [NeZero d₁]
   set r := deficit % w
   have hr_lt : r < w := Nat.mod_lt _ hw_pos
   have hq_lt : q < d₁ := by
-    by_contra! hge
+    by_contra hge; push_neg at hge
     have h1 : deficit ≥ d₁ * w :=
       calc deficit ≥ deficit / w * w := Nat.div_mul_le_self deficit w
         _ = q * w := rfl
@@ -2856,7 +3703,8 @@ private lemma case2d_rotation_sum_exists {e₁ d₁ : ℕ} [NeZero d₁]
       · simp only [Finset.sum_ite, Finset.sum_const_zero, add_zero, Finset.sum_const,
           smul_eq_mul]
         congr 1
-        trans (Finset.image ZMod.val (Finset.univ.filter (fun i : ZMod d₁ => i.val < q))).card
+        trans (Finset.image ZMod.val
+          (Finset.univ.filter (fun i : ZMod d₁ => i.val < q))).card
         · rw [Finset.card_image_of_injective _ (ZMod.val_injective _)]
         · have : Finset.image ZMod.val
               (Finset.univ.filter (fun i : ZMod d₁ => i.val < q)) =
@@ -2871,7 +3719,8 @@ private lemma case2d_rotation_sum_exists {e₁ d₁ : ℕ} [NeZero d₁]
           rw [this]; exact Finset.card_range q
       · rw [Finset.sum_ite, Finset.sum_const_zero, add_zero, Finset.sum_const, smul_eq_mul]
         have : (Finset.univ.filter (fun i : ZMod d₁ => i.val = q)).card = 1 := by
-          have : Finset.univ.filter (fun i : ZMod d₁ => i.val = q) = {(q : ZMod d₁)} := by
+          have : Finset.univ.filter (fun i : ZMod d₁ => i.val = q) =
+              {(q : ZMod d₁)} := by
             ext i; simp only [Finset.mem_filter, Finset.mem_univ, true_and,
               Finset.mem_singleton]
             constructor
@@ -2884,14 +3733,17 @@ private lemma case2d_rotation_sum_exists {e₁ d₁ : ℕ} [NeZero d₁]
     simp only [deficit]
     rw [Nat.add_mod_mod]
     have hle : d₁ * u ≤ target + e₁ * d₁ :=
-      le_add_left (le_trans (Nat.mul_le_mul_left d₁ (le_of_lt hu_lt)) (by rw [Nat.mul_comm]))
-    have hadd : d₁ * u + (target + e₁ * d₁ - d₁ * u) = target + e₁ * d₁ := Nat.add_sub_cancel' hle
+      le_add_left (le_trans (Nat.mul_le_mul_left d₁ (le_of_lt hu_lt))
+        (by rw [Nat.mul_comm]))
+    have hadd : d₁ * u + (target + e₁ * d₁ - d₁ * u) = target + e₁ * d₁ :=
+      Nat.add_sub_cancel' hle
     rw [hadd, Nat.add_mul_mod_self_left]
 
 private lemma zero_mem_zmod_set (m : ℕ) (a b : ℤ) : (0 : ZMod m) ∈ zmod_set m a b := by
   simp [zmod_set]
 
-private lemma intCast_b_mem_zmod_set (m : ℕ) (a b : ℤ) : ((b : ℤ) : ZMod m) ∈ zmod_set m a b := by
+private lemma intCast_b_mem_zmod_set (m : ℕ) (a b : ℤ) :
+    ((b : ℤ) : ZMod m) ∈ zmod_set m a b := by
   simp [zmod_set]
 
 private lemma intCast_ba_mem_zmod_set (m : ℕ) (a b : ℤ) :
@@ -2925,7 +3777,7 @@ private lemma zmod_filter_sum_last {n : ℕ} [NeZero n] (f : ZMod n → ℕ) (i 
   simp only [Finset.mem_filter, Finset.mem_univ, true_and]
   exact ⟨fun _ => True.intro, fun _ => by have := k.val_lt (n := n); grind⟩
 
--- Position arithmetic helpers for case2d_coloring_works (not important individually)
+-- Position arithmetic helpers for case2d_coloring_works
 
 /-- Position shift by 1: adding 1 to ZMod coordinate shifts position by 1 mod n. -/
 private lemma pos_shift_one {n : ℕ} [NeZero n] (j : ZMod n) (c : ℕ) :
@@ -2933,20 +3785,30 @@ private lemma pos_shift_one {n : ℕ} [NeZero n] (j : ZMod n) (c : ℕ) :
   rw [ZMod.val_add_one, Nat.mod_add_mod, Nat.mod_add_mod]; grind
 
 /-- (j + (S + V) % n) % n = ((j + S % n) % n + V) % n -/
+/- Aristotle alternative for `pos_shift_succ'` (2 lines vs 4 original, -2).
+   Full proof: `aristotle_results/result_pos_shift_succ'.lean`
+
+private lemma pos_shift_succ' (j S V n : ℕ) :
+    (j + (S + V) % n) % n = ((j + S % n) % n + V) % n := by
+      -- By the associativity of addition modulo n, we can rearrange the terms inside the modulo operation.
+      simp [Nat.add_assoc]
+-/
 private lemma pos_shift_succ' (j S V n : ℕ) :
     (j + (S + V) % n) % n = ((j + S % n) % n + V) % n := by
   have h1 : j + (S + V) = j + S + V := by grind
-  have h2 : (j + S) % n = (j + S % n) % n := (Nat.add_mod_mod j S n).symm
+  have h2 : (j + S) % n = (j + S % n) % n :=
+    (Nat.add_mod_mod j S n).symm
   rw [Nat.add_mod_mod, h1, ← Nat.mod_add_mod (j + S) n V, h2]
 
-/-- Wrap case: if (S + V) % n = k₀ % n, then (j + k₀) % n = ((j + S % n) % n + V) % n -/
+/-- Wrap case: if (S + V) % n = k₀ % n, then
+    (j + k₀) % n = ((j + S % n) % n + V) % n -/
 private lemma pos_shift_wrap' (j S V k₀ n : ℕ)
     (hsum : (S + V) % n = k₀ % n) :
     (j + k₀) % n = ((j + S % n) % n + V) % n := by
   rw [← Nat.add_mod_mod j k₀ n, ← hsum, pos_shift_succ']
 
-/-- **Subcase (2d) assembled.** Constructs the coloring for the case when both d₁
-    and e₁ are odd with e₁ ≥ 19, using rotated interval patterns. -/
+/-- The coloring for case (2d), connecting to ZMod m. Uses cycle coordinates
+    c_{i,j} = i*(b-a) + j*b and the base pattern with rotations. -/
 private lemma case2d_coloring_works {m : ℕ} {a b : ℤ}
     (hm : m ≥ 289)
     (h_gcd_coprime : (Nat.gcd b.natAbs m).gcd (Nat.gcd (b - a).natAbs m) = 1)
@@ -2974,7 +3836,8 @@ private lemma case2d_coloring_works {m : ℕ} {a b : ℤ}
   obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hd1_dvd hb_zero hba_unit hord hm_eq
   -- d₁ is odd, > 1, and ¬(3∣d₁), so d₁ ≥ 5
   have hd1_ge5 : d₁ ≥ 5 := by grind
-  obtain ⟨vals, hvals_bound, hvals_sum⟩ := case2d_rotation_sum_exists hd1_ge5 he1_ge he1_odd k₀.val
+  obtain ⟨vals, hvals_bound, hvals_sum⟩ :=
+    case2d_rotation_sum_exists hd1_ge5 he1_ge he1_odd k₀.val
   -- Cumulative rotation: rot(i) = (Σ_{j<i} vals(j)) % e₁
   let rot : ZMod d₁ → ℕ := fun i =>
     ((Finset.univ.filter (fun j : ZMod d₁ => j.val < i.val)).sum vals) % e₁
@@ -3019,7 +3882,8 @@ private lemma case2d_coloring_works {m : ℕ} {a b : ℤ}
     · refine ⟨((2 * b - a : ℤ) : ZMod m), intCast_2ba_mem_zmod_set m a b, ?_⟩
       rw [← hΦ_2ba, hχ_eq, h]; congr 1
       calc ((j_new + 1 : ZMod e₁).val + rot i_new) % e₁
-          = ((j_new.val + rot i_new) % e₁ + 1) % e₁ := pos_shift_one j_new (rot i_new)
+          = ((j_new.val + rot i_new) % e₁ + 1) % e₁ :=
+            pos_shift_one j_new (rot i_new)
         _ = ((p + vals i) % e₁ + 1) % e₁ := by rw [hpos]
         _ = (p + vals i + 1) % e₁ := Nat.mod_add_mod (p + vals i) e₁ 1
   by_cases hi : i.val + 1 < d₁
@@ -3040,17 +3904,23 @@ private lemma case2d_coloring_works {m : ℕ} {a b : ℤ}
     refine ⟨0, j + k₀, ?_, ?_⟩
     · rw [← hn, hij]; exact (case2d_shift_ba_wrap he1_b_zero k₀ hk₀ i hi_eq j).symm
     · have hrot0 : rot (0 : ZMod d₁) = 0 := by simp [rot, ZMod.val_zero]
-      have htotal : (Finset.univ.filter (fun k : ZMod d₁ => k.val < i.val)).sum vals +
-            vals i = Finset.univ.sum vals := zmod_filter_sum_last vals i hi_eq
+      have htotal :
+          (Finset.univ.filter (fun k : ZMod d₁ => k.val < i.val)).sum vals +
+            vals i = Finset.univ.sum vals :=
+        zmod_filter_sum_last vals i hi_eq
       rw [hrot0, Nat.add_zero, ZMod.val_add, Nat.mod_mod_of_dvd _ (dvd_refl e₁)]
       exact pos_shift_wrap' j.val _ (vals i) k₀.val e₁ (by rw [htotal, hvals_sum])
 
 -- Mod 3 arithmetic: (a % e₁ + b) % 3 = (a + b) % 3 when 3 ∣ e₁
-private lemma case2c_mod3 {e₁ : ℕ} (h3e : 3 ∣ e₁) (x y : ℕ) : (x % e₁ + y) % 3 = (x + y) % 3 := by
+private lemma case2c_mod3 {e₁ : ℕ} (h3e : 3 ∣ e₁) (x y : ℕ) :
+    (x % e₁ + y) % 3 = (x + y) % 3 := by
   rw [Nat.add_mod, Nat.mod_mod_of_dvd x h3e, ← Nat.add_mod]
 
-/-- **Subcase (2c):** d₁ and e₁ are both odd, with e₁ ≤ 17 and 3 ∣ e₁.
-    Uses shifted periodic 012-patterns with different shifts for adjacent cycles. -/
+/-- Subcase (2c): d₁ and e₁ are both odd, with e₁ ≤ 17 and 3 ∣ e₁.
+    Each cycle Cᵢ is colored with one of three shifted 012-patterns:
+      Pattern p: position j gets color (j + p) mod 3.
+    Adjacent cycles use different patterns, ensuring all 2×2 blocks
+    (translates of S) contain all 3 colors. -/
 lemma case_two_odd_small (hm : m ≥ 289)
     (h_gcd_coprime : (Nat.gcd b.natAbs m).gcd (Nat.gcd (b - a).natAbs m) = 1)
     (h_min : min (Nat.gcd b.natAbs m) (Nat.gcd (b - a).natAbs m) > 1)
@@ -3063,7 +3933,9 @@ lemma case_two_odd_small (hm : m ≥ 289)
   set e₁ := m / d₁ with he1_def
   have hd1_dvd : d₁ ∣ m := Nat.gcd_dvd_right _ _
   have hd1_gt1 : d₁ > 1 := by grind
-  have he1_ge3 : e₁ ≥ 3 := by grind
+  have he1_ge3 : e₁ ≥ 3 := by
+    grind
+  have he1_pos : 0 < e₁ := by grind
   have hm_eq : m = d₁ * e₁ := (Nat.mul_div_cancel' hd1_dvd).symm
   haveI : NeZero m := ⟨by grind⟩
   haveI : NeZero d₁ := ⟨by grind⟩
@@ -3152,7 +4024,8 @@ lemma case_two_odd_small (hm : m ≥ 289)
     have hhyp : (j.val + p.val) % 3 ≠ (j.val + k₀.val + p₀.val) % 3 := by
       rw [hp_eq]; exact case2c_wrap_hyp d₁ k₀.val j.val hd1_ge3 hd1_odd
     -- Apply cover_mod3_general
-    rcases cover_mod3_general p p₀ j.val (j.val + k₀.val) hhyp k with h | h | h | h
+    rcases cover_mod3_general p p₀ j.val (j.val + k₀.val) hhyp k
+      with h | h | h | h
     · exact ⟨0, zero_mem_zmod_set m a b,
         by rw [add_zero, ← hn, hij, hχ_eq, h]⟩
     · refine ⟨((b : ℤ) : ZMod m), intCast_b_mem_zmod_set m a b, ?_⟩
@@ -3171,12 +4044,46 @@ lemma case_two_odd_small (hm : m ≥ 289)
         (j.val + k₀.val + 1 + p₀.val) % 3
       have hj'val : j'.val = (j.val + k₀.val) % e₁ := ZMod.val_add j k₀
       rw [ZMod.val_zero, hzmod_succ, hj'val]
-      rw [case2c_mod3 he1_div3 ((j.val + k₀.val) % e₁ + 1) p₀.val,
-        Nat.add_assoc ((j.val + k₀.val) % e₁),
-        Nat.add_assoc (j.val + k₀.val)]
+      rw [case2c_mod3 he1_div3 ((j.val + k₀.val) % e₁ + 1) p₀.val]
+      have h1 : (j.val + k₀.val) % e₁ + 1 + p₀.val =
+            (j.val + k₀.val) % e₁ + (1 + p₀.val) := by grind
+      have h2 : j.val + k₀.val + 1 + p₀.val =
+            j.val + k₀.val + (1 + p₀.val) := by grind
+      rw [h1, h2]
       exact case2c_mod3 he1_div3 (j.val + k₀.val) (1 + p₀.val)
 
-/-- Auxiliary: rules out both cycle lengths being ≤ 17 when m ≥ 289. -/
+/-- When gcd(d₁,d₂) = 1, both d₁,d₂ > 1, both d₁,d₂ divide m,
+    and m/d₁ ≤ 17 and m/d₂ ≤ 17, we get m ≤ 289. Combined with
+    m ≥ 289 this forces m = 289 = 17², but then gcd(d₁,d₂) = 1 with
+    d₁,d₂ | 17² and d₁,d₂ > 1 is impossible. -/
+/- Aristotle alternative for `no_both_e_small` (18 lines vs 20 original, -2).
+   Full proof: `aristotle_results/result_no_both_e_small.lean`
+
+private lemma no_both_e_small {m d₁ d₂ : ℕ}
+    (hm : m ≥ 289)
+    (hcop : Nat.gcd d₁ d₂ = 1)
+    (hd₁_gt1 : d₁ > 1) (hd₂_gt1 : d₂ > 1)
+    (hd₁_dvd : d₁ ∣ m) (hd₂_dvd : d₂ ∣ m)
+    (he₁_le : m / d₁ ≤ 17) (he₂_le : m / d₂ ≤ 17) : False := by
+      -- Since $d₁$ and $d₂$ are coprime and both divide $m$, their product $d₁*d₂$ must also divide $m$. Therefore, $m \geq d₁*d₂$.
+      have h_prod_div : d₁ * d₂ ∣ m := by
+        -- Since $d₁$ and $d₂$ are coprime and both divide $m$, their product $d₁*d₂$ must also divide $m$ by the property of coprime divisors.
+        apply Nat.Coprime.mul_dvd_of_dvd_of_dvd hcop hd₁_dvd hd₂_dvd;
+      -- Since $d₁$ and $d₂$ are coprime and both divide $m$, their product $d₁*d₂$ must also divide $m$. Therefore, $m \geq d₁*d₂$. Given that $m \geq 289$, we have $289 \leq d₁*d₂$.
+      have h_prod_ge : 289 ≤ d₁ * d₂ := by
+        -- Since $m$ is a multiple of $d₁ * d₂$, we have $m = (d₁ * d₂) * k$ for some integer $k$.
+        obtain ⟨k, hk⟩ : ∃ k, m = d₁ * d₂ * k := h_prod_div;
+        rcases k with ( _ | _ | k ) <;> simp_all! +arith +decide [ Nat.mul_div_assoc ];
+        simp_all +decide [ mul_assoc, Nat.mul_div_assoc ];
+        simp_all +decide [ Nat.mul_div_cancel_left _ ( by linarith : 0 < d₁ ), Nat.mul_div_cancel_left _ ( by linarith : 0 < d₂ ) ] ; nlinarith only [ hm, hd₁_gt1, hd₂_gt1, he₁_le, he₂_le ] ;
+      -- Combining the inequalities $m \geq d₁ * d₂$ and $m \leq 17 * d₁$ and $m \leq 17 * d₂$, we get $d₁ * d₂ \leq 17 * d₁$ and $d₁ * d₂ \leq 17 * d₂$.
+      have h_combined : d₁ * d₂ ≤ 17 * d₁ ∧ d₁ * d₂ ≤ 17 * d₂ := by
+        exact ⟨ by nlinarith [ Nat.div_mul_cancel hd₁_dvd, Nat.le_of_dvd ( by linarith ) h_prod_div ], by nlinarith [ Nat.div_mul_cancel hd₂_dvd, Nat.le_of_dvd ( by linarith ) h_prod_div ] ⟩;
+      -- Since $d₁$ and $d₂$ are both greater than 1 and their product is 289, the only possible pair is (17, 17), but this contradicts the coprimality condition.
+      have h_contra : d₁ = 17 ∧ d₂ = 17 := by
+        constructor <;> nlinarith only [ hd₁_gt1, hd₂_gt1, h_prod_ge, h_combined ];
+      aesop_cat
+-/
 private lemma no_both_e_small {m d₁ d₂ : ℕ}
     (hm : m ≥ 289)
     (hcop : Nat.gcd d₁ d₂ = 1)
@@ -3184,26 +4091,31 @@ private lemma no_both_e_small {m d₁ d₂ : ℕ}
     (hd₁_dvd : d₁ ∣ m) (hd₂_dvd : d₂ ∣ m)
     (he₁_le : m / d₁ ≤ 17) (he₂_le : m / d₂ ≤ 17) : False := by
   have hd₁_bound : m ≤ d₁ * 17 := by
-    rw [← Nat.mul_div_cancel' hd₁_dvd]; gcongr
+    calc m = d₁ * (m / d₁) := (Nat.mul_div_cancel' hd₁_dvd).symm
+      _ ≤ d₁ * 17 := by gcongr
   have hd₂_bound : m ≤ d₂ * 17 := by
-    rw [← Nat.mul_div_cancel' hd₂_dvd]; gcongr
+    calc m = d₂ * (m / d₂) := (Nat.mul_div_cancel' hd₂_dvd).symm
+      _ ≤ d₂ * 17 := by gcongr
   have hprod_le : d₁ * d₂ ≤ m :=
     Nat.le_of_dvd (by grind)
       (Nat.Coprime.mul_dvd_of_dvd_of_dvd (by rwa [Nat.Coprime]) hd₁_dvd hd₂_dvd)
   -- d₁*d₂ ≤ m ≤ d₁*17 → d₂ ≤ 17; similarly d₁ ≤ 17
-  have hd₂_le : d₂ ≤ 17 := Nat.le_of_mul_le_mul_left (hprod_le.trans hd₁_bound) (by grind)
+  have hd₂_le : d₂ ≤ 17 :=
+    Nat.le_of_mul_le_mul_left (hprod_le.trans hd₁_bound) (by grind)
   have hd₁_le : d₁ ≤ 17 :=
-    Nat.le_of_mul_le_mul_left (mul_comm d₁ d₂ ▸ hprod_le.trans hd₂_bound) (by grind)
+    Nat.le_of_mul_le_mul_left
+      (mul_comm d₁ d₂ ▸ hprod_le.trans hd₂_bound) (by grind)
   -- 289 ≤ m ≤ d₁*17 → d₁ ≥ 17; similarly d₂ ≥ 17
   -- So d₁ = d₂ = 17, gcd(17,17) = 17 ≠ 1.
   have hd₁_eq : d₁ = 17 := by grind
   have hd₂_eq : d₂ = 17 := by grind
   rw [hd₁_eq, hd₂_eq] at hcop; simp at hcop
 
-/-! ### Aggregation of Case 2 -/
-
-/-- **Main Case 2 (Multiple Cycles).** Aggregates all subcases (2a)–(2d).
-    First applies WLOG to ensure 3 ∤ d₁, then dispatches on parity of d₁ and e₁. -/
+/-- Aggregation of Main Case 2.
+    Assumption: min(gcd(b, m), gcd(b-a, m)) > 1.
+    Matches the paper's proof structure: first WLOG swap so that 3 ∤ d₁
+    (choosing the smallest non-multiple-of-3), then split into subcases
+    (2a)–(2d). -/
 lemma main_case_two (hm : m ≥ 289)
     (h_gcd_coprime : (Nat.gcd b.natAbs m).gcd (Nat.gcd (b - a).natAbs m) = 1)
     (h_min : min (Nat.gcd b.natAbs m) (Nat.gcd (b - a).natAbs m) > 1) :
@@ -3228,14 +4140,15 @@ lemma main_case_two (hm : m ≥ 289)
           set a' := (-a : ℤ); set b' := (b - a : ℤ)
           have hba_eq : (b' - a').natAbs = b.natAbs := by
             change (b - a - -a).natAbs = b.natAbs; congr 1; ring
-          have hcop' : (Nat.gcd b'.natAbs m).gcd (Nat.gcd (b' - a').natAbs m) = 1 := by
+          have hcop' : (Nat.gcd b'.natAbs m).gcd
+              (Nat.gcd (b' - a').natAbs m) = 1 := by
             rw [hba_eq]; rwa [Nat.gcd_comm]
-          have hmin' : min (Nat.gcd b'.natAbs m) (Nat.gcd (b' - a').natAbs m) > 1 := by
+          have hmin' : min (Nat.gcd b'.natAbs m)
+              (Nat.gcd (b' - a').natAbs m) > 1 := by
             rw [hba_eq]; rwa [min_comm]
           have h3' : ¬ (3 ∣ Nat.gcd b'.natAbs m) := by
             intro h3d'; have := Nat.dvd_gcd h3 h3d'
-            rw [h_gcd_coprime] at this
-            grind
+            rw [h_gcd_coprime] at this; grind
           rcases Nat.even_or_odd (m / Nat.gcd b'.natAbs m) with he' | ho'
           · exact case_two_e1_even m a' b' hm hcop' hmin' he'
           · rcases Nat.even_or_odd (Nat.gcd b'.natAbs m) with hd' | hd'
@@ -3249,7 +4162,8 @@ lemma main_case_two (hm : m ≥ 289)
       set e₁ := m / d₁
       have hd₁_dvd : d₁ ∣ m := Nat.gcd_dvd_right _ _
       have hd₂_dvd : d₂ ∣ m := Nat.gcd_dvd_right _ _
-      have hd₂_pos : 0 < d₂ := Nat.pos_of_ne_zero (by intro h; simp [h] at hmin)
+      have hd₂_pos : 0 < d₂ :=
+        Nat.pos_of_ne_zero (by intro h; simp [h] at hmin)
       by_cases he_le : e₁ ≤ 17
       · -- Case 2c: prove 3 ∣ e₁
         -- Since gcd(d₁,d₂)=1 and 3 ∤ d₁, if 3 ∣ d₂ then 3 ∣ m hence 3 ∣ e₁.
@@ -3257,19 +4171,24 @@ lemma main_case_two (hm : m ≥ 289)
         by_cases h3d₂ : 3 ∣ d₂
         · have h3m : 3 ∣ m := dvd_trans h3d₂ hd₂_dvd
           have h3e₁ : 3 ∣ e₁ := by
-            have h3de : 3 ∣ d₁ * e₁ := Nat.mul_div_cancel' hd₁_dvd ▸ h3m
-            have hcop3 : Nat.Coprime 3 d₁ := (Nat.Prime.coprime_iff_not_dvd (by decide)).mpr h3_nd₁
+            have h3de : 3 ∣ d₁ * e₁ :=
+              (Nat.mul_div_cancel' hd₁_dvd).symm ▸ h3m
+            have hcop3 : Nat.Coprime 3 d₁ :=
+              (Nat.Prime.coprime_iff_not_dvd (by decide)).mpr h3_nd₁
             exact hcop3.dvd_of_dvd_mul_left h3de
-          exact case_two_odd_small m a' b' hm hcop hmin hd₁_odd he₁_odd he_le h3e₁
+          exact case_two_odd_small m a' b' hm hcop hmin hd₁_odd he₁_odd
+            he_le h3e₁
         · -- 3 ∤ d₁ and 3 ∤ d₂ and e₁ ≤ 17: swap and show new e₁ ≥ 19.
           -- After swap, new e₁' = m/d₂. If e₁' ≤ 17 too, contradiction.
           rw [← zmod_set_swap m a' b']
           set a'' := (-a' : ℤ); set b'' := (b' - a' : ℤ)
           have hba_eq : (b'' - a'').natAbs = b'.natAbs := by
             change (b' - a' - -a').natAbs = b'.natAbs; congr 1; ring
-          have hcop' : (Nat.gcd b''.natAbs m).gcd (Nat.gcd (b'' - a'').natAbs m) = 1 := by
+          have hcop' : (Nat.gcd b''.natAbs m).gcd
+              (Nat.gcd (b'' - a'').natAbs m) = 1 := by
             rw [hba_eq]; rwa [Nat.gcd_comm]
-          have hmin' : min (Nat.gcd b''.natAbs m) (Nat.gcd (b'' - a'').natAbs m) > 1 := by
+          have hmin' : min (Nat.gcd b''.natAbs m)
+              (Nat.gcd (b'' - a'').natAbs m) > 1 := by
             rw [hba_eq]; rwa [min_comm]
           -- Dispatch on parity
           rcases Nat.even_or_odd (m / Nat.gcd b''.natAbs m) with he' | ho'
@@ -3279,23 +4198,28 @@ lemma main_case_two (hm : m ≥ 289)
             · -- Both odd after swap. Show e₁' ≥ 19 by contradiction.
               have he₁'_ge : m / Nat.gcd b''.natAbs m ≥ 19 := by
                 by_contra hlt; push_neg at hlt
+                have hle : m / Nat.gcd b''.natAbs m ≤ 17 := by grind
+                have hd₁_gt1 : d₁ > 1 := by grind
+                have hd₂_gt1 : d₂ > 1 := by grind
                 rw [Nat.gcd_comm] at hcop
-                exact no_both_e_small hm hcop (by grind) (by grind) hd₂_dvd hd₁_dvd (by grind) he_le
-              exact case2d_coloring_works hm hcop' hmin' hd' ho' he₁'_ge h3d₂
+                exact no_both_e_small hm hcop hd₂_gt1 hd₁_gt1
+                  hd₂_dvd hd₁_dvd hle he_le
+              exact case2d_coloring_works hm hcop' hmin' hd' ho'
+                he₁'_ge h3d₂
       · have he₁_ge : e₁ ≥ 19 := by grind
-        exact case2d_coloring_works hm hcop hmin hd₁_odd he₁_odd he₁_ge h3_nd₁
+        exact case2d_coloring_works hm hcop hmin hd₁_odd he₁_odd
+          he₁_ge h3_nd₁
 
 end Case2_MultipleCycles
 
-/-! ## Assembly: connecting ZMod m back to ℤ
+/-! ## Assembly
 
-The remaining lemmas are the glue between the Case 1/Case 2 analysis in $\mathbb{Z}_m$
-and the final statement over $\mathbb{Z}$, culminating in `normal_bit`.
+The remaining lemmas connect the `ZMod m` analysis back to `ℤ`: cardinality of
+`zmod_set`, the GCD coprimality reduction, and the final theorem `normal_bit`
+which dispatches on `min(d₁, d₂) = 1` vs `> 1`.
 -/
 
-section Assembly
-
-/-- Auxiliary: the set zmod_set m a b has 4 elements when 0 < a < b and 2b - a < m. -/
+/-- The set zmod_set m a b has 4 elements when 0 < a < b and 2b - a < m. -/
 lemma zmod_set_card_eq_four {a b : ℤ} {m : ℕ}
     (ha : 0 < a) (hab : a < b) (hbm : 2 * b - a < ↑m) :
     (zmod_set m a b).card = 4 := by
@@ -3317,7 +4241,8 @@ lemma zmod_set_card_eq_four {a b : ℤ} {m : ℕ}
   · simp only [mem_insert, mem_singleton]; push_neg; exact ⟨ne12, ne13⟩
   · simp only [mem_insert, mem_singleton]; push_neg; exact ⟨ne01, ne02, ne03⟩
 
-/-- Auxiliary: the coprimality gcd(d₁, d₂) = 1 follows from gcd(a, b, c) = 1. -/
+/-- The coprimality gcd(d₁, d₂) = 1 follows from gcd(a, b, c) = 1 and m = c - a + b,
+    since gcd(b-a, b, m) = gcd(b-a, b, c-a+b) = gcd(a, b, c). -/
 lemma gcd_coprime_of_gcd_abc {a b c : ℤ} {m : ℕ}
     (hm : (m : ℤ) = c - a + b) (hgcd : Finset.gcd {a, b, c} id = 1) :
     (Nat.gcd b.natAbs m).gcd (Nat.gcd (b - a).natAbs m) = 1 := by
@@ -3330,14 +4255,9 @@ lemma gcd_coprime_of_gcd_abc {a b c : ℤ} {m : ℕ}
   have hd_ba : (d : ℤ) ∣ (b - a) := Int.natCast_dvd.mpr
     ((Nat.gcd_dvd_right (Nat.gcd _ _) _).trans (Nat.gcd_dvd_left _ _))
   -- d | a and d | c follow from d | b, d | (b-a), d | m
-  have hd_a : (d : ℤ) ∣ a := by
-    have : a = b - (b - a) := by ring
-    rw [this]
-    exact dvd_sub hd_b hd_ba
-  have hd_c : (d : ℤ) ∣ c := by
-    have : (c : ℤ) = ↑m - b + a := by grind
-    rw [this]
-    exact dvd_add (dvd_sub hd_m hd_b) hd_a
+  have hd_a : (d : ℤ) ∣ a := (by ring : a = b - (b - a)) ▸ dvd_sub hd_b hd_ba
+  have hd_c : (d : ℤ) ∣ c := (by grind : (c : ℤ) = ↑m - b + a) ▸
+    dvd_add (dvd_sub hd_m hd_b) hd_a
   have hd_dvd_gcd : (d : ℤ) ∣ Finset.gcd {a, b, c} id :=
     Finset.dvd_gcd (fun x hx => by
       simp only [Finset.mem_insert, Finset.mem_singleton] at hx
@@ -3348,26 +4268,28 @@ lemma gcd_coprime_of_gcd_abc {a b c : ℤ} {m : ℕ}
   rw [hgcd] at hd_dvd_gcd
   exact Nat.eq_one_of_dvd_one (Int.natCast_dvd_natCast.mp hd_dvd_gcd)
 
-/-- Auxiliary: lifts polychromaticity from ZMod m back to ℤ, combining the
-    homomorphism ℤ → ZMod m (Lemma 12(ii)) with `polychromNumber_zmod`. -/
+/-- Reduction from HasPolychromColouring on zmod_set to HasPolychromColouring on {0, a, b, c} in ℤ.
+    Combines the homomorphism ℤ → ZMod m (Lemma 12(ii)) with the translation
+    equivalence (Lemma 12(iii), i.e. `polychromNumber_zmod`). -/
 lemma hasPolychromColouring_of_zmod_set {a b c : ℤ} {m : ℕ}
     (hm_eq : (m : ℤ) = c - a + b)
     (h : HasPolychromColouring (Fin 3) (zmod_set m a b)) :
     HasPolychromColouring (Fin 3) ({0, a, b, c} : Finset ℤ) := by
   apply HasPolychromColouring.of_image (Int.castAddHom (ZMod m))
-  change HasPolychromColouring (Fin 3) (({0, a, b, c} : Finset ℤ).image (Int.cast : ℤ → ZMod m))
+  change HasPolychromColouring (Fin 3)
+    (({0, a, b, c} : Finset ℤ).image (Int.cast : ℤ → ZMod m))
   apply hasPolychromColouring_fin_of_le (by simp)
   rw [polychromNumber_zmod hm_eq]
   exact le_polychromNumber h
 
 /--
-**Main theorem of this file.** Every 4-element set $\{0, a, b, c\}$ satisfying the
+The main theorem of this file: every 4-element set $\{0, a, b, c\}$ satisfying the
 normalization conditions ($0 < a < b$, $a + b \le c$, $c \ge 289$, $\gcd(a, b, c) = 1$)
 admits a 3-polychromatic coloring.
 
-This is the entry point used by `Main.lean` to handle the large-c case. The proof
-dispatches to `main_case_one` or `main_case_two` based on
-$\min(\gcd(b, m), \gcd(b{-}a, m))$.
+This serves as the "combinatorial bit" of the overall polychromatic coloring theorem.
+The proof dispatches to `main_case_one` (Case 1: Single Cycle) or `main_case_two`
+(Case 2: Multiple Cycles) based on the value of $\min(\gcd(b, m), \gcd(b-a, m))$.
 -/
 theorem normal_bit :
     ∀ a b c : ℤ, 0 < a → a < b → a + b ≤ c → 289 ≤ c → Finset.gcd {a, b, c} id = 1 →
@@ -3388,5 +4310,3 @@ theorem normal_bit :
   · have : 0 < d₁ := Nat.gcd_pos_of_pos_right _ hm_pos
     have : 0 < d₂ := Nat.gcd_pos_of_pos_right _ hm_pos
     exact main_case_two m a b (by grind) (gcd_coprime_of_gcd_abc hm_eq hgcd) (by grind)
-
-end Assembly

--- a/Lean/Polychromatic/FourThree/Combi.lean
+++ b/Lean/Polychromatic/FourThree/Combi.lean
@@ -826,6 +826,17 @@ private lemma two_pairs_cover (j₁ j₂ : ℕ) (hne : j₁ % 3 ≠ j₂ % 3)
 private lemma lt_two' (n : ℕ) (h : n < 2) : n = 0 ∨ n = 1 := by omega
 
 /-- Phase differs when gap is 1 or 2 mod s, and 3 ∣ s. -/
+/- Aristotle alternative for `phase_ne_of_gap` (4 lines vs 13 original, -9).
+
+private lemma phase_ne_of_gap {s j₀ jg : ℕ} (hs3 : 3 ∣ s)
+    (hj₀ : j₀ < s) (hjg : jg < s)
+    (hgap : (jg + s - j₀) % s = 1 ∨ (jg + s - j₀) % s = 2) :
+    j₀ % 3 ≠ jg % 3 := by
+      -- Since $s$ is a multiple of 3, we can simplify the gap condition modulo 3.
+      have h_mod3 : (jg + s - j₀) % 3 = 1 ∨ (jg + s - j₀) % 3 = 2 := by
+        obtain h | h := hgap <;> rw [ ← Nat.mod_mod_of_dvd _ hs3, h ] <;> norm_num [ Nat.mod_eq_of_lt ] ;
+      omega
+-/
 private lemma phase_ne_of_gap {s j₀ jg : ℕ} (hs3 : 3 ∣ s)
     (hj₀ : j₀ < s) (hjg : jg < s)
     (hgap : (jg + s - j₀) % s = 1 ∨ (jg + s - j₀) % s = 2) :
@@ -1096,6 +1107,15 @@ private def eqp_off (q r : ℕ) (p : ℕ) : ℕ :=
   if p < r * (q + 1) then p % (q + 1)
   else (p - r * (q + 1)) % q
 
+/- Aristotle alternative for `eqp_idx_m` (4 lines vs 6 original, -2).
+
+private lemma eqp_idx_m (q r s : ℕ) (hq : 0 < q) (hr : r < s) :
+    eqp_idx q r (s * q + r) = s := by
+      unfold eqp_idx;
+      split_ifs <;> simp_all +decide [ Nat.add_div, Nat.mul_div_cancel, hq ];
+      · nlinarith;
+      · exact Eq.symm ( by nlinarith [ Nat.div_mul_le_self ( s * q + r - r * ( q + 1 ) ) q, Nat.sub_add_cancel ( by linarith : r * ( q + 1 ) ≤ s * q + r ), Nat.div_add_mod ( s * q + r - r * ( q + 1 ) ) q, Nat.mod_lt ( s * q + r - r * ( q + 1 ) ) hq ] )
+-/
 private lemma eqp_idx_m (q r s : ℕ) (hq : 0 < q) (hr : r < s) :
     eqp_idx q r (s * q + r) = s := by
   have hge : ¬(s * q + r < r * (q + 1)) := by nlinarith
@@ -1106,6 +1126,17 @@ private lemma eqp_idx_m (q r s : ℕ) (hq : 0 < q) (hr : r < s) :
   rw [hsub, Nat.mul_div_cancel _ hq]; omega
 
 -- General fact: consecutive ℕ quotients differ by 0 or 1
+/- Aristotle alternative for `div_step` (6 lines vs 9 original, -3).
+
+private lemma div_step (a b : ℕ) (hb : 0 < b) :
+    (a + 1) / b = a / b ∨ (a + 1) / b = a / b + 1 := by
+      -- Since $a \geq b$, we can write $a = b * k + r$ where $0 \leq r < b$.
+      obtain ⟨k, r, hr⟩ : ∃ k r, a = b * k + r ∧ 0 ≤ r ∧ r < b := by
+        exact ⟨ a / b, a % b, by rw [ Nat.div_add_mod ], Nat.zero_le _, Nat.mod_lt _ hb ⟩;
+      norm_num [ hr, Nat.add_div, hb ];
+      rcases b with ( _ | _ | b ) <;> simp_all +decide [ Nat.div_eq_of_lt, Nat.mod_eq_of_lt ];
+      exact lt_or_ge _ _
+-/
 private lemma div_step (a b : ℕ) (hb : 0 < b) :
     (a + 1) / b = a / b ∨ (a + 1) / b = a / b + 1 := by
   have hle : a / b ≤ (a + 1) / b :=
@@ -1118,6 +1149,25 @@ private lemma div_step (a b : ℕ) (hb : 0 < b) :
       ≤ b * (a / b + 1) / b := Nat.div_le_div_right hub
     _ = a / b + 1 := Nat.mul_div_cancel_left _ hb
 
+/- Aristotle alternative for `eqp_idx_step` (13 lines vs 20 original, -7).
+
+private lemma eqp_idx_step (q r p : ℕ) (hq : 0 < q) :
+    eqp_idx q r (p + 1) = eqp_idx q r p ∨
+    eqp_idx q r (p + 1) = eqp_idx q r p + 1 := by
+      -- By definition of eqp_idx, we have two cases to consider.
+      unfold eqp_idx;
+      split_ifs <;> simp_all +decide [ Nat.succ_div ];
+      · tauto;
+      · linarith;
+      · -- Since $p < r * (q + 1)$ and $r * (q + 1) \leq p + 1$, we have $p = r * (q + 1) - 1$.
+        have hp : p = r * (q + 1) - 1 := by
+          omega;
+        cases r <;> cases q <;> simp_all +decide [ Nat.succ_mul ];
+        simp +arith +decide [ Nat.add_div ];
+        norm_num [ Nat.div_eq_of_lt, Nat.mod_eq_of_lt ];
+      · rw [ show p + 1 - r * ( q + 1 ) = ( p - r * ( q + 1 ) ) + 1 by rw [ tsub_add_eq_add_tsub ( by linarith ) ] ] ; simp +arith +decide [ Nat.succ_div ] ;
+        exact em' _
+-/
 private lemma eqp_idx_step (q r p : ℕ) (hq : 0 < q) :
     eqp_idx q r (p + 1) = eqp_idx q r p ∨
     eqp_idx q r (p + 1) = eqp_idx q r p + 1 := by
@@ -1158,6 +1208,30 @@ private lemma mod_zero_step (a b : ℕ) (hb : 0 < b)
   have h4 : b * ((a + 1) / b) = b * (a / b) + b := by grind
   grind
 
+/- Aristotle alternative for `eqp_off_succ_same` (18 lines vs 34 original, -16).
+
+private lemma eqp_off_succ_same (q r p : ℕ) (hq : 0 < q)
+    (h : eqp_idx q r (p + 1) = eqp_idx q r p) :
+    eqp_off q r (p + 1) = eqp_off q r p + 1 := by
+      -- By definition of eqp_off, we have eqp_off q r (p + 1) = (p + 1) % (q + 1) if p + 1 < r * (q + 1), otherwise it's (p + 1 - r * (q + 1)) % q.
+      by_cases h_case : p + 1 < r * (q + 1);
+      · unfold eqp_idx eqp_off at *;
+        split_ifs at * <;> simp_all +decide [ Nat.succ_eq_add_one, Nat.add_div ];
+        · rcases q with ( _ | q ) <;> simp_all +decide [ Nat.div_eq_of_lt, Nat.mod_eq_of_lt ];
+          rw [ Nat.add_mod, Nat.mod_eq_of_lt ] <;> aesop;
+        · grind;
+      · unfold eqp_off;
+        -- Since $p + 1 \geq r * (q + 1)$, we have $p \geq r * (q + 1)$. Therefore, $p = r * (q + 1) + k$ for some $k$.
+        obtain ⟨k, hk⟩ : ∃ k, p = r * (q + 1) + k := by
+          use p - r * (q + 1);
+          unfold eqp_idx at h;
+          split_ifs at h <;> try omega;
+          norm_num [ show p + 1 - r * ( q + 1 ) = 0 by omega ] at h;
+          nlinarith [ Nat.div_mul_le_self p ( q + 1 ) ];
+        simp_all +decide [ eqp_idx ];
+        split_ifs at * <;> simp_all +decide [ add_assoc, Nat.add_sub_add_left ];
+        rw [ mod_step ] ; aesop
+-/
 private lemma eqp_off_succ_same (q r p : ℕ) (hq : 0 < q)
     (h : eqp_idx q r (p + 1) = eqp_idx q r p) :
     eqp_off q r (p + 1) = eqp_off q r p + 1 := by
@@ -1196,6 +1270,22 @@ private lemma eqp_off_succ_same (q r p : ℕ) (hq : 0 < q)
       unfold eqp_idx; rw [if_neg h2]
     rw [h3, h4, hsub] at h; omega
 
+/- Aristotle alternative for `eqp_off_succ_new` (10 lines vs 30 original, -20).
+
+private lemma eqp_off_succ_new (q r p : ℕ) (hq : 0 < q)
+    (h : eqp_idx q r (p + 1) ≠ eqp_idx q r p) :
+    eqp_off q r (p + 1) = 0 := by
+      unfold eqp_idx eqp_off at *;
+      split_ifs at h <;> simp_all +decide [ Nat.succ_div ];
+      · exact Nat.mod_eq_zero_of_dvd h;
+      · linarith;
+      · cases lt_or_eq_of_le ‹_› <;> first | linarith | aesop;
+      · split_ifs <;> simp_all +decide [ Nat.succ_sub ];
+        · linarith;
+        · cases k : ( p - r * ( q + 1 ) ) / q <;> simp_all +decide [ Nat.succ_div ];
+          · exact Nat.mod_eq_zero_of_dvd h;
+          · exact Nat.mod_eq_zero_of_dvd h
+-/
 private lemma eqp_off_succ_new (q r p : ℕ) (hq : 0 < q)
     (h : eqp_idx q r (p + 1) ≠ eqp_idx q r p) :
     eqp_off q r (p + 1) = 0 := by
@@ -1230,6 +1320,19 @@ private lemma eqp_off_succ_new (q r p : ℕ) (hq : 0 < q)
     have := div_step (p - r * (q + 1)) q hq
     omega
 
+/- Aristotle alternative for `gap_mod_cases_gen` (6 lines vs 8 original, -2).
+
+private lemma gap_mod_cases_gen (s j₀ jg d : ℕ)
+    (hj₀ : j₀ < s) (hjg : jg < s)
+    (hmod : (jg + s - j₀) % s = d) :
+    jg + s - j₀ = d ∨ jg + s - j₀ = s + d := by
+      -- Since $(jg + s - j₀) \mod s = d$, we have $jg + s - j₀ = k * s + d$ for some integer $k$.
+      obtain ⟨k, hk⟩ : ∃ k : ℕ, jg + s - j₀ = k * s + d := by
+        -- By the division algorithm, we can write $jg + s - j₀$ as $k * s + d$ for some integer $k$.
+        use (jg + s - j₀) / s;
+        rw [ ← hmod, Nat.div_add_mod' ];
+      rcases k with ( _ | _ | k ) <;> simp_all +decide [ Nat.succ_mul ] ; omega;
+-/
 private lemma gap_mod_cases_gen (s j₀ jg d : ℕ)
     (hj₀ : j₀ < s) (hjg : jg < s)
     (hmod : (jg + s - j₀) % s = d) :
@@ -1425,6 +1528,19 @@ private lemma straddle2_gap1 (s g m : ℕ)
       have hsac12 := Nat.sub_add_cancel hmono12
       omega
 
+/- Aristotle alternative for `eqp_idx_succ_lt_m` (5 lines vs 6 original, -1).
+
+private lemma eqp_idx_succ_lt_m (q r s p : ℕ)
+    (hq_pos : 0 < q) (hr_lt : r < s)
+    (hm_eq : m = s * q + r)
+    (hp : p < m) :
+    p + 1 < m ∨ eqp_idx q r (p + 1) = s := by
+      -- Apply the lemma eqp_idx_m with the given conditions.
+      have h_eqp_idx_m : eqp_idx q r (s * q + r) = s := by
+        -- Apply the lemma eqp_idx_m with the given conditions to conclude the proof.
+        apply eqp_idx_m q r s hq_pos hr_lt;
+      grind +ring
+-/
 private lemma eqp_idx_succ_lt_m (q r s p : ℕ)
     (hq_pos : 0 < q) (hr_lt : r < s)
     (hm_eq : m = s * q + r)
@@ -1437,6 +1553,25 @@ private lemma eqp_idx_succ_lt_m (q r s p : ℕ)
     rw [hpm, hm_eq]
     exact eqp_idx_m q r s hq_pos hr_lt
 
+/- Aristotle alternative for `non_straddle_witness` (7 lines vs 10 original, -3).
+
+private lemma non_straddle_witness (q r p : ℕ)
+    (hq_pos : 0 < q)
+    (hp : p < m) (hp1 : p + 1 < m)
+    (hsame : eqp_idx q r (p + 1) = eqp_idx q r p)
+    (j : ℕ) (hj : j = eqp_idx q r p)
+    (t : ℕ) (ht : t < 3) (hpair : t = j % 3 ∨ t = (j + 1) % 3) :
+    ∃ d ∈ ({0, 1} : Finset ℕ),
+      (eqp_idx q r ((p + d) % m) +
+        eqp_off q r ((p + d) % m) % 2) % 3 = t := by
+          -- By Lemma `eqp_off_succ_same`, we know that `eqp_off q r (p + 1) = eqp_off q r p + 1`.
+          have h_off_succ : eqp_off q r (p + 1) = eqp_off q r p + 1 := by
+            -- Since $eqp_idx q r (p + 1) = eqp_idx q r p$, we can apply the definition of $eqp_off$ to conclude that $eqp_off q r (p + 1) = eqp_off q r p + 1$.
+            apply eqp_off_succ_same q r p hq_pos hsame;
+          cases hpair <;> simp_all +decide [ Nat.mod_eq_of_lt ];
+          · cases Nat.mod_two_eq_zero_or_one ( eqp_off q r p ) <;> simp +decide [ *, Nat.add_mod ];
+          · cases Nat.mod_two_eq_zero_or_one ( eqp_off q r p ) <;> simp +decide [ *, Nat.add_mod ]
+-/
 private lemma non_straddle_witness (q r p : ℕ)
     (hq_pos : 0 < q)
     (hp : p < m) (hp1 : p + 1 < m)
@@ -2685,6 +2820,15 @@ private lemma cycle_index_shift_ba {m : ℕ} {a b : ℤ} {d₁ : ℕ}
   rw [← hu]; ring_nf; rw [u.inv_mul]; ring
 
 /-- If Φ(i, j+1) = Φ(i, j) + b, then Φ⁻¹(x+b) = (same_i, j+1). -/
+/- Aristotle alternative for `equiv_symm_shift_b` (1 lines vs 3 original, -2).
+
+private lemma equiv_symm_shift_b {d₁ e₁ : ℕ} {γ : Type*} [AddCommMonoid γ]
+    (Φ : ZMod d₁ × ZMod e₁ ≃ γ) {b : γ}
+    (hΦ : ∀ i : ZMod d₁, ∀ j : ZMod e₁, Φ (i, j + 1) = Φ (i, j) + b)
+    (x : γ) :
+    Φ.symm (x + b) = ((Φ.symm x).1, (Φ.symm x).2 + 1) := by
+      grind
+-/
 private lemma equiv_symm_shift_b {d₁ e₁ : ℕ} {γ : Type*} [AddCommMonoid γ]
     (Φ : ZMod d₁ × ZMod e₁ ≃ γ) {b : γ}
     (hΦ : ∀ i : ZMod d₁, ∀ j : ZMod e₁, Φ (i, j + 1) = Φ (i, j) + b)
@@ -2695,6 +2839,15 @@ private lemma equiv_symm_shift_b {d₁ e₁ : ℕ} {γ : Type*} [AddCommMonoid �
   exact Φ.symm_apply_eq.mpr key.symm
 
 /-- If α(Φ(i,j)) = i for all i,j, then (Φ⁻¹(x)).1 = α(x). -/
+/- Aristotle alternative for `equiv_symm_fst_eq` (1 lines vs 2 original, -1).
+
+private lemma equiv_symm_fst_eq {d₁ e₁ : ℕ} {γ : Type*}
+    (Φ : ZMod d₁ × ZMod e₁ ≃ γ) (α : γ → ZMod d₁)
+    (hα : ∀ i : ZMod d₁, ∀ j : ZMod e₁, α (Φ (i, j)) = i)
+    (x : γ) :
+    (Φ.symm x).1 = α x := by
+      grind
+-/
 private lemma equiv_symm_fst_eq {d₁ e₁ : ℕ} {γ : Type*}
     (Φ : ZMod d₁ × ZMod e₁ ≃ γ) (α : γ → ZMod d₁)
     (hα : ∀ i : ZMod d₁, ∀ j : ZMod e₁, α (Φ (i, j)) = i)
@@ -2706,6 +2859,27 @@ private lemma equiv_symm_fst_eq {d₁ e₁ : ℕ} {γ : Type*}
 /-- Polychromaticity from an orbit coloring.
     Given an orbit equivalence Φ with shift properties and a coloring f,
     if f covers all colors at any translate, then f ∘ Φ.symm is polychromatic. -/
+/- Aristotle alternative for `orbit_coloring_polychrom` (4 lines vs 24 original, -20).
+
+private lemma orbit_coloring_polychrom {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
+    [NeZero m] [NeZero d₁] [NeZero e₁]
+    (Φ : ZMod d₁ × ZMod e₁ ≃ ZMod m)
+    (hΦ_add_b : ∀ x : ZMod m,
+      Φ.symm (x + ↑b) = ((Φ.symm x).1, (Φ.symm x).2 + 1))
+    (hΦ_cycle_shift : ∀ x : ZMod m,
+      (Φ.symm (x + ↑(b - a))).1 = (Φ.symm x).1 + 1)
+    (f : ZMod d₁ × ZMod e₁ → Fin 3)
+    (hcovers : ∀ (n : ZMod m) (k : Fin 3),
+      k = f ((Φ.symm n).1, (Φ.symm n).2) ∨
+      k = f ((Φ.symm n).1, (Φ.symm n).2 + 1) ∨
+      k = f ((Φ.symm n).1 + 1, (Φ.symm (n + ↑(b - a))).2) ∨
+      k = f ((Φ.symm n).1 + 1, (Φ.symm (n + ↑(b - a))).2 + 1)) :
+    HasPolychromColouring (Fin 3) (zmod_set m a b) := by
+      refine' ⟨ fun x => f ( Φ.symm x ), fun n k => _ ⟩;
+      obtain h|h|h|h := hcovers n k <;> simp_all +decide [ zmod_set ];
+      · grind;
+      · rw [ show ( n + ( 2 * b - a : ZMod m ) ) = ( n + ( b - a : ZMod m ) ) + b by ring, hΦ_add_b ] ; aesop;
+-/
 private lemma orbit_coloring_polychrom {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
     [NeZero m] [NeZero d₁] [NeZero e₁]
     (Φ : ZMod d₁ × ZMod e₁ ≃ ZMod m)

--- a/Lean/Polychromatic/FourThree/aristotle_results/compare.py
+++ b/Lean/Polychromatic/FourThree/aristotle_results/compare.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Compare Aristotle proof results against original proofs in Combi.lean.
+
+Overview
+--------
+Aristotle (https://aristotle.harmonic.fun) is an automated theorem prover.
+We submit lemmas from Combi.lean (via golf_batch.py) and Aristotle returns
+result files with alternative proofs. This script compares those results
+against the originals to identify which Aristotle proofs are shorter.
+
+Each result file (result_*.lean) has the structure:
+  1. Import stubs (Mathlib imports + stub definitions with `admit`)
+  2. Section/variable declarations matching Combi.lean's structure
+  3. Dependencies of the target lemma, proved with `admit`
+  4. Optionally, NEW helper lemmas Aristotle introduced
+  5. The target lemma with Aristotle's proof
+
+Line counting
+-------------
+For each result, we compute:
+  - **Body lines**: lines after `:= by` for the target lemma only (the
+    declaration signature is identical in both versions, so not counted)
+  - **Helper lines**: signature + body lines for any NEW helper lemmas
+    that Aristotle introduced and that don't already exist in Combi.lean.
+    These represent genuinely new code that would need to be added.
+  - **Total** = Body + Helper, compared against the original body line count.
+
+Stubs (proofs that are just `admit`/`sorry`) and lemmas that already exist
+in Combi.lean are excluded from the helper count. The "end Stubs" marker
+in each result file separates the boilerplate from the real content.
+
+When multiple result files exist for the same lemma (e.g. result_foo.lean
+and result_new_foo.lean), the script picks the best non-sorry result.
+
+Usage
+-----
+  python3 compare.py                    # Full comparison, sorted by delta
+  python3 compare.py --only better      # Only show improvements
+  python3 compare.py --sort name        # Sort alphabetically
+  python3 compare.py --sort status      # Group by status
+
+Output columns: Lemma, Orig (original body lines), Body (Aristotle target
+body), Help (new helper lines), Total (Body+Help), Delta (Total-Orig),
+Status (BETTER/SAME/WORSE/SORRY/N/A), New helpers (names).
+"""
+
+import argparse
+import os
+import re
+
+RESULTS_DIR = os.path.dirname(os.path.abspath(__file__))
+COMBI_PATH = os.path.join(RESULTS_DIR, "..", "Combi.lean")
+
+# Skip these result files (duplicates / old versions)
+SKIP_FILES = {
+    "result_case_one_interval_v2.lean",
+    "result_case_one_interval_v3.lean",
+    "result_case_one_res_3g_add_1_v2.lean",
+    "result_case_one_res_3g_add_4_v2.lean",
+    "result_old_batch_9.lean",
+}
+
+
+def parse_combi(path):
+    """Return two things:
+    1. dict: lemma_name -> proof body line count
+    2. set: all declaration names in Combi.lean
+    """
+    with open(path) as f:
+        lines = f.read().splitlines()
+
+    bodies = {}
+    names = set()
+    in_comment = False
+
+    for i, line in enumerate(lines):
+        # Track block comments (skip Aristotle alternatives)
+        if "/-" in line and not in_comment:
+            in_comment = True
+        if "-/" in line and in_comment:
+            in_comment = False
+            continue
+        if in_comment:
+            continue
+
+        m = re.match(
+            r"^(?:private\s+)?(?:noncomputable\s+)?(?:lemma|theorem|def)\s+(\S+)",
+            line,
+        )
+        if m:
+            name = m.group(1)
+            names.add(name)
+
+            # Find := by within next 15 lines
+            for j in range(i, min(i + 15, len(lines))):
+                if ":= by" in lines[j]:
+                    after = lines[j][lines[j].index(":= by") + 5 :].strip()
+                    body = 0
+                    if after and after not in ("admit", "sorry"):
+                        body = 1
+                    for k in range(j + 1, len(lines)):
+                        l = lines[k]
+                        if l.strip() == "":
+                            break
+                        if re.match(
+                            r"^(?:private\s+)?(?:noncomputable\s+)?"
+                            r"(?:lemma|theorem|def|end |section |namespace |"
+                            r"open |set_option|@\[|#|/-)",
+                            l,
+                        ):
+                            break
+                        body += 1
+                    bodies[name] = body
+                    break
+                if ":= sorry" in lines[j]:
+                    bodies[name] = 1
+                    break
+
+    return bodies, names
+
+
+def parse_aristotle(filepath, combi_names):
+    """Parse an Aristotle result file.
+
+    Returns (target_name, target_body, helper_lines, has_sorry, helper_names)
+    where:
+    - target_body = body lines only (after := by) for the target lemma
+    - helper_lines = sig + body for NEW helpers not in Combi.lean
+    - has_sorry = True if target proof contains sorry/admit
+    - helper_names = list of new helper names
+    """
+    with open(filepath) as f:
+        lines = f.read().splitlines()
+
+    # Find end of Stubs section
+    stubs_end = 0
+    for i, line in enumerate(lines):
+        if line.strip() == "end Stubs":
+            stubs_end = i
+            break
+
+    decls = []  # (name, sig_lines, body_lines, is_stub, has_sorry)
+    i = stubs_end
+    n = len(lines)
+    in_comment = False
+
+    while i < n:
+        stripped = lines[i].strip()
+        if "/-" in stripped and not in_comment:
+            in_comment = True
+        if "-/" in stripped and in_comment:
+            in_comment = False
+            i += 1
+            continue
+        if in_comment:
+            i += 1
+            continue
+
+        m = re.match(
+            r"^(?:private\s+)?(?:noncomputable\s+)?"
+            r"(?:lemma|theorem|def)\s+(\S+)",
+            stripped,
+        )
+        if m:
+            name = m.group(1)
+            sig_start = i
+            for j in range(i, min(i + 20, n)):
+                if ":= by" in lines[j]:
+                    after = lines[j][lines[j].index(":= by") + 5 :].strip()
+                    is_stub = after in ("admit", "sorry")
+                    body = 0
+                    has_sorry = False
+
+                    if not is_stub and after:
+                        body = 1
+
+                    if not is_stub:
+                        for k in range(j + 1, n):
+                            bl = lines[k]
+                            if bl.strip() == "":
+                                break
+                            if re.match(
+                                r"^(?:private\s+)?(?:noncomputable\s+)?"
+                                r"(?:lemma|theorem|def|end |section |"
+                                r"namespace |open |set_option|@\[|#|/-|macro )",
+                                bl,
+                            ):
+                                break
+                            if bl.strip() in ("admit", "sorry") and body == 0:
+                                is_stub = True
+                                break
+                            body += 1
+                            if "sorry" in bl:
+                                has_sorry = True
+
+                    sig_count = j - sig_start  # lines before := by
+                    decls.append((name, sig_count, body, is_stub, has_sorry))
+                    break
+                elif ":=" in lines[j]:
+                    # Direct definition (not := by)
+                    is_stub = "sorry" in lines[j] or "admit" in lines[j]
+                    body = 1  # the := line
+                    for k in range(j + 1, n):
+                        bl = lines[k]
+                        if bl.strip() == "":
+                            break
+                        if re.match(
+                            r"^(?:private\s+)?(?:noncomputable\s+)?"
+                            r"(?:lemma|theorem|def|end |section |"
+                            r"namespace |open |set_option|@\[|#|/-|macro )",
+                            bl,
+                        ):
+                            break
+                        body += 1
+                    sig_count = j - sig_start
+                    decls.append((name, sig_count, body, is_stub, False))
+                    break
+
+        # Catch macro lines as helpers
+        if stripped.startswith("macro "):
+            decls.append(("_macro_", 0, 1, False, False))
+
+        i += 1
+
+    if not decls:
+        return None, 0, 0, True, []
+
+    # Target = last non-stub declaration
+    target = None
+    target_idx = None
+    for idx in range(len(decls) - 1, -1, -1):
+        if not decls[idx][3]:
+            target = decls[idx]
+            target_idx = idx
+            break
+
+    if target is None:
+        return decls[-1][0] if decls else None, 0, 0, True, []
+
+    # NEW helpers = non-stub, not target, name not in Combi.lean
+    helper_lines = 0
+    helper_names = []
+    for idx, (name, sig, body, stub, _) in enumerate(decls):
+        if stub or idx == target_idx:
+            continue
+        clean = name.replace("Finset.", "")
+        if clean not in combi_names and name not in combi_names:
+            helper_lines += sig + body
+            helper_names.append(clean)
+
+    return target[0], target[2], helper_lines, target[4], helper_names
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sort",
+        choices=["delta", "name", "status"],
+        default="delta",
+        help="Sort order (default: delta)",
+    )
+    parser.add_argument(
+        "--only",
+        choices=["better", "worse", "same", "sorry"],
+        help="Only show results with this status",
+    )
+    args = parser.parse_args()
+
+    combi_bodies, combi_names = parse_combi(COMBI_PATH)
+
+    # Process all result files, deduplicate by target name
+    all_results = {}  # key -> (target_body, helper_lines, sorry, fname, helper_names)
+
+    for f in sorted(os.listdir(RESULTS_DIR)):
+        if not f.startswith("result_") or not f.endswith(".lean") or f in SKIP_FILES:
+            continue
+        path = os.path.join(RESULTS_DIR, f)
+        name, tbody, hlines, sorry, hnames = parse_aristotle(path, combi_names)
+        if name is None:
+            continue
+        name = name.replace("Finset.", "")
+        total = tbody + hlines
+
+        key = name
+        if key not in all_results:
+            all_results[key] = (tbody, hlines, sorry, f, hnames)
+        elif sorry and not all_results[key][2]:
+            pass  # keep non-sorry
+        elif not sorry and all_results[key][2]:
+            all_results[key] = (tbody, hlines, sorry, f, hnames)
+        elif not sorry and total < (all_results[key][0] + all_results[key][1]):
+            all_results[key] = (tbody, hlines, sorry, f, hnames)
+
+    # Build rows
+    rows = []
+    for name in sorted(all_results):
+        tbody, hlines, sorry, fname, hnames = all_results[name]
+        orig = combi_bodies.get(name)
+        total = tbody + hlines
+
+        if sorry:
+            status = "SORRY"
+            delta = None
+        elif orig is None:
+            status = "N/A"
+            delta = None
+        else:
+            delta = total - orig
+            status = "BETTER" if delta < 0 else ("WORSE" if delta > 0 else "SAME")
+
+        rows.append((name, orig, tbody, hlines, total, delta, status, fname, hnames))
+
+    # Filter
+    if args.only:
+        rows = [r for r in rows if r[6].lower() == args.only]
+
+    # Sort
+    status_order = {"BETTER": 0, "SAME": 1, "WORSE": 2, "SORRY": 3, "N/A": 4}
+    if args.sort == "delta":
+        rows.sort(
+            key=lambda r: (status_order[r[6]], r[5] if r[5] is not None else 999)
+        )
+    elif args.sort == "name":
+        rows.sort(key=lambda r: r[0])
+    elif args.sort == "status":
+        rows.sort(key=lambda r: (status_order[r[6]], r[0]))
+
+    # Print
+    print(
+        f"{'Lemma':<38} {'Orig':>4} {'Body':>4} {'Help':>5} "
+        f"{'Total':>5} {'Delta':>6} {'Status':<7} {'New helpers'}"
+    )
+    print("-" * 120)
+
+    counts = {}
+    for name, orig, tbody, hlines, total, delta, status, fname, hnames in rows:
+        orig_s = str(orig) if orig is not None else "?"
+        delta_s = f"{delta:+d}" if delta is not None else "N/A"
+        help_s = f"+{hlines}" if hlines > 0 else ""
+        print(
+            f"{name:<38} {orig_s:>4} {tbody:>4} {help_s:>5} "
+            f"{total:>5} {delta_s:>6} {status:<7} {', '.join(hnames)}"
+        )
+        counts[status] = counts.get(status, 0) + 1
+
+    total_delta = sum(r[5] for r in rows if r[5] is not None)
+    print(
+        f"\nBETTER: {counts.get('BETTER', 0)}  "
+        f"SAME: {counts.get('SAME', 0)}  "
+        f"WORSE: {counts.get('WORSE', 0)}  "
+        f"SORRY: {counts.get('SORRY', 0)}  "
+        f"N/A: {counts.get('N/A', 0)}"
+    )
+    print(f"Net delta: {total_delta:+d} lines")
+
+
+if __name__ == "__main__":
+    main()

--- a/Lean/Polychromatic/FourThree/aristotle_results/golf_batch.py
+++ b/Lean/Polychromatic/FourThree/aristotle_results/golf_batch.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+"""
+Batch-submit proofs from Combi.lean to Aristotle for golfing.
+
+Overview
+--------
+Aristotle (https://aristotle.harmonic.fun) is an automated theorem prover.
+This script extracts lemmas from Combi.lean and submits them to Aristotle
+to find shorter proofs. Results are saved as result_<name>.lean files in
+the same directory, and submission status is tracked in status.json.
+
+How it works
+------------
+For each eligible proof (non-sorry, ≥ min-size lines):
+
+1. **Extract**: Parse Combi.lean to find all lemma/def declarations, their
+   signatures, proof bodies, and line ranges.
+
+2. **Dependency resolution**: BFS over the file to find all lemmas that the
+   target transitively references. These are included in the scratch file
+   with their proofs replaced by `admit`, so Aristotle knows their types
+   but doesn't need to re-prove them.
+
+3. **Scratch file creation**: Build a minimal .lean file containing:
+   - Import stubs (Mathlib imports + stub definitions for IsPolychrom,
+     HasPolychromColouring, polychromNumber, etc.)
+   - Section/variable declarations that are in scope
+   - Transitive dependencies with proofs replaced by `admit`
+   - The target lemma with its proof replaced by `sorry`
+   This avoids sending the full 2500-line Combi.lean to Aristotle.
+
+4. **Submission**: Send the scratch file to Aristotle via `aristotlelib`
+   SDK. Aristotle attempts to prove the sorry'd lemma and writes the
+   result to result_<name>.lean.
+
+5. **Status tracking**: Results are recorded in status.json so already-
+   completed proofs are skipped on re-runs. Proofs are submitted in
+   batches of --batch size concurrently.
+
+Requirements
+------------
+- `aristotlelib` Python package (install in a dedicated venv/pyenv)
+- Aristotle API key configured for aristotlelib
+
+Usage
+-----
+  PYENV_VERSION=aristotle python3 golf_batch.py              # submit all ≥5 lines
+  PYENV_VERSION=aristotle python3 golf_batch.py --min-size 3  # submit all ≥3 lines
+  PYENV_VERSION=aristotle python3 golf_batch.py --batch 5     # 5 concurrent submissions
+  PYENV_VERSION=aristotle python3 golf_batch.py --start-from case2b_coverage_gen
+  PYENV_VERSION=aristotle python3 golf_batch.py --only foo,bar,baz
+  PYENV_VERSION=aristotle python3 golf_batch.py --list        # dry run: list eligible proofs
+
+Output files
+------------
+  scratch_<name>.lean  - the minimal file sent to Aristotle (can be deleted)
+  result_<name>.lean   - Aristotle's response with its proof attempt
+  status.json          - tracks which proofs have been submitted and their results
+
+Use compare.py to evaluate which Aristotle results are actually shorter.
+"""
+
+import asyncio
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+import aristotlelib
+
+COMBI_PATH = Path(__file__).parent.parent / "Combi.lean"
+RESULTS_DIR = Path(__file__).parent
+STATUS_FILE = RESULTS_DIR / "status.json"
+
+# Stub definitions to replace `import Polychromatic.*` so Aristotle doesn't
+# pull in the full project (which has files incompatible with its mathlib).
+IMPORT_STUBS = """\
+import Mathlib.Algebra.Ring.AddAut
+import Mathlib.Algebra.Group.Action.Pointwise.Finset
+import Mathlib.Data.ZMod.Basic
+
+open Finset Pointwise
+
+set_option autoImplicit true
+
+section Stubs
+
+variable {G : Type*} [DecidableEq G] [AddCommGroup G]
+
+def IsPolychrom (S : Finset G) (χ : G → K) : Prop :=
+  ∀ n : G, ∀ k : K, ∃ a ∈ S, χ (n + a) = k
+
+def HasPolychromColouring (K : Type*) (S : Finset G) : Prop :=
+  ∃ χ : G → K, IsPolychrom S χ
+
+@[simp] lemma hasPolychromColouring_univ [Fintype G] :
+    HasPolychromColouring G (Finset.univ : Finset G) := by admit
+
+lemma HasPolychromColouring.of_image {H : Type*} [DecidableEq H] [AddCommGroup H]
+    {F : Type*} [FunLike F G H] [AddHomClass F G H] (φ : F)
+    {K : Type*} {S : Finset G}
+    (h : HasPolychromColouring K (S.image φ)) :
+    HasPolychromColouring K S := by admit
+
+noncomputable def polychromNumber (S : Finset G) : ℕ :=
+  sSup {n | HasPolychromColouring (Fin n) S}
+
+lemma polychromNumber_vadd {n : G} {S : Finset G} :
+    polychromNumber (n +ᵥ S) = polychromNumber S := by admit
+
+lemma le_polychromNumber {S : Finset G} {n : ℕ} (hn : HasPolychromColouring (Fin n) S) :
+    n ≤ polychromNumber S := by admit
+
+lemma hasPolychromColouring_fin_of_le {S : Finset G} {n : ℕ}
+    (hn : n ≠ 0) (hS : n ≤ polychromNumber S) :
+    HasPolychromColouring (Fin n) S := by admit
+
+lemma polychromNumber_iso {H : Type*} [DecidableEq H] [AddCommGroup H]
+    {F : Type*} [EquivLike F G H] [AddEquivClass F G H] (φ : F)
+    {S : Finset G} :
+    polychromNumber (S.image φ) = polychromNumber S := by admit
+
+end Stubs
+
+set_option autoImplicit false
+
+"""
+
+
+def extract_proofs(filepath: Path) -> list[dict]:
+    """Extract all proofs with their line ranges from Combi.lean."""
+    with open(filepath) as f:
+        lines = f.readlines()
+
+    decl_pat = re.compile(r'^(private\s+)?(theorem|lemma|def|instance)\s+(\S+)')
+    proofs = []
+    i = 0
+    while i < len(lines):
+        m = decl_pat.match(lines[i])
+        if m:
+            name = m.group(3)
+            start = i  # 0-indexed
+
+            # Find ':= by', ':= fun', ':= if', ':= sorry', or plain ':='
+            j = i
+            has_proof = False
+            is_sorry = False
+            is_term = False
+            by_line = -1
+            while j < len(lines):
+                if ':= by' in lines[j]:
+                    has_proof = True
+                    by_line = j
+                    break
+                if ':= sorry' in lines[j]:
+                    is_sorry = True
+                    break
+                if ':= fun' in lines[j] or ':= if' in lines[j]:
+                    has_proof = True
+                    by_line = j
+                    break
+                # Plain term-mode definition (e.g. `def foo := expr`)
+                if ':=' in lines[j] and not any(
+                    p in lines[j] for p in [':= by', ':= sorry', ':= fun', ':= if']
+                ):
+                    is_term = True
+                    by_line = j
+                    break
+                # Match-expression definition (equation compiler, e.g. `| 0 => ...`)
+                if j > i and re.match(r'^\s+\|', lines[j]):
+                    is_term = True
+                    by_line = i  # include from declaration start
+                    break
+                if j > i and decl_pat.match(lines[j]):
+                    break
+                j += 1
+
+            if has_proof or is_term:
+                # Find end of proof/definition
+                k = by_line + 1
+                while k < len(lines):
+                    line = lines[k]
+                    if decl_pat.match(line):
+                        break
+                    if re.match(r'^(section|end|namespace|/-!|/--|open|variable|#)', line):
+                        break
+                    k += 1
+                proof_lines = k - start
+                proofs.append({
+                    'name': name,
+                    'start': start,        # 0-indexed inclusive
+                    'by_line': by_line,     # 0-indexed, line with ':= by'
+                    'end': k,              # 0-indexed exclusive
+                    'size': proof_lines,
+                    'is_sorry': is_sorry,
+                    'is_term': is_term,    # term-mode def, include verbatim
+                })
+                i = k
+                continue
+            elif is_sorry:
+                proofs.append({
+                    'name': name,
+                    'start': start,
+                    'by_line': j,
+                    'end': j + 1,
+                    'size': j + 1 - start,
+                    'is_sorry': True,
+                })
+                i = j + 1
+                continue
+        i += 1
+    return proofs
+
+
+def find_dependencies(filepath: Path, proof: dict, all_proofs: list[dict]) -> list[dict]:
+    """Find proofs that the target proof transitively references."""
+    with open(filepath) as f:
+        lines = f.readlines()
+
+    def direct_deps(p: dict) -> list[dict]:
+        body = ''.join(lines[p['start']:p['end']])
+        deps = []
+        for q in all_proofs:
+            if q['name'] == p['name']:
+                continue
+            if q['start'] >= p['start']:
+                continue  # only look at earlier declarations
+            if re.search(r'\b' + re.escape(q['name']) + r'\b', body):
+                deps.append(q)
+        return deps
+
+    # BFS for transitive dependencies
+    seen = {proof['name']}
+    queue = direct_deps(proof)
+    result = []
+    while queue:
+        dep = queue.pop(0)
+        if dep['name'] in seen:
+            continue
+        seen.add(dep['name'])
+        result.append(dep)
+        queue.extend(direct_deps(dep))
+
+    # Sort by file order so definitions come before uses
+    result.sort(key=lambda p: p['start'])
+    return result
+
+
+def create_scratch_file(filepath: Path, proof: dict, output_path: Path,
+                        all_proofs: list[dict] | None = None):
+    """Create a minimal file with just the target lemma (sorry'd) and its
+    dependencies (admitted), plus stubs for imported definitions.
+
+    This avoids sending 2500 lines to Aristotle, which causes env errors.
+    """
+    with open(filepath) as f:
+        lines = f.readlines()
+
+    out = [IMPORT_STUBS]
+
+    # Find section variables that are in scope for this proof
+    # (e.g. `variable (m : ℕ)`)
+    for idx in range(proof['start']):
+        line = lines[idx]
+        if line.startswith('variable '):
+            out.append(line)
+        elif line.startswith('section ') or line.startswith('end '):
+            out.append(line)
+
+    out.append('\n')
+
+    # Add dependencies as admitted lemmas (or verbatim for term-mode defs)
+    if all_proofs:
+        deps = find_dependencies(filepath, proof, all_proofs)
+        for dep in deps:
+            if dep.get('is_term'):
+                # Term-mode definition: include verbatim
+                for idx in range(dep['start'], dep['end']):
+                    out.append(lines[idx])
+            else:
+                # Proof: include signature but replace proof with admit
+                for idx in range(dep['start'], dep['end']):
+                    if idx == dep['by_line']:
+                        by_line_text = lines[idx]
+                        for pattern in [':= by', ':= fun', ':= if']:
+                            if pattern in by_line_text:
+                                out.append(by_line_text[:by_line_text.index(pattern)]
+                                           + ':= by admit\n')
+                                break
+                        break
+                    else:
+                        out.append(lines[idx])
+            out.append('\n')
+
+    # Add the target proof as sorry
+    for idx in range(proof['start'], proof['end']):
+        if idx == proof['by_line']:
+            by_line_text = lines[idx]
+            for pattern in [':= by', ':= fun', ':= if']:
+                if pattern in by_line_text:
+                    out.append(by_line_text[:by_line_text.index(pattern)]
+                               + ':= sorry\n')
+                    break
+            break
+        else:
+            out.append(lines[idx])
+
+    with open(output_path, 'w') as f:
+        f.writelines(out)
+
+
+def load_status() -> dict:
+    if STATUS_FILE.exists():
+        with open(STATUS_FILE) as f:
+            return json.load(f)
+    return {}
+
+
+def save_status(status: dict):
+    with open(STATUS_FILE, 'w') as f:
+        json.dump(status, f, indent=2)
+
+
+async def submit_proof(proof: dict, scratch_path: Path, output_path: Path,
+                       completed: dict) -> tuple[str, str]:
+    """Submit a single proof to Aristotle via SDK and return (name, status)."""
+    name = proof['name']
+
+    try:
+        with open(scratch_path) as f:
+            content = f.read()
+
+        solution_path = await aristotlelib.Project.prove_from_file(
+            input_content=content,
+            auto_add_imports=False,
+            validate_lean_project=False,
+            output_file_path=str(output_path),
+        )
+
+        if not output_path.exists():
+            result = "failed: no output"
+            print(f"  ✗ {name}: no output file produced")
+        else:
+            result_text = output_path.read_text()
+            if 'sorry' not in result_text:
+                result = "proved"
+                print(f"  ✓ {name} PROVED")
+            elif 'The following was proved' in result_text[:500]:
+                result = "proved"
+                print(f"  ✓ {name} PROVED (with header)")
+            else:
+                result = "still_sorry"
+                print(f"  ~ {name} returned but still sorry")
+    except Exception as e:
+        result = f"failed: {e}"
+        print(f"  ✗ {name} failed: {e}")
+
+    completed[name] = result
+    return name, result
+
+
+def _format_elapsed(seconds: float) -> str:
+    m, s = divmod(int(seconds), 60)
+    if m >= 60:
+        h, m = divmod(m, 60)
+        return f"{h}h{m:02d}m"
+    return f"{m}m{s:02d}s"
+
+
+async def _progress_printer(total: int, completed: dict, names: list[str],
+                             start_time: float):
+    """Print periodic progress updates while waiting for submissions."""
+    import time
+    while len(completed) < total:
+        await asyncio.sleep(60)
+        elapsed = time.time() - start_time
+        done = len(completed)
+        pending = [n for n in names if n not in completed]
+        pending_str = ", ".join(pending[:4])
+        if len(pending) > 4:
+            pending_str += f", ... (+{len(pending) - 4})"
+        print(f"  ⏳ {done}/{total} complete, {_format_elapsed(elapsed)} elapsed. "
+              f"Waiting: {pending_str}")
+
+
+async def run_batch(proofs: list[dict], all_proofs: list[dict], batch_size: int):
+    """Submit a batch of proofs concurrently."""
+    import time
+    status = load_status()
+
+    tasks = []
+    for proof in proofs:
+        name = proof['name']
+        if name in status and status[name].get('result') in ('proved', 'complete'):
+            print(f"  Skipping {name} (already done)")
+            continue
+
+        scratch_path = RESULTS_DIR / f"scratch_{name}.lean"
+        output_path = RESULTS_DIR / f"result_{name}.lean"
+
+        create_scratch_file(COMBI_PATH, proof, scratch_path, all_proofs)
+
+        tasks.append((proof, scratch_path, output_path))
+
+    # Process in batches
+    for i in range(0, len(tasks), batch_size):
+        batch = tasks[i:i + batch_size]
+        names = [p['name'] for p, _, _ in batch]
+        print(f"\nBatch {i // batch_size + 1}: {len(batch)} proofs")
+        print(f"  Submitting: {', '.join(names)}")
+
+        completed = {}
+        start_time = time.time()
+
+        # Launch proof submissions + progress printer concurrently
+        proof_tasks = [
+            submit_proof(p, sp, op, completed) for p, sp, op in batch
+        ]
+        progress_task = asyncio.create_task(
+            _progress_printer(len(batch), completed, names, start_time)
+        )
+
+        results = await asyncio.gather(*proof_tasks)
+        progress_task.cancel()
+
+        elapsed = time.time() - start_time
+        print(f"  Batch done in {_format_elapsed(elapsed)}")
+
+        for (proof, _, _), (_, result) in zip(batch, results):
+            status[proof['name']] = {
+                'result': result,
+                'size': proof['size'],
+                'lines': f"L{proof['start']+1}-{proof['end']}",
+            }
+        save_status(status)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--batch', type=int, default=10, help='Batch size')
+    parser.add_argument('--min-size', type=int, default=5, help='Min proof lines')
+    parser.add_argument('--start-from', type=str, help='Start from this proof name')
+    parser.add_argument('--only', type=str, help='Comma-separated list of proof names')
+    parser.add_argument('--list', action='store_true', help='Just list eligible proofs')
+    args = parser.parse_args()
+
+    os.chdir(COMBI_PATH.parent.parent.parent)  # cd to Lean/
+
+    all_proofs = extract_proofs(COMBI_PATH)
+
+    # Filter: non-sorry, non-term-mode, ≥ min_size lines
+    eligible = [p for p in all_proofs
+                if not p.get('is_sorry') and not p.get('is_term') and p['size'] >= args.min_size]
+
+    if args.only:
+        names = set(args.only.split(','))
+        eligible = [p for p in eligible if p['name'] in names]
+
+    if args.start_from:
+        idx = next((i for i, p in enumerate(eligible) if p['name'] == args.start_from), 0)
+        eligible = eligible[idx:]
+
+    if args.list:
+        for p in eligible:
+            print(f"{p['size']:4d} lines  L{p['start']+1:4d}-{p['end']:4d}  {p['name']}")
+        print(f"\nTotal: {len(eligible)} eligible proofs")
+        return
+
+    print(f"Eligible proofs: {len(eligible)} (≥{args.min_size} lines, non-sorry)")
+    asyncio.run(run_batch(eligible, all_proofs, args.batch))
+
+
+if __name__ == '__main__':
+    main()

--- a/Lean/Polychromatic/FourThree/aristotle_results/golf_batch.py
+++ b/Lean/Polychromatic/FourThree/aristotle_results/golf_batch.py
@@ -74,6 +74,15 @@ COMBI_PATH = Path(__file__).parent.parent / "Combi.lean"
 RESULTS_DIR = Path(__file__).parent
 STATUS_FILE = RESULTS_DIR / "status.json"
 
+
+def sanitize_filename(name: str) -> str:
+    """Sanitize a Lean identifier for use in filenames.
+
+    Lean identifiers can contain apostrophes (e.g. pos_shift_succ'), which are
+    fragile in filenames across platforms and shells. Replace them with `_prime`.
+    """
+    return name.replace("'", "_prime")
+
 # Stub definitions to replace `import Polychromatic.*` so Aristotle doesn't
 # pull in the full project (which has files incompatible with its mathlib).
 IMPORT_STUBS = """\
@@ -397,8 +406,9 @@ async def run_batch(proofs: list[dict], all_proofs: list[dict], batch_size: int)
             print(f"  Skipping {name} (already done)")
             continue
 
-        scratch_path = RESULTS_DIR / f"scratch_{name}.lean"
-        output_path = RESULTS_DIR / f"result_{name}.lean"
+        safe_name = sanitize_filename(name)
+        scratch_path = RESULTS_DIR / f"scratch_{safe_name}.lean"
+        output_path = RESULTS_DIR / f"result_{safe_name}.lean"
 
         create_scratch_file(COMBI_PATH, proof, scratch_path, all_proofs)
 


### PR DESCRIPTION
Adds scripts for automated proof golfing via [Aristotle](https://aristotle.harmonic.fun) and annotates shorter proof alternatives as comments in Combi.lean.

**Scripts** (`Lean/Polychromatic/FourThree/aristotle_results/`):
- `golf_batch.py` — extracts lemmas from Combi.lean, creates minimal scratch files with dependencies admitted, and submits them to Aristotle via the SDK
- `compare.py` — compares all Aristotle result files against Combi.lean originals with helper-inclusive line counting

**Results**: Out of ~100 lemmas submitted, Aristotle found shorter proofs for 24, matched on 13, and produced longer proofs for 46 (the rest were sorry or N/A). The 24 winners are annotated as `/- Aristotle alternative for ... -/` comments containing the full proof, totalling -167 lines of potential savings. The biggest wins are `case2d_rotation_sum_exists` (-49), `case_one_dispatch` (-33), `case_one_div_3g3` (-13), `case_wrap_BB` (-13), `blockColor_polychrom` (-12), `case2d_shift_ba_wrap` (-10), and `exists_g_of_coprime` (-10).

The annotations are for reference when manually golfing — the Aristotle proofs often need adaptation since they may use different proof strategies.