### PR TITLE
Extract orbitEquiv and apply to all 4 case lemmas

### DIFF
--- a/Lean/Polychromatic/FourThree/Combi.lean
+++ b/Lean/Polychromatic/FourThree/Combi.lean
@@ -141,6 +141,6 @@ theorem normal_bit :
     grind
   · have : 0 < d₁ := Nat.gcd_pos_of_pos_right _ hm_pos
     have : 0 < d₂ := Nat.gcd_pos_of_pos_right _ hm_pos
-    exact main_case_two m a b (by grind) (gcd_coprime_of_gcd_abc hm_eq hgcd) (by grind)
+    exact main_case_two (by grind) (gcd_coprime_of_gcd_abc hm_eq hgcd) (by grind)
 
 end Assembly

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -110,26 +110,22 @@ private lemma d₁_dvd_b : (d₁ : ℤ) ∣ b :=
 private lemma b_zero_mod_d1 [NeZero m] : (b : ZMod d₁) = 0 :=
   (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mpr (d₁_dvd_b (b := b))
 
-private lemma ba_coprime_d1
-    (h_gcd_coprime : Nat.gcd d₁ d₂ = 1) :
+private lemma ba_coprime_d1 (h_gcd_coprime : Nat.gcd d₁ d₂ = 1) :
     Nat.Coprime (b - a).natAbs d₁ :=
   Nat.dvd_one.mp (h_gcd_coprime ▸ Nat.dvd_gcd (Nat.gcd_dvd_right _ _)
       (Nat.dvd_gcd (Nat.gcd_dvd_left _ _) (dvd_trans (Nat.gcd_dvd_right _ _) d₁_dvd_m)))
 
-private lemma orbitMap_i_eq [NeZero m]
-    (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) {i₁ i₂ : ZMod d₁} {j₁ j₂ : ZMod e₁}
-    (heq : orbitMap m a b (i₁, j₁) = orbitMap m a b (i₂, j₂)) :
-    i₁ = i₂ := by
+private lemma orbitMap_i_eq [NeZero m] (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
+    {i₁ i₂ : ZMod d₁} {j₁ j₂ : ZMod e₁}
+    (heq : orbitMap m a b (i₁, j₁) = orbitMap m a b (i₂, j₂)) : i₁ = i₂ := by
   simp only [orbitMap] at heq
   have := congr_arg (ZMod.castHom d₁_dvd_m (ZMod d₁)) heq
   simp only [map_add, map_mul, map_natCast, map_intCast] at this
   simp only [b_zero_mod_d1, mul_zero, add_zero, ZMod.natCast_val, ZMod.cast_id] at this
   exact hba_unit.mul_right_cancel this
 
-private lemma orbitMap_j_eq [NeZero m]
-    {j₁ j₂ : ZMod e₁}
-    (hj_smul : (j₁.val : ℕ) • (b : ZMod m) = (j₂.val : ℕ) • (b : ZMod m)) :
-    j₁ = j₂ := by
+private lemma orbitMap_j_eq [NeZero m] {j₁ j₂ : ZMod e₁}
+    (hj_smul : (j₁.val : ℕ) • (b : ZMod m) = (j₂.val : ℕ) • (b : ZMod m)) : j₁ = j₂ := by
   wlog h : j₁.val ≤ j₂.val with H
   · exact (H hj_smul.symm (Nat.le_of_not_le h)).symm
   · have h3 : (j₂.val - j₁.val) • (b : ZMod m) = 0 :=
@@ -140,8 +136,7 @@ private lemma orbitMap_j_eq [NeZero m]
       (by grind [ZMod.val_lt j₁, ZMod.val_lt j₂])
     exact ZMod.val_injective _ (by grind)
 
-private lemma orbitMap_injective [NeZero m]
-    (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) :
+private lemma orbitMap_injective [NeZero m] (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) :
     Function.Injective (orbitMap m a b : ZMod d₁ × ZMod e₁ → ZMod m) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   intro ⟨i₁, j₁⟩ ⟨i₂, j₂⟩ heq
@@ -151,16 +146,14 @@ private lemma orbitMap_injective [NeZero m]
   have hj_smul : (j₁.val : ℕ) • (b : ZMod m) = (j₂.val : ℕ) • (b : ZMod m) := by grind
   exact Prod.ext rfl (orbitMap_j_eq hj_smul)
 
-private lemma orbitMap_bijective [NeZero m]
-    (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) :
+private lemma orbitMap_bijective [NeZero m] (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) :
     Function.Bijective (orbitMap m a b : ZMod d₁ × ZMod e₁ → ZMod m) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   exact (Fintype.bijective_iff_injective_and_card _).mpr
     ⟨orbitMap_injective hba_unit,
      by simp only [Fintype.card_prod, ZMod.card]; linarith [hm_eq]⟩
 
-private lemma orbitMap_shift_b [NeZero m]
-    (he1_b_zero : e₁ • (b : ZMod m) = 0) :
+private lemma orbitMap_shift_b [NeZero m] (he1_b_zero : e₁ • (b : ZMod m) = 0) :
     ∀ p : ZMod d₁ × ZMod e₁,
       orbitMap m a b p + (b : ZMod m) = orbitMap m a b (p.1, p.2 + 1) := by
   intro ⟨i, j⟩
@@ -177,8 +170,7 @@ private lemma orbitMap_shift_b [NeZero m]
       rw [this, hje, he1_b_zero]
     rw [hv, Nat.cast_zero, zero_mul, add_zero, add_assoc, h1, add_zero]
 
-private lemma orbitMap_shift_ba [NeZero m]
-    (i : ZMod d₁) (j : ZMod e₁) (hi : i.val + 1 < d₁) :
+private lemma orbitMap_shift_ba [NeZero m] (i : ZMod d₁) (j : ZMod e₁) (hi : i.val + 1 < d₁) :
     orbitMap m a b (i, j) + ((b - a : ℤ) : ZMod m) = orbitMap m a b (i + 1, j) := by
   simp only [orbitMap]
   have : (i + 1).val = i.val + 1 := by rw [ZMod.val_add_one]; exact Nat.mod_eq_of_lt hi
@@ -212,17 +204,17 @@ private lemma equiv_symm_shift_b {γ : Type*} [AddCommMonoid γ]
     Φ.symm (x + b) = ((Φ.symm x).1, (Φ.symm x).2 + 1) := by grind
 
 /-- If α(Φ(i,j)) = i for all i,j, then (Φ⁻¹(x)).1 = α(x). -/
-private lemma equiv_symm_fst_eq {γ : Type*}
-    (Φ : ZMod d₁ × ZMod e₁ ≃ γ) (α : γ → ZMod d₁)
-    (hα : ∀ i : ZMod d₁, ∀ j : ZMod e₁, α (Φ (i, j)) = i) (x : γ) : (Φ.symm x).1 = α x := by grind
+private lemma equiv_symm_fst_eq {γ : Type*} (Φ : ZMod d₁ × ZMod e₁ ≃ γ) (α : γ → ZMod d₁)
+    (hα : ∀ i : ZMod d₁, ∀ j : ZMod e₁, α (Φ (i, j)) = i) (x : γ) :
+    (Φ.symm x).1 = α x := by grind
 
 /-- Build the orbit equivalence from the standard hypotheses. -/
 private noncomputable def orbitEquiv [NeZero m]
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) : ZMod d₁ × ZMod e₁ ≃ ZMod m :=
   Equiv.ofBijective (orbitMap m a b) (orbitMap_bijective hba_unit)
 
-private lemma orbitEquiv_shift_b [NeZero m]
-    {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)} (x : ZMod m) :
+private lemma orbitEquiv_shift_b [NeZero m] {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
+    (x : ZMod m) :
     (orbitEquiv hba_unit).symm (x + ↑b) =
     (((orbitEquiv hba_unit).symm x).1,
      ((orbitEquiv hba_unit).symm x).2 + 1) := by
@@ -231,8 +223,8 @@ private lemma orbitEquiv_shift_b [NeZero m]
     (orbitMap_shift_b (addOrderOf_b_eq (b := b) (m := m) ▸
       addOrderOf_nsmul_eq_zero _) (i, j)).symm) x
 
-private lemma orbitEquiv_cycle_shift [NeZero m]
-    {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)} (x : ZMod m) :
+private lemma orbitEquiv_cycle_shift [NeZero m] {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
+    (x : ZMod m) :
     ((orbitEquiv hba_unit).symm (x + ↑(b - a))).1 =
     ((orbitEquiv hba_unit).symm x).1 + 1 := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
@@ -248,8 +240,7 @@ private lemma orbitEquiv_cycle_shift [NeZero m]
   exact (hΦ_cycle x).symm
 
 /-- In the non-wrap case, the second coordinate is preserved by the (b-a) shift. -/
-private lemma orbitEquiv_snd_shift_ba [NeZero m]
-    {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
+private lemma orbitEquiv_snd_shift_ba [NeZero m] {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
     (n : ZMod m) (hi : (orbitEquiv hba_unit).symm n |>.1.val + 1 < d₁) :
     ((orbitEquiv hba_unit).symm (n + ↑(b - a))).2 =
     ((orbitEquiv hba_unit).symm n).2 := by
@@ -260,9 +251,8 @@ private lemma orbitEquiv_snd_shift_ba [NeZero m]
   have hΦ : Φ (i + 1, j) = n + ↑(b - a) := by
     simp only [Φ, orbitEquiv, Equiv.ofBijective_apply] at hn ⊢
     rw [← hn]; exact hshift.symm
-  have h := congrArg Prod.snd (show Φ.symm (n + ↑(b - a)) = (i + 1, j) by
-    rw [← hΦ, Φ.symm_apply_apply])
-  exact h
+  have h : Φ.symm (n + ↑(b - a)) = (i + 1, j) := by rw [← hΦ, Φ.symm_apply_apply]
+  rw [h]
 
 /-- **Key infrastructure for Case 2.** Polychromaticity from an orbit coloring:
     given an orbit equivalence Φ with shift properties and a coloring f,
@@ -300,10 +290,8 @@ private lemma orbit_coloring_polychrom
 
 /-- **Subcase (2a).** $e_1$ is even. Each cycle uses two alternating colors;
     adjacent cycles skip different colors. The simplest of the four subcases. -/
-lemma case_two_e1_even (hm : m ≥ 289)
-    (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
-    (h_min : min d₁ d₂ > 1)
-    (he1_even : Even e₁) :
+lemma case_two_e1_even (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
+    (h_min : min d₁ d₂ > 1) (he1_even : Even e₁) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   haveI : NeZero m := ⟨by grind⟩
@@ -347,10 +335,8 @@ private lemma case2b_coverage_gen (d e : ℕ) [NeZero d] [NeZero e]
 /-- **Subcase (2b).** $d_1$ is even and $e_1$ is odd.
     Alternating patterns with a "degenerate" position fixup at different positions
     for even and odd cycles, ensuring they do not overlap across adjacent cycles. -/
-lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
-    (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
-    (h_min : min d₁ d₂ > 1)
-    (hd1_even : Even d₁) (he1_odd : Odd e₁) :
+lemma case_two_d1_even_e1_odd (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
+    (h_min : min d₁ d₂ > 1) (hd1_even : Even d₁) (he1_odd : Odd e₁) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   -- e₁ ≥ 3: e₁ is odd and e₁ = 1 would give d₁ = m, contradicting gcd(d₁,d₂) = 1
@@ -580,8 +566,7 @@ private lemma basePattern_rotation_covers {e j : ℕ} (he : Odd e) (hge : e ≥ 
       simp_all [intervalColors, Finset.mem_insert, Finset.mem_singleton]
   grind
 
-private lemma case2d_wrap_shift [NeZero m]
-    (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) :
+private lemma case2d_wrap_shift [NeZero m] (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) :
     ∃ k₀ : ZMod e₁, (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m) := by
   set Φ := orbitEquiv hba_unit
   set q := Φ.symm ((d₁ : ℕ) • ((b - a : ℤ) : ZMod m))
@@ -605,12 +590,10 @@ private lemma case2d_wrap_shift [NeZero m]
   simp only [hq_i, ZMod.val_zero, Nat.cast_zero, zero_mul, zero_add] at hφq
   grind
 
-private lemma case2d_shift_ba_wrap [NeZero m]
-    (he1_b_zero : e₁ • (b : ZMod m) = 0) (k₀ : ZMod e₁)
-    (hk₀ : (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m))
+private lemma case2d_shift_ba_wrap [NeZero m] (he1_b_zero : e₁ • (b : ZMod m) = 0)
+    (k₀ : ZMod e₁) (hk₀ : (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m))
     (i : ZMod d₁) (hi : i.val = d₁ - 1) :
-    ∀ (j : ZMod e₁),
-      orbitMap m a b (i, j) + ((b - a : ℤ) : ZMod m) =
+    ∀ (j : ZMod e₁), orbitMap m a b (i, j) + ((b - a : ℤ) : ZMod m) =
         orbitMap m a b ((0 : ZMod d₁), j + k₀) := by
   intro j
   simp only [orbitMap, ZMod.val_zero, Nat.cast_zero, zero_mul, zero_add]
@@ -632,9 +615,8 @@ private lemma case2d_shift_ba_wrap [NeZero m]
 
 /-- In the wrap case, the second coordinate shifts by k₀. -/
 private lemma orbitEquiv_snd_shift_ba_wrap [NeZero m]
-    {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
-    (he1_b_zero : e₁ • (b : ZMod m) = 0) (k₀ : ZMod e₁)
-    (hk₀ : (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m))
+    {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)} (he1_b_zero : e₁ • (b : ZMod m) = 0)
+    (k₀ : ZMod e₁) (hk₀ : (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m))
     (n : ZMod m) (hi : (orbitEquiv hba_unit).symm n |>.1.val = d₁ - 1) :
     ((orbitEquiv hba_unit).symm (n + ↑(b - a))).2 =
     ((orbitEquiv hba_unit).symm n).2 + k₀ := by
@@ -645,9 +627,8 @@ private lemma orbitEquiv_snd_shift_ba_wrap [NeZero m]
   have hΦ : Φ ((0 : ZMod d₁), j + k₀) = n + ↑(b - a) := by
     simp only [Φ, orbitEquiv, Equiv.ofBijective_apply] at hn ⊢
     rw [← hn]; exact (hshift j).symm
-  have h := congrArg Prod.snd (show Φ.symm (n + ↑(b - a)) = (0, j + k₀) by
-    rw [← hΦ, Φ.symm_apply_apply])
-  exact h
+  have h : Φ.symm (n + ↑(b - a)) = (0, j + k₀) := by rw [← hΦ, Φ.symm_apply_apply]
+  rw [h]
 
 /-- Given d₁ ≥ 3 values each in [u, e₁-u] can sum to any target mod e₁,
     since the range has width ≥ e₁/3 and d₁ ≥ 3. -/
@@ -766,10 +747,8 @@ private lemma pos_shift_wrap' (j S V k₀ n : ℕ) (hsum : (S + V) % n = k₀ % 
 
 /-- **Subcase (2d) assembled.** Constructs the coloring for the case when both d₁
     and e₁ are odd with e₁ ≥ 19, using rotated interval patterns. -/
-private lemma case2d_coloring_works (hm : m ≥ 289)
-    (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
-    (h_min : min d₁ d₂ > 1)
-    (hd1_odd : Odd d₁) (he1_odd : Odd e₁)
+private lemma case2d_coloring_works (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
+    (h_min : min d₁ d₂ > 1) (hd1_odd : Odd d₁) (he1_odd : Odd e₁)
     (he1_ge : e₁ ≥ 19) (h3 : ¬ (3 ∣ d₁)) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
@@ -833,11 +812,8 @@ private lemma case2c_mod3 (h3e : 3 ∣ e₁) (x y : ℕ) : (x % e₁ + y) % 3 = 
 
 /-- **Subcase (2c):** d₁ and e₁ are both odd, with e₁ ≤ 17 and 3 ∣ e₁.
     Uses shifted periodic 012-patterns with different shifts for adjacent cycles. -/
-lemma case_two_odd_small (hm : m ≥ 289)
-    (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
-    (h_min : min d₁ d₂ > 1)
-    (hd1_odd : Odd d₁)
-    (he1_div3 : 3 ∣ e₁) :
+lemma case_two_odd_small (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
+    (h_min : min d₁ d₂ > 1) (hd1_odd : Odd d₁) (he1_div3 : 3 ∣ e₁) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   haveI : NeZero m := ⟨by grind⟩
@@ -881,22 +857,17 @@ lemma case_two_odd_small (hm : m ≥ 289)
       have hhyp : (j.val + p.val) % 3 ≠ (j.val + k₀.val + p₀.val) % 3 := by
         rw [hp_eq]; exact case2c_wrap_hyp d₁ k₀.val j.val hd1_ge3 hd1_odd
       have hj'_val : (j + k₀).val = (j.val + k₀.val) % e₁ := ZMod.val_add j k₀
+      have hi1_val : (i + 1).val = 0 := by rw [ZMod.val_add_one, hi_eq]; grind [Nat.mod_self]
       rcases cover_mod3_general p p₀ j.val (j.val + k₀.val) hhyp k with h | h | h | h
       · left; exact h
       · right; left; rw [h, show p = case2c_pattern d₁ k₀.val i.val from rfl]
         exact Fin.ext (by simp [f, ZMod.val_add_one, case2c_mod3 he1_div3])
       · right; right; left; rw [h]
-        have hi1_val : (i + 1).val = 0 := by
-          rw [ZMod.val_add_one, hi_eq]
-          grind [Nat.mod_self]
         refine Fin.ext ?_
         simp only [f, hi1_val]
         rw [hj'_val]
         exact (case2c_mod3 he1_div3 (j.val + k₀.val) p₀.val).symm
       · right; right; right; rw [h]
-        have hi1_val : (i + 1).val = 0 := by
-          rw [ZMod.val_add_one, hi_eq]
-          grind [Nat.mod_self]
         refine Fin.ext ?_
         simp only [f, hi1_val, ZMod.val_add_one]
         rw [hj'_val, show (↑p₀ : ℕ) = ↑(case2c_pattern d₁ k₀.val 0) from rfl]
@@ -920,8 +891,7 @@ private lemma no_both_e_small {m' d d' : ℕ} (hm : m' ≥ 289) (hcop : Nat.gcd 
 
 /-- **Main Case 2 (Multiple Cycles).** Aggregates all subcases (2a)–(2d).
     First applies WLOG to ensure 3 ∤ d₁, then dispatches on parity of d₁ and e₁. -/
-lemma main_case_two (hm : m ≥ 289)
-    (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
+lemma main_case_two (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
     (h_min : min d₁ d₂ > 1) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   rcases Nat.even_or_odd e₁ with he | ho

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -506,21 +506,16 @@ private lemma basePattern_consec_pair {e j : ℕ} (he : Odd e) (hge : e ≥ 19) 
         grind
       exact this.ge
     · -- Boundary: last element of interval + first of next
-      have : intervalColors (whichInterval e j) ⊆ {basePattern e j, basePattern e (j + 1)} := by
-        simp only [whichInterval] at hsame ⊢
-        grind [basePattern, intervalColors]
-      exact this
+      simp only [whichInterval] at hsame ⊢
+      grind [basePattern, intervalColors]
   · -- Wrap: j = e - 1
     push_neg at hj1
     have hj_eq : j = e - 1 := by grind
     subst hj_eq
     have : e - 1 + 1 = e := by grind
     rw [this, Nat.mod_self]
-    have : intervalColors (whichInterval e (e - 1)) ⊆
-        {basePattern e (e - 1), basePattern e 0} := by
-      simp only [whichInterval]
-      grind [basePattern, intervalColors]
-    exact this
+    simp only [whichInterval]
+    grind [basePattern, intervalColors]
 
 /-- A rotation by r ∈ [u, e₁-u] moves to a different interval:
     whichInterval(j) ≠ whichInterval((j + r) % e₁). -/
@@ -693,9 +688,9 @@ private lemma case2d_rotation_sum_exists {e d : ℕ} [NeZero d]
         smul_eq_mul, hcard_lt, hcard_eq, one_mul]
     rw [hsum_f, hsum_g, Nat.mul_comm q w, hqr]
     simp only [deficit]
-    rw [Nat.add_mod_mod]
-    rw [Nat.add_sub_cancel' (le_add_left (le_trans (Nat.mul_le_mul_left d (le_of_lt hu_lt))
-      (by rw [Nat.mul_comm]))), Nat.add_mul_mod_self_left]
+    rw [Nat.add_mod_mod, Nat.add_sub_cancel' (le_add_left (le_trans
+      (Nat.mul_le_mul_left d (le_of_lt hu_lt)) (by rw [Nat.mul_comm]))),
+      Nat.add_mul_mod_self_left]
 
 /-- Splitting a ZMod filter sum at a boundary -/
 private lemma zmod_filter_sum_succ {n : ℕ} [NeZero n] (f : ZMod n → ℕ) (i : ZMod n) :
@@ -725,9 +720,8 @@ private lemma pos_shift_one {n : ℕ} [NeZero n] (j : ZMod n) (c : ℕ) :
 /-- (j + (S + V) % n) % n = ((j + S % n) % n + V) % n -/
 private lemma pos_shift_succ' (j S V n : ℕ) :
     (j + (S + V) % n) % n = ((j + S % n) % n + V) % n := by
-  have h1 : j + (S + V) = j + S + V := by grind
-  have h2 : (j + S) % n = (j + S % n) % n := (Nat.add_mod_mod j S n).symm
-  rw [Nat.add_mod_mod, h1, ← Nat.mod_add_mod (j + S) n V, h2]
+  have h1 : j + (S + V) = j + S + V := (Nat.add_assoc j S V).symm
+  rw [Nat.add_mod_mod, h1, ← Nat.mod_add_mod (j + S) n V, (Nat.add_mod_mod j S n).symm]
 
 /-- Wrap case: if (S + V) % n = k₀ % n, then (j + k₀) % n = ((j + S % n) % n + V) % n -/
 private lemma pos_shift_wrap' (j S V k₀ n : ℕ) (hsum : (S + V) % n = k₀ % n) :

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -761,76 +761,66 @@ private lemma case2d_coloring_works (hm : m ≥ 289)
   have he1_b_zero : e₁ • (b : ZMod m) = 0 := hord ▸ addOrderOf_nsmul_eq_zero _
   let Φ := orbitEquiv hm_eq hb_zero hba_unit hord
   obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hd1_dvd hb_zero hba_unit hord hm_eq
-  -- d₁ is odd, > 1, and ¬(3∣d₁), so d₁ ≥ 5
   have hd1_ge5 : d₁ ≥ 5 := by grind
   obtain ⟨vals, hvals_bound, hvals_sum⟩ := case2d_rotation_sum_exists hd1_ge5 he1_ge he1_odd k₀.val
-  -- Cumulative rotation: rot(i) = (Σ_{j<i} vals(j)) % e₁
   let rot : ZMod d₁ → ℕ := fun i =>
     ((Finset.univ.filter (fun j : ZMod d₁ => j.val < i.val)).sum vals) % e₁
-  -- Coloring: χ(x) = basePattern(e₁, (j-coord + rot(i-coord)) % e₁)
-  let χ : ZMod m → Fin 3 := fun x =>
-    let coord := Φ.symm x
-    basePattern e₁ ((coord.2.val + rot coord.1) % e₁)
-  refine ⟨χ, fun n k => ?_⟩
-  -- χ at orbit coordinates simplifies via Equiv.symm_apply_apply
-  have hχ_eq : ∀ (i' : ZMod d₁) (j' : ZMod e₁),
-      χ (Φ (i', j')) = basePattern e₁ ((j'.val + rot i') % e₁) := by
-    intro i' j'; simp only [χ, Equiv.symm_apply_apply]
-  -- Coordinates of n
-  set ij := Φ.symm n
-  have hn : Φ ij = n := Equiv.apply_symm_apply Φ n
-  set i := ij.1; set j := ij.2
-  have hij : ij = (i, j) := (Prod.eta ij).symm
-  -- Base position p
-  set p := (j.val + rot i) % e₁ with hp_def
-  have hp_lt : p < e₁ := Nat.mod_lt _ (NeZero.pos e₁)
-  -- Shift lemmas
-  have hΦ_b : Φ (i, j + 1) = n + ((b : ℤ) : ZMod m) := by
-    rw [← hn, hij]; exact (orbitMap_shift_b he1_b_zero (i, j)).symm
-  -- Apply rotation covers
-  have covers := basePattern_rotation_covers he1_odd he1_ge
-    (hvals_bound i).1 (hvals_bound i).2 hp_lt k
-  simp only [Finset.mem_insert, Finset.mem_singleton] at covers
-  -- (b-a) shift: obtain shifted coordinates and position equality
-  suffices ∃ (i_new : ZMod d₁) (j_new : ZMod e₁),
-      Φ (i_new, j_new) = n + ((b - a : ℤ) : ZMod m) ∧
-      (j_new.val + rot i_new) % e₁ = (p + vals i) % e₁ by
-    obtain ⟨i_new, j_new, hΦ_ba, hpos⟩ := this
-    have hΦ_2ba : Φ (i_new, j_new + 1) = n + ((2 * b - a : ℤ) : ZMod m) := by
-      rw [intCast_2ba_eq, ← add_assoc, ← hΦ_ba]
-      exact (orbitMap_shift_b he1_b_zero (i_new, j_new)).symm
-    rcases covers with h | h | h | h
-    · exact ⟨0, zero_mem_zmod_set m a b, by rw [add_zero, ← hn, hij, hχ_eq, h]⟩
-    · exact ⟨((b : ℤ) : ZMod m), intCast_b_mem_zmod_set m a b,
-        by rw [← hΦ_b, hχ_eq, h]; congr 1; exact pos_shift_one j (rot i)⟩
-    · exact ⟨((b - a : ℤ) : ZMod m), intCast_ba_mem_zmod_set m a b,
-        by rw [← hΦ_ba, hχ_eq, h]; congr 1⟩
-    · refine ⟨((2 * b - a : ℤ) : ZMod m), intCast_2ba_mem_zmod_set m a b, ?_⟩
-      rw [← hΦ_2ba, hχ_eq, h]; congr 1
-      calc ((j_new + 1 : ZMod e₁).val + rot i_new) % e₁
-          = ((j_new.val + rot i_new) % e₁ + 1) % e₁ := pos_shift_one j_new (rot i_new)
-        _ = ((p + vals i) % e₁ + 1) % e₁ := by rw [hpos]
-        _ = (p + vals i + 1) % e₁ := Nat.mod_add_mod (p + vals i) e₁ 1
-  by_cases hi : i.val + 1 < d₁
-  · -- No-wrap case
-    refine ⟨i + 1, j, ?_, ?_⟩
-    · rw [← hn, hij]; exact (orbitMap_shift_ba i j hi).symm
-    · change (j.val + ((Finset.univ.filter
+  let f : ZMod d₁ × ZMod e₁ → Fin 3 := fun ⟨i, j⟩ =>
+    basePattern e₁ ((j.val + rot i) % e₁)
+  exact orbit_coloring_polychrom Φ orbitEquiv_shift_b orbitEquiv_cycle_shift f (fun n k => by
+    set i := (Φ.symm n).1; set j := (Φ.symm n).2
+    set j' := (Φ.symm (n + ↑(b - a))).2
+    set p := (j.val + rot i) % e₁ with hp_def
+    have hp_lt : p < e₁ := Nat.mod_lt _ (NeZero.pos e₁)
+    have covers := basePattern_rotation_covers he1_odd he1_ge
+      (hvals_bound i).1 (hvals_bound i).2 hp_lt k
+    simp only [Finset.mem_insert, Finset.mem_singleton] at covers
+    suffices hpos : (j'.val + rot (i + 1)) % e₁ = (p + vals i) % e₁ by
+      rcases covers with h | h | h | h
+      · left; exact h
+      · right; left; rw [h]; simp only [f]; congr 1; exact (pos_shift_one j (rot i)).symm
+      · right; right; left; rw [h]; simp only [f]; congr 1; exact hpos.symm
+      · right; right; right; rw [h]; simp only [f]; congr 1
+        calc (p + vals i + 1) % e₁
+            = ((p + vals i) % e₁ + 1) % e₁ := (Nat.mod_add_mod (p + vals i) e₁ 1).symm
+          _ = ((j'.val + rot (i + 1)) % e₁ + 1) % e₁ := by rw [hpos]
+          _ = ((j' + 1 : ZMod e₁).val + rot (i + 1)) % e₁ :=
+              (pos_shift_one j' (rot (i + 1))).symm
+    by_cases hi : i.val + 1 < d₁
+    · have hj'_eq : j' = j := by
+        have hshift := @orbitMap_shift_ba m a b d₁ e₁ ‹NeZero d₁› i j hi
+        have hn : Φ (i, j) = n := Prod.eta (Φ.symm n) ▸ Equiv.apply_symm_apply Φ n
+        have hΦ : Φ (i + 1, j) = n + ↑(b - a) := by
+          simp only [Φ, orbitEquiv, Equiv.ofBijective_apply] at hn ⊢
+          rw [← hn]; exact hshift.symm
+        have h := congrArg Prod.snd (show Φ.symm (n + ↑(b - a)) = (i + 1, j) by
+          rw [← hΦ, Φ.symm_apply_apply])
+        exact h
+      rw [hj'_eq]
+      change (j.val + ((Finset.univ.filter
         (fun k : ZMod d₁ => k.val < (i + 1).val)).sum vals) % e₁) % e₁ =
         ((j.val + ((Finset.univ.filter
         (fun k : ZMod d₁ => k.val < i.val)).sum vals) % e₁) % e₁ + vals i) % e₁
-      have : (i + 1).val = i.val + 1 := by rw [ZMod.val_add_one]; exact Nat.mod_eq_of_lt hi
-      rw [this, zmod_filter_sum_succ vals i]
+      rw [show (i + 1).val = i.val + 1 from by rw [ZMod.val_add_one]; exact Nat.mod_eq_of_lt hi,
+          zmod_filter_sum_succ vals i]
       exact pos_shift_succ' j.val _ (vals i) e₁
-  · -- Wrap case: i = d₁ - 1
-    have hi_eq : i.val = d₁ - 1 := by grind [ZMod.val_lt]
-    refine ⟨0, j + k₀, ?_, ?_⟩
-    · rw [← hn, hij]
-      exact (case2d_shift_ba_wrap he1_b_zero k₀ hk₀ i hi_eq j).symm
-    · have hrot0 : rot (0 : ZMod d₁) = 0 := by simp [rot, ZMod.val_zero]
-      rw [hrot0, Nat.add_zero, ZMod.val_add, Nat.mod_mod_of_dvd _ (dvd_refl e₁)]
+    · have hi_eq : i.val = d₁ - 1 := by grind [ZMod.val_lt]
+      have hj'_eq : j' = j + k₀ := by
+        have hshift := case2d_shift_ba_wrap he1_b_zero k₀ hk₀ i hi_eq
+        have hn : Φ (i, j) = n := Prod.eta (Φ.symm n) ▸ Equiv.apply_symm_apply Φ n
+        have hΦ : Φ ((0 : ZMod d₁), j + k₀) = n + ↑(b - a) := by
+          simp only [Φ, orbitEquiv, Equiv.ofBijective_apply] at hn ⊢
+          rw [← hn]; exact (hshift j).symm
+        change (Φ.symm (n + ↑(b - a))).2 = j + k₀
+        rw [← hΦ, Φ.symm_apply_apply]
+      rw [hj'_eq]
+      have hi1_zero : (i + 1 : ZMod d₁) = 0 := by
+        apply ZMod.val_injective; rw [ZMod.val_add_one, hi_eq, ZMod.val_zero]
+        grind [Nat.mod_self]
+      have hrot0 : rot (0 : ZMod d₁) = 0 := by simp [rot, ZMod.val_zero]
+      rw [hi1_zero, hrot0, Nat.add_zero, ZMod.val_add, Nat.mod_mod_of_dvd _ (dvd_refl e₁)]
       exact pos_shift_wrap' j.val _ (vals i) k₀.val e₁
-        (by rw [zmod_filter_sum_last vals i hi_eq, hvals_sum])
+        (by rw [zmod_filter_sum_last vals i hi_eq, hvals_sum]))
 
 -- Mod 3 arithmetic: (a % e₁ + b) % 3 = (a + b) % 3 when 3 ∣ e₁
 private lemma case2c_mod3 (h3e : 3 ∣ e₁) (x y : ℕ) : (x % e₁ + y) % 3 = (x + y) % 3 := by

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -76,10 +76,10 @@ private lemma d₁_dvd_m : d₁ ∣ m := Nat.gcd_dvd_right _ _
 private lemma m_eq_d₁_mul_e₁ : m = d₁ * e₁ := (Nat.mul_div_cancel' (d₁_dvd_m (b := b))).symm
 
 instance neZero_d₁ [NeZero m] : NeZero d₁ :=
-  ⟨fun h => absurd (by rw [m_eq_d₁_mul_e₁ (m := m) (b := b), h, zero_mul]) (NeZero.ne m)⟩
+  ⟨fun h => absurd (by grind) (NeZero.ne m)⟩
 
 instance neZero_e₁ [NeZero m] : NeZero e₁ :=
-  ⟨fun h => absurd (by rw [m_eq_d₁_mul_e₁ (m := m) (b := b), h, mul_zero]) (NeZero.ne m)⟩
+  ⟨fun h => absurd (by grind only [m_eq_d₁_mul_e₁]) (NeZero.ne m)⟩
 
 /-! ### Orbit coloring framework -/
 

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -96,9 +96,11 @@ private lemma addOrderOf_b_eq (hm : 0 < m) :
   · have : (b : ZMod m) = -(b.natAbs : ZMod m) := by rw [h]; simp
     rw [this, addOrderOf_neg]; exact key
 
-private lemma b_zero_mod_d1 [NeZero d₁] : (b : ZMod d₁) = 0 := by
-  rw [ZMod.intCast_zmod_eq_zero_iff_dvd]
-  exact Int.natCast_dvd.mpr (Nat.gcd_dvd_left b.natAbs m)
+private lemma d₁_dvd_b : (d₁ : ℤ) ∣ b :=
+  Int.natCast_dvd.mpr (Nat.gcd_dvd_left b.natAbs m)
+
+private lemma b_zero_mod_d1 [NeZero d₁] : (b : ZMod d₁) = 0 :=
+  (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mpr (d₁_dvd_b (b := b))
 
 private lemma ba_coprime_d1
     (h_gcd_coprime : Nat.gcd d₁ d₂ = 1) :
@@ -132,14 +134,14 @@ private lemma orbitMap_j_eq [NeZero e₁]
     exact ZMod.val_injective _ (by grind)
 
 private lemma orbitMap_injective [NeZero m]
-    (hm_eq : m = d₁ * e₁) (hb_zero : (b : ZMod d₁) = 0)
+    (hm_eq : m = d₁ * e₁)
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
     (hord : addOrderOf (b : ZMod m) = e₁) :
     Function.Injective (orbitMap m a b : ZMod d₁ × ZMod e₁ → ZMod m) := by
   haveI : NeZero d₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, zero_mul]) (NeZero.ne m)⟩
   haveI : NeZero e₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, mul_zero]) (NeZero.ne m)⟩
   intro ⟨i₁, j₁⟩ ⟨i₂, j₂⟩ heq
-  have hi := orbitMap_i_eq hb_zero hba_unit heq
+  have hi := orbitMap_i_eq b_zero_mod_d1 hba_unit heq
   subst hi
   simp only [orbitMap] at heq
   have hj_smul : (j₁.val : ℕ) • (b : ZMod m) = (j₂.val : ℕ) • (b : ZMod m) := by grind
@@ -153,7 +155,7 @@ private lemma orbitMap_bijective [NeZero m]
   haveI : NeZero d₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, zero_mul]) (NeZero.ne m)⟩
   haveI : NeZero e₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, mul_zero]) (NeZero.ne m)⟩
   exact (Fintype.bijective_iff_injective_and_card _).mpr
-    ⟨orbitMap_injective hm_eq hb_zero hba_unit hord,
+    ⟨orbitMap_injective hm_eq hba_unit hord,
      by simp only [Fintype.card_prod, ZMod.card]; linarith [hm_eq]⟩
 
 private lemma orbitMap_shift_b [NeZero e₁]

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -359,7 +359,6 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
         (h_gcd_coprime ▸ Nat.dvd_gcd this (dvd_refl _))) (by grind)
     · grind
   haveI : NeZero m := ⟨by grind⟩
-  have hb_zero : (Int.cast b : ZMod d₁) = 0 := b_zero_mod_d1
   have hba_unit : IsUnit (Int.cast (b - a) : ZMod d₁) :=
     isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   let Φ := orbitEquiv hba_unit
@@ -494,7 +493,6 @@ private def intervalColors : Fin 3 → Finset (Fin 3)
   | 1 => {1, 2}
   | 2 => {0, 2}
 
-
 /-- Combined: for any j, {basePattern(j), basePattern(j+1 mod e₁)} is the
     interval pair of whichInterval(j). -/
 private lemma basePattern_consec_pair {e j : ℕ} (he : Odd e) (hge : e ≥ 19) (hj : j < e) :
@@ -574,7 +572,6 @@ private lemma basePattern_rotation_covers {e j : ℕ} (he : Odd e) (hge : e ≥ 
   grind
 
 private lemma case2d_wrap_shift [NeZero m]
-    (hb_zero : (b : ZMod d₁) = 0)
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) :
     ∃ k₀ : ZMod e₁, (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m) := by
   set Φ := orbitEquiv hba_unit
@@ -583,7 +580,8 @@ private lemma case2d_wrap_shift [NeZero m]
     set f := ZMod.castHom d₁_dvd_m (ZMod d₁)
     have hfφ : f (Φ q) = q.1 * ((b - a : ℤ) : ZMod d₁) := by
       change f (orbitMap m a b q) = _
-      simp only [orbitMap, map_add, map_mul, map_natCast, map_intCast, hb_zero, mul_zero, add_zero]
+      simp only [orbitMap, map_add, map_mul, map_natCast, map_intCast,
+        b_zero_mod_d1, mul_zero, add_zero]
       rw [ZMod.natCast_val, ZMod.cast_id]
     rw [Equiv.apply_symm_apply] at hfφ
     have : f (d₁ • ((b - a : ℤ) : ZMod m)) = 0 := by
@@ -765,12 +763,11 @@ private lemma case2d_coloring_works (hm : m ≥ 289)
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   haveI : NeZero m := ⟨by grind⟩
-  have hb_zero : (b : ZMod d₁) = 0 := b_zero_mod_d1
   have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   have he1_b_zero : e₁ • (b : ZMod m) = 0 :=
     addOrderOf_b_eq (b := b) (m := m) ▸ addOrderOf_nsmul_eq_zero _
   let Φ := orbitEquiv hba_unit
-  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hb_zero hba_unit
+  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hba_unit
   have hd1_ge5 : d₁ ≥ 5 := by grind
   obtain ⟨vals, hvals_bound, hvals_sum⟩ := case2d_rotation_sum_exists hd1_ge5 he1_ge he1_odd k₀.val
   let rot : ZMod d₁ → ℕ := fun i =>
@@ -832,12 +829,11 @@ lemma case_two_odd_small (hm : m ≥ 289)
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   haveI : NeZero m := ⟨by grind⟩
-  have hb_zero : (b : ZMod d₁) = 0 := b_zero_mod_d1
   have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   have he1_b_zero : e₁ • (b : ZMod m) = 0 :=
     addOrderOf_b_eq (b := b) (m := m) ▸ addOrderOf_nsmul_eq_zero _
   let Φ := orbitEquiv hba_unit
-  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hb_zero hba_unit
+  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hba_unit
   have hd1_ge3 : d₁ ≥ 3 := by grind
   let f : ZMod d₁ × ZMod e₁ → Fin 3 := fun ⟨i, j⟩ =>
     ⟨(j.val + (case2c_pattern d₁ k₀.val i.val).val) % 3, Nat.mod_lt _ (by grind)⟩

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -70,6 +70,9 @@ private lemma color_covers_even (d e : ℕ) [NeZero d] [NeZero e] (hd_ge2 : d �
     k = cycle_coloring d e (i + 1, j₂ + 1) := by
   grind [cycle_coloring, Fin.ext_iff, zmod_val_add_one]
 
+private lemma d₁_dvd_m : d₁ ∣ m := Nat.gcd_dvd_right _ _
+private lemma m_eq_d₁_mul_e₁ : m = d₁ * e₁ := (Nat.mul_div_cancel' (d₁_dvd_m (b := b))).symm
+
 /-! ### Orbit coloring framework -/
 
 section OrbitFramework
@@ -98,19 +101,19 @@ private lemma b_zero_mod_d1
   rw [ZMod.intCast_zmod_eq_zero_iff_dvd]
   exact Int.natCast_dvd.mpr (hd1_def ▸ Nat.gcd_dvd_left b.natAbs m)
 
-private lemma ba_coprime_d1 (hd1_dvd : d₁ ∣ m)
+private lemma ba_coprime_d1
     (h_gcd_coprime : Nat.gcd d₁ (Nat.gcd (b - a).natAbs m) = 1) :
     Nat.Coprime (b - a).natAbs d₁ :=
   Nat.dvd_one.mp (h_gcd_coprime ▸ Nat.dvd_gcd (Nat.gcd_dvd_right _ _)
-      (Nat.dvd_gcd (Nat.gcd_dvd_left _ _) (dvd_trans (Nat.gcd_dvd_right _ _) hd1_dvd)))
+      (Nat.dvd_gcd (Nat.gcd_dvd_left _ _) (dvd_trans (Nat.gcd_dvd_right _ _) d₁_dvd_m)))
 
 private lemma orbitMap_i_eq [NeZero d₁]
-    (hd1_dvd : d₁ ∣ m) (hb_zero : (b : ZMod d₁) = 0)
+    (hb_zero : (b : ZMod d₁) = 0)
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) {i₁ i₂ : ZMod d₁} {j₁ j₂ : ZMod e₁}
     (heq : orbitMap m a b (i₁, j₁) = orbitMap m a b (i₂, j₂)) :
     i₁ = i₂ := by
   simp only [orbitMap] at heq
-  have := congr_arg (ZMod.castHom hd1_dvd (ZMod d₁)) heq
+  have := congr_arg (ZMod.castHom d₁_dvd_m (ZMod d₁)) heq
   simp only [map_add, map_mul, map_natCast, map_intCast] at this
   simp only [hb_zero, mul_zero, add_zero, ZMod.natCast_val, ZMod.cast_id] at this
   exact hba_unit.mul_right_cancel this
@@ -134,11 +137,10 @@ private lemma orbitMap_injective [NeZero m]
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
     (hord : addOrderOf (b : ZMod m) = e₁) :
     Function.Injective (orbitMap m a b : ZMod d₁ × ZMod e₁ → ZMod m) := by
-  have hd1_dvd : d₁ ∣ m := Nat.gcd_dvd_right _ _
   haveI : NeZero d₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, zero_mul]) (NeZero.ne m)⟩
   haveI : NeZero e₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, mul_zero]) (NeZero.ne m)⟩
   intro ⟨i₁, j₁⟩ ⟨i₂, j₂⟩ heq
-  have hi := orbitMap_i_eq hd1_dvd hb_zero hba_unit heq
+  have hi := orbitMap_i_eq hb_zero hba_unit heq
   subst hi
   simp only [orbitMap] at heq
   have hj_smul : (j₁.val : ℕ) • (b : ZMod m) = (j₂.val : ℕ) • (b : ZMod m) := by grind
@@ -183,9 +185,9 @@ private lemma orbitMap_shift_ba [NeZero d₁]
 
 /-- The cycle index α(x) = castHom(x) * u⁻¹ satisfies α(φ(i,j)) = i. -/
 private lemma orbitMap_cycle_index [NeZero d₁]
-    (hd1_dvd : d₁ ∣ m) (hb_zero : (b : ZMod d₁) = 0)
+    (hb_zero : (b : ZMod d₁) = 0)
     (u : (ZMod d₁)ˣ) (hu : ↑u = ((b - a : ℤ) : ZMod d₁)) (i : ZMod d₁) (j : ZMod e₁) :
-    ZMod.castHom hd1_dvd (ZMod d₁) (orbitMap m a b (i, j)) * u⁻¹ = i := by
+    ZMod.castHom d₁_dvd_m (ZMod d₁) (orbitMap m a b (i, j)) * u⁻¹ = i := by
   simp only [orbitMap]
   rw [map_add, map_mul, map_mul, map_natCast, map_intCast,
     map_natCast, map_intCast, hb_zero, mul_zero, add_zero, mul_assoc, ← hu, u.mul_inv, mul_one]
@@ -193,9 +195,9 @@ private lemma orbitMap_cycle_index [NeZero d₁]
 
 /-- The cycle index α shifts by 1 when (b-a) is added. -/
 private lemma cycle_index_shift_ba [NeZero d₁]
-    (hd1_dvd : d₁ ∣ m) (u : (ZMod d₁)ˣ) (hu : ↑u = ((b - a : ℤ) : ZMod d₁)) (x : ZMod m) :
-    ZMod.castHom hd1_dvd (ZMod d₁) (x + ↑(b - a)) * u⁻¹ =
-    ZMod.castHom hd1_dvd (ZMod d₁) x * u⁻¹ + 1 := by
+    (u : (ZMod d₁)ˣ) (hu : ↑u = ((b - a : ℤ) : ZMod d₁)) (x : ZMod m) :
+    ZMod.castHom d₁_dvd_m (ZMod d₁) (x + ↑(b - a)) * u⁻¹ =
+    ZMod.castHom d₁_dvd_m (ZMod d₁) x * u⁻¹ + 1 := by
   simp only [map_add, map_intCast, add_mul]
   rw [← hu]; ring_nf; rw [u.inv_mul]; ring
 
@@ -231,16 +233,15 @@ private lemma orbitEquiv_cycle_shift [NeZero m] {hm_eq : m = d₁ * e₁}
     {hord : addOrderOf (b : ZMod m) = e₁} (x : ZMod m) :
     ((orbitEquiv hm_eq hb_zero hba_unit hord).symm (x + ↑(b - a))).1 =
     ((orbitEquiv hm_eq hb_zero hba_unit hord).symm x).1 + 1 := by
-  have hd1_dvd : d₁ ∣ m := Nat.gcd_dvd_right _ _
   haveI : NeZero d₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, zero_mul]) (NeZero.ne m)⟩
   let u_ba := hba_unit.choose
   have hu_ba : ↑u_ba = ((b - a : ℤ) : ZMod d₁) := hba_unit.choose_spec
-  let α : ZMod m → ZMod d₁ := fun x => ZMod.castHom hd1_dvd (ZMod d₁) x * u_ba⁻¹
+  let α : ZMod m → ZMod d₁ := fun x => ZMod.castHom d₁_dvd_m (ZMod d₁) x * u_ba⁻¹
   have hΦ_cycle := equiv_symm_fst_eq (orbitEquiv hm_eq hb_zero hba_unit hord) α
-    (orbitMap_cycle_index hd1_dvd hb_zero u_ba hu_ba)
+    (orbitMap_cycle_index hb_zero u_ba hu_ba)
   rw [hΦ_cycle (x + ↑(b - a))]
   dsimp only [α]
-  rw [cycle_index_shift_ba hd1_dvd u_ba hu_ba]
+  rw [cycle_index_shift_ba u_ba hu_ba]
   congr 1
   exact (hΦ_cycle x).symm
 
@@ -304,21 +305,20 @@ lemma case_two_e1_even (hm : m ≥ 289)
     (h_min : min (Nat.gcd b.natAbs m) (Nat.gcd (b - a).natAbs m) > 1)
     (he1_even : Even (m / Nat.gcd b.natAbs m)) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
-  have hd₁_dvd : d₁ ∣ m := Nat.gcd_dvd_right _ _
-  have hm_eq : m = d₁ * e₁ := (Nat.mul_div_cancel' hd₁_dvd).symm
+  have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   have he₁_ge2 : e₁ ≥ 2 := by
-    have : 0 < e₁ := Nat.div_pos (Nat.le_of_dvd (by grind) hd₁_dvd) (by grind)
+    have : 0 < e₁ := Nat.div_pos (Nat.le_of_dvd (by grind) d₁_dvd_m) (by grind)
     grind
   haveI : NeZero m := ⟨by grind⟩
   haveI : NeZero d₁ := ⟨by grind⟩
   haveI : NeZero e₁ := ⟨by grind⟩
   have hb_zero : (Int.cast b : ZMod d₁) = 0 := b_zero_mod_d1 rfl
-  have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 hd₁_dvd h_gcd_coprime)
+  have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind) rfl
   let Φ := orbitEquiv hm_eq hb_zero hba_unit hord
   have hd₁_ge2 : d₁ ≥ 2 := by grind
   have he₁_ge2 : e₁ ≥ 2 := by
-    have : 0 < e₁ := Nat.div_pos (Nat.le_of_dvd (by grind) hd₁_dvd) (by grind)
+    have : 0 < e₁ := Nat.div_pos (Nat.le_of_dvd (by grind) d₁_dvd_m) (by grind)
     grind
   exact orbit_coloring_polychrom Φ orbitEquiv_shift_b orbitEquiv_cycle_shift
     (cycle_coloring d₁ e₁)
@@ -363,8 +363,7 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
     (h_min : min (Nat.gcd b.natAbs m) (Nat.gcd (b - a).natAbs m) > 1)
     (hd1_even : Even (Nat.gcd b.natAbs m)) (he1_odd : Odd (m / Nat.gcd b.natAbs m)) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
-  have hd₁_dvd : d₁ ∣ m := Nat.gcd_dvd_right _ _
-  have hm_eq : m = d₁ * e₁ := (Nat.mul_div_cancel' hd₁_dvd).symm
+  have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   -- e₁ ≥ 3: e₁ is odd and e₁ = 1 would give d₁ = m, contradicting gcd(d₁,d₂) = 1
   have he₁_ge3 : e₁ ≥ 3 := by
     by_contra! h
@@ -380,7 +379,7 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
   haveI : NeZero e₁ := ⟨by grind⟩
   have hb_zero : (Int.cast b : ZMod d₁) = 0 := b_zero_mod_d1 rfl
   have hba_unit : IsUnit (Int.cast (b - a) : ZMod d₁) :=
-    isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 hd₁_dvd h_gcd_coprime)
+    isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind) rfl
   let Φ := orbitEquiv hm_eq hb_zero hba_unit hord
   -- d₂ properties for the compatibility argument
@@ -595,14 +594,14 @@ private lemma basePattern_rotation_covers {e j : ℕ} (he : Odd e) (hge : e ≥ 
   grind
 
 private lemma case2d_wrap_shift [NeZero m] [NeZero d₁] [NeZero e₁]
-    (hd1_dvd : d₁ ∣ m) (hb_zero : (b : ZMod d₁) = 0)
+    (hb_zero : (b : ZMod d₁) = 0)
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) (hord : addOrderOf (b : ZMod m) = e₁)
     (hm_eq : m = d₁ * e₁) :
     ∃ k₀ : ZMod e₁, (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m) := by
   set Φ := orbitEquiv hm_eq hb_zero hba_unit hord
   set q := Φ.symm ((d₁ : ℕ) • ((b - a : ℤ) : ZMod m))
   have hq_i : q.1 = 0 := by
-    set f := ZMod.castHom hd1_dvd (ZMod d₁)
+    set f := ZMod.castHom d₁_dvd_m (ZMod d₁)
     have hfφ : f (Φ q) = q.1 * ((b - a : ℤ) : ZMod d₁) := by
       change f (orbitMap m a b q) = _
       simp only [orbitMap, map_add, map_mul, map_natCast, map_intCast, hb_zero, mul_zero, add_zero]
@@ -787,17 +786,16 @@ private lemma case2d_coloring_works (hm : m ≥ 289)
     (hd1_odd : Odd (Nat.gcd b.natAbs m)) (he1_odd : Odd (m / Nat.gcd b.natAbs m))
     (he1_ge : m / Nat.gcd b.natAbs m ≥ 19) (h3 : ¬ (3 ∣ Nat.gcd b.natAbs m)) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
-  have hd₁_dvd : d₁ ∣ m := Nat.gcd_dvd_right _ _
-  have hm_eq : m = d₁ * e₁ := (Nat.mul_div_cancel' hd₁_dvd).symm
+  have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   haveI : NeZero m := ⟨by grind⟩
   haveI : NeZero d₁ := ⟨by grind⟩
   haveI : NeZero e₁ := ⟨by grind⟩
   have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind) rfl
   have hb_zero : (b : ZMod d₁) = 0 := b_zero_mod_d1 rfl
-  have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 hd₁_dvd h_gcd_coprime)
+  have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   have he1_b_zero : e₁ • (b : ZMod m) = 0 := hord ▸ addOrderOf_nsmul_eq_zero _
   let Φ := orbitEquiv hm_eq hb_zero hba_unit hord
-  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hd₁_dvd hb_zero hba_unit hord hm_eq
+  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hb_zero hba_unit hord hm_eq
   have hd1_ge5 : d₁ ≥ 5 := by grind
   obtain ⟨vals, hvals_bound, hvals_sum⟩ := case2d_rotation_sum_exists hd1_ge5 he1_ge he1_odd k₀.val
   let rot : ZMod d₁ → ℕ := fun i =>
@@ -857,17 +855,16 @@ lemma case_two_odd_small (hm : m ≥ 289)
     (hd1_odd : Odd (Nat.gcd b.natAbs m)) (_he1_odd : Odd (m / Nat.gcd b.natAbs m))
     (_he1_le : m / Nat.gcd b.natAbs m ≤ 17) (he1_div3 : 3 ∣ m / Nat.gcd b.natAbs m) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
-  have hd₁_dvd : d₁ ∣ m := Nat.gcd_dvd_right _ _
-  have hm_eq : m = d₁ * e₁ := (Nat.mul_div_cancel' hd₁_dvd).symm
+  have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   haveI : NeZero m := ⟨by grind⟩
   haveI : NeZero d₁ := ⟨by grind⟩
   haveI : NeZero e₁ := ⟨by grind⟩
   have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind) rfl
   have hb_zero : (b : ZMod d₁) = 0 := b_zero_mod_d1 rfl
-  have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 hd₁_dvd h_gcd_coprime)
+  have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   have he1_b_zero : e₁ • (b : ZMod m) = 0 := hord ▸ addOrderOf_nsmul_eq_zero _
   let Φ := orbitEquiv hm_eq hb_zero hba_unit hord
-  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hd₁_dvd hb_zero hba_unit hord hm_eq
+  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hb_zero hba_unit hord hm_eq
   have hd1_ge3 : d₁ ≥ 3 := by grind
   let f : ZMod d₁ × ZMod e₁ → Fin 3 := fun ⟨i, j⟩ =>
     ⟨(j.val + (case2c_pattern d₁ k₀.val i.val).val) % 3, Nat.mod_lt _ (by grind)⟩

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -113,9 +113,10 @@ private lemma ba_coprime_d1 (h_gcd_coprime : Nat.gcd d₁ d₂ = 1) :
   Nat.dvd_one.mp (h_gcd_coprime ▸ Nat.dvd_gcd (Nat.gcd_dvd_right _ _)
       (Nat.dvd_gcd (Nat.gcd_dvd_left _ _) (dvd_trans (Nat.gcd_dvd_right _ _) d₁_dvd_m)))
 
-private lemma orbitMap_i_eq [NeZero m] (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
+private lemma orbitMap_i_eq [NeZero m] (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
     {i₁ i₂ : ZMod d₁} {j₁ j₂ : ZMod e₁}
     (heq : orbitMap m a b (i₁, j₁) = orbitMap m a b (i₂, j₂)) : i₁ = i₂ := by
+  have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   simp only [orbitMap] at heq
   have := congr_arg (ZMod.castHom d₁_dvd_m (ZMod d₁)) heq
   simp only [map_add, map_mul, map_natCast, map_intCast] at this
@@ -134,19 +135,19 @@ private lemma orbitMap_j_eq [NeZero m] {j₁ j₂ : ZMod e₁}
       (by grind [ZMod.val_lt j₁, ZMod.val_lt j₂])
     exact ZMod.val_injective _ (by grind)
 
-private lemma orbitMap_injective [NeZero m] (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) :
+private lemma orbitMap_injective [NeZero m] (h_gcd_coprime : Nat.gcd d₁ d₂ = 1) :
     Function.Injective (orbitMap m a b : ZMod d₁ × ZMod e₁ → ZMod m) := by
   intro ⟨i₁, j₁⟩ ⟨i₂, j₂⟩ heq
-  have hi := orbitMap_i_eq hba_unit heq
+  have hi := orbitMap_i_eq h_gcd_coprime heq
   subst hi
   simp only [orbitMap] at heq
   have hj_smul : (j₁.val : ℕ) • (b : ZMod m) = (j₂.val : ℕ) • (b : ZMod m) := by grind
   exact Prod.ext rfl (orbitMap_j_eq hj_smul)
 
-private lemma orbitMap_bijective [NeZero m] (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) :
+private lemma orbitMap_bijective [NeZero m] (h_gcd_coprime : Nat.gcd d₁ d₂ = 1) :
     Function.Bijective (orbitMap m a b : ZMod d₁ × ZMod e₁ → ZMod m) :=
   (Fintype.bijective_iff_injective_and_card _).mpr
-    ⟨orbitMap_injective hba_unit, by
+    ⟨orbitMap_injective h_gcd_coprime, by
       simp only [Fintype.card_prod, ZMod.card]
       linarith [m_eq_d₁_mul_e₁ (m := m) (b := b)]⟩
 
@@ -206,34 +207,34 @@ private lemma equiv_symm_fst_eq {γ : Type*} (Φ : ZMod d₁ × ZMod e₁ ≃ γ
 
 /-- Build the orbit equivalence from the standard hypotheses. -/
 private noncomputable def orbitEquiv [NeZero m]
-    (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) : ZMod d₁ × ZMod e₁ ≃ ZMod m :=
-  Equiv.ofBijective (orbitMap m a b) (orbitMap_bijective hba_unit)
+    (h_gcd_coprime : Nat.gcd d₁ d₂ = 1) : ZMod d₁ × ZMod e₁ ≃ ZMod m :=
+  Equiv.ofBijective (orbitMap m a b) (orbitMap_bijective h_gcd_coprime)
 
-private lemma orbitEquiv_shift_b [NeZero m] {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
-    (x : ZMod m) :
-    (orbitEquiv hba_unit).symm (x + ↑b) =
-    (((orbitEquiv hba_unit).symm x).1, ((orbitEquiv hba_unit).symm x).2 + 1) :=
+private lemma orbitEquiv_shift_b [NeZero m] {h_gcd_coprime : Nat.gcd d₁ d₂ = 1} (x : ZMod m) :
+    (orbitEquiv h_gcd_coprime).symm (x + ↑b) =
+    (((orbitEquiv h_gcd_coprime).symm x).1, ((orbitEquiv h_gcd_coprime).symm x).2 + 1) :=
   equiv_symm_shift_b _ (fun i j =>
     (orbitMap_shift_b (addOrderOf_b_eq (b := b) (m := m) ▸
       addOrderOf_nsmul_eq_zero _) (i, j)).symm) x
 
-private lemma orbitEquiv_cycle_shift [NeZero m] {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
-    (x : ZMod m) :
-    ((orbitEquiv hba_unit).symm (x + ↑(b - a))).1 = ((orbitEquiv hba_unit).symm x).1 + 1 := by
+private lemma orbitEquiv_cycle_shift [NeZero m] {h_gcd_coprime : Nat.gcd d₁ d₂ = 1} (x : ZMod m) :
+    ((orbitEquiv h_gcd_coprime).symm (x + ↑(b - a))).1 =
+    ((orbitEquiv h_gcd_coprime).symm x).1 + 1 := by
+  have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   let u_ba := hba_unit.choose
   have hu_ba : ↑u_ba = ((b - a : ℤ) : ZMod d₁) := hba_unit.choose_spec
   let α : ZMod m → ZMod d₁ := fun x => ZMod.castHom d₁_dvd_m (ZMod d₁) x * u_ba⁻¹
-  have hΦ_cycle := equiv_symm_fst_eq (orbitEquiv hba_unit) α (orbitMap_cycle_index u_ba hu_ba)
+  have hΦ_cycle := equiv_symm_fst_eq (orbitEquiv h_gcd_coprime) α (orbitMap_cycle_index u_ba hu_ba)
   rw [hΦ_cycle (x + ↑(b - a))]
   dsimp only [α]
   rw [cycle_index_shift_ba u_ba hu_ba]
   grind
 
 /-- In the non-wrap case, the second coordinate is preserved by the (b-a) shift. -/
-private lemma orbitEquiv_snd_shift_ba [NeZero m] {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
-    (n : ZMod m) (hi : (orbitEquiv hba_unit).symm n |>.1.val + 1 < d₁) :
-    ((orbitEquiv hba_unit).symm (n + ↑(b - a))).2 = ((orbitEquiv hba_unit).symm n).2 := by
-  set Φ := orbitEquiv hba_unit
+private lemma orbitEquiv_snd_shift_ba [NeZero m] {h_gcd_coprime : Nat.gcd d₁ d₂ = 1}
+    (n : ZMod m) (hi : (orbitEquiv h_gcd_coprime).symm n |>.1.val + 1 < d₁) :
+    ((orbitEquiv h_gcd_coprime).symm (n + ↑(b - a))).2 = ((orbitEquiv h_gcd_coprime).symm n).2 := by
+  set Φ := orbitEquiv h_gcd_coprime
   set i := (Φ.symm n).1
   set j := (Φ.symm n).2
   have hshift := orbitMap_shift_ba (a := a) i j hi
@@ -284,8 +285,7 @@ lemma case_two_e1_even (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
     (h_min : min d₁ d₂ > 1) (he1_even : Even e₁) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   haveI : NeZero m := ⟨by grind [m_eq_d₁_mul_e₁ (m := m) (b := b)]⟩
-  have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
-  exact orbit_coloring_polychrom (orbitEquiv hba_unit) orbitEquiv_shift_b
+  exact orbit_coloring_polychrom (orbitEquiv h_gcd_coprime) orbitEquiv_shift_b
     orbitEquiv_cycle_shift (cycle_coloring d₁ e₁)
     (fun n k => color_covers_even d₁ e₁ (by grind) (parity_flip_even e₁ he1_even) _ _ _ k)
 
@@ -339,9 +339,7 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d�
         (h_gcd_coprime ▸ Nat.dvd_gcd this (dvd_refl _))) (by grind)
     · grind
   haveI : NeZero m := ⟨by grind⟩
-  have hba_unit : IsUnit (Int.cast (b - a) : ZMod d₁) :=
-    isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
-  let Φ := orbitEquiv hba_unit
+  let Φ := orbitEquiv h_gcd_coprime
   -- d₂ properties for the compatibility argument
   have hd₂_dvd : d₂ ∣ m := Nat.gcd_dvd_right _ _
   have hd₂_gt1 : d₂ > 1 := by grind
@@ -547,9 +545,9 @@ private lemma basePattern_rotation_covers {e j : ℕ} (he : Odd e) (hge : e ≥ 
       simp_all [intervalColors, Finset.mem_insert, Finset.mem_singleton]
   grind
 
-private lemma case2d_wrap_shift [NeZero m] (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) :
+private lemma case2d_wrap_shift [NeZero m] (h_gcd_coprime : Nat.gcd d₁ d₂ = 1) :
     ∃ k₀ : ZMod e₁, (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m) := by
-  set Φ := orbitEquiv hba_unit
+  set Φ := orbitEquiv h_gcd_coprime
   set q := Φ.symm ((d₁ : ℕ) • ((b - a : ℤ) : ZMod m))
   have hq_i : q.1 = 0 := by
     set f := ZMod.castHom d₁_dvd_m (ZMod d₁)
@@ -562,7 +560,8 @@ private lemma case2d_wrap_shift [NeZero m] (hba_unit : IsUnit ((b - a : ℤ) : Z
     have : f (d₁ • ((b - a : ℤ) : ZMod m)) = 0 := by
       rw [nsmul_eq_mul, map_mul, map_natCast, map_intCast, ZMod.natCast_self, zero_mul]
     rw [this] at hfφ
-    exact hba_unit.mul_left_eq_zero.mp hfφ.symm
+    exact (isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)).mul_left_eq_zero.mp
+      hfφ.symm
   refine ⟨q.2, ?_⟩
   have hφq := Equiv.apply_symm_apply Φ ((d₁ : ℕ) • ((b - a : ℤ) : ZMod m))
   change orbitMap m a b q = _ at hφq
@@ -595,11 +594,12 @@ private lemma case2d_shift_ba_wrap [NeZero m] (he1_b_zero : e₁ • (b : ZMod m
 
 /-- In the wrap case, the second coordinate shifts by k₀. -/
 private lemma orbitEquiv_snd_shift_ba_wrap [NeZero m]
-    {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)} (he1_b_zero : e₁ • (b : ZMod m) = 0)
+    {h_gcd_coprime : Nat.gcd d₁ d₂ = 1} (he1_b_zero : e₁ • (b : ZMod m) = 0)
     (k₀ : ZMod e₁) (hk₀ : (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m))
-    (n : ZMod m) (hi : (orbitEquiv hba_unit).symm n |>.1.val = d₁ - 1) :
-    ((orbitEquiv hba_unit).symm (n + ↑(b - a))).2 = ((orbitEquiv hba_unit).symm n).2 + k₀ := by
-  set Φ := orbitEquiv hba_unit
+    (n : ZMod m) (hi : (orbitEquiv h_gcd_coprime).symm n |>.1.val = d₁ - 1) :
+    ((orbitEquiv h_gcd_coprime).symm (n + ↑(b - a))).2 =
+    ((orbitEquiv h_gcd_coprime).symm n).2 + k₀ := by
+  set Φ := orbitEquiv h_gcd_coprime
   set i := (Φ.symm n).1
   set j := (Φ.symm n).2
   have hshift := case2d_shift_ba_wrap he1_b_zero k₀ hk₀ i hi
@@ -719,11 +719,10 @@ private lemma case2d_coloring_works (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d�
     (he1_ge : e₁ ≥ 19) (h3 : ¬ (3 ∣ d₁)) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   haveI : NeZero m := ⟨by grind [m_eq_d₁_mul_e₁ (m := m) (b := b)]⟩
-  have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   have he1_b_zero : e₁ • (b : ZMod m) = 0 :=
     addOrderOf_b_eq (b := b) (m := m) ▸ addOrderOf_nsmul_eq_zero _
-  let Φ := orbitEquiv hba_unit
-  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hba_unit
+  let Φ := orbitEquiv h_gcd_coprime
+  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift h_gcd_coprime
   have hd1_ge5 : d₁ ≥ 5 := by grind
   obtain ⟨vals, hvals_bound, hvals_sum⟩ := case2d_rotation_sum_exists hd1_ge5 he1_ge he1_odd k₀.val
   let rot : ZMod d₁ → ℕ := fun i =>
@@ -786,11 +785,10 @@ lemma case_two_odd_small (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1
     (h_min : min d₁ d₂ > 1) (hd1_odd : Odd d₁) (he1_div3 : 3 ∣ e₁) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   haveI : NeZero m := ⟨by grind [m_eq_d₁_mul_e₁ (m := m) (b := b)]⟩
-  have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   have he1_b_zero : e₁ • (b : ZMod m) = 0 :=
     addOrderOf_b_eq (b := b) (m := m) ▸ addOrderOf_nsmul_eq_zero _
-  let Φ := orbitEquiv hba_unit
-  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hba_unit
+  let Φ := orbitEquiv h_gcd_coprime
+  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift h_gcd_coprime
   have hd1_ge3 : d₁ ≥ 3 := by grind
   let f : ZMod d₁ × ZMod e₁ → Fin 3 := fun ⟨i, j⟩ =>
     ⟨(j.val + (case2c_pattern d₁ k₀.val i.val).val) % 3, Nat.mod_lt _ (by grind)⟩

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -858,87 +858,68 @@ lemma case_two_odd_small (hm : m ≥ 289)
   let Φ := orbitEquiv hm_eq hb_zero hba_unit hord
   obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hd1_dvd hb_zero hba_unit hord hm_eq
   have hd1_ge3 : d₁ ≥ 3 := by grind
-  -- Coloring: χ(x) = (j + pattern(i)) mod 3 where (i,j) = Φ⁻¹(x)
-  let χ : ZMod m → Fin 3 := fun x =>
-    let coord := Φ.symm x
-    ⟨(coord.2.val + (case2c_pattern d₁ k₀.val coord.1.val).val) % 3, Nat.mod_lt _ (by grind)⟩
-  refine ⟨χ, fun n k => ?_⟩
-  -- χ at orbit coordinates
-  have hχ_eq : ∀ (i' : ZMod d₁) (j' : ZMod e₁),
-      χ (Φ (i', j')) = ⟨(j'.val + (case2c_pattern d₁ k₀.val i'.val).val) % 3,
-        Nat.mod_lt _ (by grind)⟩ := by intro i' j'; simp only [χ, Equiv.symm_apply_apply]
-  -- Coordinates of n
-  set ij := Φ.symm n with hij_def
-  have hn : Φ ij = n := Equiv.apply_symm_apply Φ n
-  set i := ij.1 with hi_def
-  set j := ij.2 with hj_def
-  have hij : ij = (i, j) := (Prod.eta ij).symm
-  set p := case2c_pattern d₁ k₀.val i.val
-  -- ZMod e₁ successor: (jj + 1).val = (jj.val + 1) % e₁
-  have hzmod_succ : ∀ (jj : ZMod e₁), (jj + 1 : ZMod e₁).val = (jj.val + 1) % e₁ := ZMod.val_add_one
-  -- Shift: n + b = Φ(i, j+1)
-  have hΦ_b : Φ (i, j + 1) = n + ((b : ℤ) : ZMod m) := by
-    rw [← hn, hij]; exact (orbitMap_shift_b he1_b_zero (i, j)).symm
-  -- Case split: wrap or non-wrap
-  by_cases hi : i.val + 1 < d₁
-  · -- Non-wrap case: i+1 < d₁
-    set i' := i + 1
-    set p' := case2c_pattern d₁ k₀.val i'.val
-    -- Shift: n + (b-a) = Φ(i', j)
-    have hΦ_ba : Φ (i', j) = n + ((b - a : ℤ) : ZMod m) := by
-      rw [← hn, hij]; exact (orbitMap_shift_ba i j hi).symm
-    -- Shift: n + (2b-a) = Φ(i', j+1)
-    have hΦ_2ba : Φ (i', j + 1) = n + ((2 * b - a : ℤ) : ZMod m) := by
-      rw [intCast_2ba_eq, ← add_assoc, ← hΦ_ba]
-      exact (orbitMap_shift_b he1_b_zero (i', j)).symm
-    -- Coverage hypothesis
-    have hi'_eq : i'.val = i.val + 1 := by rw [ZMod.val_add_one]; exact Nat.mod_eq_of_lt hi
-    have hhyp : (j.val + p.val) % 3 ≠ (j.val + p'.val) % 3 := by
-      change (j.val + (case2c_pattern d₁ k₀.val i.val).val) % 3 ≠
-        (j.val + (case2c_pattern d₁ k₀.val i'.val).val) % 3
-      rw [hi'_eq]
-      exact case2c_nonwrap_hyp d₁ k₀.val i.val j.val hd1_ge3 hd1_odd hi
-    -- Apply cover_mod3_general
-    rcases cover_mod3_general p p' j.val j.val hhyp k with h | h | h | h
-    · exact ⟨0, zero_mem_zmod_set m a b, by rw [add_zero, ← hn, hij, hχ_eq, h]⟩
-    · refine ⟨((b : ℤ) : ZMod m), intCast_b_mem_zmod_set m a b, ?_⟩
-      rw [← hΦ_b, hχ_eq, h]; congr 1; rw [hzmod_succ, case2c_mod3 he1_div3]
-    · exact ⟨((b - a : ℤ) : ZMod m), intCast_ba_mem_zmod_set m a b, by rw [← hΦ_ba, hχ_eq, h]⟩
-    · refine ⟨((2 * b - a : ℤ) : ZMod m), intCast_2ba_mem_zmod_set m a b, ?_⟩
-      rw [← hΦ_2ba, hχ_eq, h]; congr 1; rw [hzmod_succ, case2c_mod3 he1_div3]
-  · -- Wrap case: i = d₁ - 1
-    have hi_eq : i.val = d₁ - 1 := by grind [ZMod.val_lt]
-    set j' : ZMod e₁ := j + k₀
-    set p₀ := case2c_pattern d₁ k₀.val 0
-    -- Shift: n + (b-a) = Φ(0, j')
-    have hΦ_ba : Φ (0, j') = n + ((b - a : ℤ) : ZMod m) := by
-      rw [← hn, hij]
-      exact (case2d_shift_ba_wrap he1_b_zero k₀ hk₀ i hi_eq j).symm
-    -- Shift: n + (2b-a) = Φ(0, j'+1)
-    have hΦ_2ba : Φ (0, j' + 1) = n + ((2 * b - a : ℤ) : ZMod m) := by
-      rw [intCast_2ba_eq, ← add_assoc, ← hΦ_ba]
-      exact (orbitMap_shift_b he1_b_zero (0, j')).symm
-    -- Coverage hypothesis: (j + p_last) % 3 ≠ (j + k₀ + p₀) % 3
-    have hp_eq : p = case2c_pattern d₁ k₀.val (d₁ - 1) := by grind
-    have hhyp : (j.val + p.val) % 3 ≠ (j.val + k₀.val + p₀.val) % 3 := by
-      rw [hp_eq]; exact case2c_wrap_hyp d₁ k₀.val j.val hd1_ge3 hd1_odd
-    -- Apply cover_mod3_general
-    have hj'_val : j'.val = (j.val + k₀.val) % e₁ := ZMod.val_add j k₀
-    rcases cover_mod3_general p p₀ j.val (j.val + k₀.val) hhyp k with h | h | h | h
-    · exact ⟨0, zero_mem_zmod_set m a b, by rw [add_zero, ← hn, hij, hχ_eq, h]⟩
-    · refine ⟨((b : ℤ) : ZMod m), intCast_b_mem_zmod_set m a b, ?_⟩
-      rw [← hΦ_b, hχ_eq, h]; congr 1; rw [hzmod_succ, case2c_mod3 he1_div3]
-    · refine ⟨((b - a : ℤ) : ZMod m), intCast_ba_mem_zmod_set m a b, ?_⟩
-      rw [← hΦ_ba, hχ_eq, h]; congr 1
-      change (j'.val + (case2c_pattern d₁ k₀.val (ZMod.val 0)).val) % 3 = _
-      rw [ZMod.val_zero, hj'_val]
-      exact case2c_mod3 he1_div3 (j.val + k₀.val) p₀.val
-    · refine ⟨((2 * b - a : ℤ) : ZMod m), intCast_2ba_mem_zmod_set m a b, ?_⟩
-      rw [← hΦ_2ba, hχ_eq, h]; congr 1
-      change ((j' + 1).val + (case2c_pattern d₁ k₀.val (ZMod.val 0)).val) % 3 = _
-      rw [ZMod.val_zero, hzmod_succ, hj'_val]
-      rw [case2c_mod3 he1_div3, Nat.add_assoc, Nat.add_assoc]
-      exact case2c_mod3 he1_div3 (j.val + k₀.val) (1 + p₀.val)
+  let f : ZMod d₁ × ZMod e₁ → Fin 3 := fun ⟨i, j⟩ =>
+    ⟨(j.val + (case2c_pattern d₁ k₀.val i.val).val) % 3, Nat.mod_lt _ (by grind)⟩
+  exact orbit_coloring_polychrom Φ orbitEquiv_shift_b orbitEquiv_cycle_shift f (fun n k => by
+    set i := (Φ.symm n).1; set j := (Φ.symm n).2
+    set j' := (Φ.symm (n + ↑(b - a))).2
+    set p := case2c_pattern d₁ k₀.val i.val
+    by_cases hi : i.val + 1 < d₁
+    · have hj'_eq : j' = j := by
+        have hshift := @orbitMap_shift_ba m a b d₁ e₁ ‹NeZero d₁› i j hi
+        have hn : Φ (i, j) = n := Prod.eta (Φ.symm n) ▸ Equiv.apply_symm_apply Φ n
+        have : Φ (i + 1, j) = n + ↑(b - a) := by
+          simp only [Φ, orbitEquiv, Equiv.ofBijective_apply] at hn ⊢; rw [← hn]; exact hshift.symm
+        have h := congrArg Prod.snd (show Φ.symm (n + ↑(b - a)) = (i + 1, j) by
+          rw [← this, Φ.symm_apply_apply])
+        exact h
+      rw [hj'_eq]
+      set p' := case2c_pattern d₁ k₀.val (i + 1).val
+      have hi'_eq : (i + 1).val = i.val + 1 := by
+        rw [ZMod.val_add_one]; exact Nat.mod_eq_of_lt hi
+      have hhyp : (j.val + p.val) % 3 ≠ (j.val + p'.val) % 3 := by
+        change (j.val + (case2c_pattern d₁ k₀.val i.val).val) % 3 ≠
+          (j.val + (case2c_pattern d₁ k₀.val (i + 1).val).val) % 3
+        rw [hi'_eq]; exact case2c_nonwrap_hyp d₁ k₀.val i.val j.val hd1_ge3 hd1_odd hi
+      rcases cover_mod3_general p p' j.val j.val hhyp k with h | h | h | h
+      · left; exact h
+      · right; left; rw [h, show p = case2c_pattern d₁ k₀.val i.val from rfl]
+        exact Fin.ext (by simp [f, ZMod.val_add_one, case2c_mod3 he1_div3])
+      · right; right; left; exact h
+      · right; right; right
+        rw [h, show p' = case2c_pattern d₁ k₀.val (i.val + 1) from by simp [p', hi'_eq]]
+        exact Fin.ext (by
+          simp [f, ZMod.val_add_one, case2c_mod3 he1_div3, Nat.mod_eq_of_lt hi])
+    · have hi_eq : i.val = d₁ - 1 := by grind [ZMod.val_lt]
+      have hj'_eq : j' = j + k₀ := by
+        have hshift := case2d_shift_ba_wrap he1_b_zero k₀ hk₀ i hi_eq j
+        have hn : Φ (i, j) = n := Prod.eta (Φ.symm n) ▸ Equiv.apply_symm_apply Φ n
+        have : Φ ((0 : ZMod d₁), j + k₀) = n + ↑(b - a) := by
+          simp only [Φ, orbitEquiv, Equiv.ofBijective_apply] at hn ⊢
+          rw [← hn]; exact hshift.symm
+        change (Φ.symm (n + ↑(b - a))).2 = j + k₀
+        rw [← this, Φ.symm_apply_apply]
+      rw [hj'_eq]
+      set p₀ := case2c_pattern d₁ k₀.val 0
+      have hp_eq : p = case2c_pattern d₁ k₀.val (d₁ - 1) := by grind
+      have hhyp : (j.val + p.val) % 3 ≠ (j.val + k₀.val + p₀.val) % 3 := by
+        rw [hp_eq]; exact case2c_wrap_hyp d₁ k₀.val j.val hd1_ge3 hd1_odd
+      have hj'_val : (j + k₀).val = (j.val + k₀.val) % e₁ := ZMod.val_add j k₀
+      rcases cover_mod3_general p p₀ j.val (j.val + k₀.val) hhyp k with h | h | h | h
+      · left; exact h
+      · right; left; rw [h, show p = case2c_pattern d₁ k₀.val i.val from rfl]
+        exact Fin.ext (by simp [f, ZMod.val_add_one, case2c_mod3 he1_div3])
+      · right; right; left; rw [h]
+        have hi1_val : (i + 1).val = 0 := by
+          rw [ZMod.val_add_one, hi_eq]; grind [Nat.mod_self]
+        refine Fin.ext ?_; simp only [f, hi1_val]
+        rw [hj'_val]; exact (case2c_mod3 he1_div3 (j.val + k₀.val) p₀.val).symm
+      · right; right; right; rw [h]
+        have hi1_val : (i + 1).val = 0 := by
+          rw [ZMod.val_add_one, hi_eq]; grind [Nat.mod_self]
+        refine Fin.ext ?_; simp only [f, hi1_val, ZMod.val_add_one]
+        rw [hj'_val, show (↑p₀ : ℕ) = ↑(case2c_pattern d₁ k₀.val 0) from rfl]
+        simp only [case2c_mod3 he1_div3, Nat.add_assoc])
 
 /-- Auxiliary: rules out both cycle lengths being ≤ 17 when m ≥ 289. -/
 private lemma no_both_e_small {m d₁ d₂ : ℕ} (hm : m ≥ 289) (hcop : Nat.gcd d₁ d₂ = 1)

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -121,9 +121,13 @@ private lemma orbitMap_j_eq {m : ℕ} {b : ℤ} {e₁ : ℕ} [NeZero e₁]
       (by grind [j₁.val_lt (n := e₁), j₂.val_lt (n := e₁)])
     exact ZMod.val_injective _ (by grind)
 
-private lemma orbitMap_injective {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero m] [NeZero d₁] [NeZero e₁]
-    (hd1_dvd : d₁ ∣ m) (hb_zero : (b : ZMod d₁) = 0) (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
+private lemma orbitMap_injective {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero m]
+    (hm_eq : m = d₁ * e₁) (hb_zero : (b : ZMod d₁) = 0)
+    (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
     (hord : addOrderOf (b : ZMod m) = e₁) : Function.Injective (orbitMap m a b d₁ e₁) := by
+  have hd1_dvd : d₁ ∣ m := hm_eq ▸ dvd_mul_right d₁ e₁
+  haveI : NeZero d₁ := ⟨by rintro rfl; exact absurd (by simp [hm_eq]) (NeZero.ne m)⟩
+  haveI : NeZero e₁ := ⟨by rintro rfl; exact absurd (by simp [hm_eq]) (NeZero.ne m)⟩
   intro ⟨i₁, j₁⟩ ⟨i₂, j₂⟩ heq
   have hi := orbitMap_i_eq hd1_dvd hb_zero hba_unit heq
   subst hi
@@ -131,12 +135,14 @@ private lemma orbitMap_injective {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero
   have hj_smul : (j₁.val : ℕ) • (b : ZMod m) = (j₂.val : ℕ) • (b : ZMod m) := by grind
   exact Prod.ext rfl (orbitMap_j_eq hord hj_smul)
 
-private lemma orbitMap_bijective {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero m] [NeZero d₁] [NeZero e₁]
-    (hm_eq : m = d₁ * e₁) (hd1_dvd : d₁ ∣ m) (hb_zero : (b : ZMod d₁) = 0)
+private lemma orbitMap_bijective {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero m]
+    (hm_eq : m = d₁ * e₁) (hb_zero : (b : ZMod d₁) = 0)
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
-    (hord : addOrderOf (b : ZMod m) = e₁) : Function.Bijective (orbitMap m a b d₁ e₁) :=
-  (Fintype.bijective_iff_injective_and_card _).mpr
-    ⟨orbitMap_injective hd1_dvd hb_zero hba_unit hord,
+    (hord : addOrderOf (b : ZMod m) = e₁) : Function.Bijective (orbitMap m a b d₁ e₁) := by
+  haveI : NeZero d₁ := ⟨by rintro rfl; exact absurd (by simp [hm_eq]) (NeZero.ne m)⟩
+  haveI : NeZero e₁ := ⟨by rintro rfl; exact absurd (by simp [hm_eq]) (NeZero.ne m)⟩
+  exact (Fintype.bijective_iff_injective_and_card _).mpr
+    ⟨orbitMap_injective hm_eq hb_zero hba_unit hord,
      by simp [Fintype.card_prod, ZMod.card, hm_eq]⟩
 
 private lemma orbitMap_shift_b {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero e₁]
@@ -196,12 +202,49 @@ private lemma equiv_symm_fst_eq {d₁ e₁ : ℕ} {γ : Type*}
 
 /-! ### Orbit coloring framework -/
 
+section OrbitFramework
+variable {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero m]
+
+/-- Build the orbit equivalence from the standard hypotheses. -/
+private noncomputable def orbitEquiv (hm_eq : m = d₁ * e₁)
+    (hb_zero : (b : ZMod d₁) = 0) (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
+    (hord : addOrderOf (b : ZMod m) = e₁) : ZMod d₁ × ZMod e₁ ≃ ZMod m :=
+  Equiv.ofBijective (orbitMap m a b d₁ e₁) (orbitMap_bijective hm_eq hb_zero hba_unit hord)
+
+private lemma orbitEquiv_shift_b {hm_eq : m = d₁ * e₁}
+    {hb_zero : (b : ZMod d₁) = 0} {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
+    {hord : addOrderOf (b : ZMod m) = e₁} (x : ZMod m) :
+    (orbitEquiv hm_eq hb_zero hba_unit hord).symm (x + ↑b) =
+    (((orbitEquiv hm_eq hb_zero hba_unit hord).symm x).1,
+     ((orbitEquiv hm_eq hb_zero hba_unit hord).symm x).2 + 1) := by
+  haveI : NeZero e₁ := ⟨by rintro rfl; exact absurd (by simp [hm_eq]) (NeZero.ne m)⟩
+  exact equiv_symm_shift_b _ (fun i j =>
+    (orbitMap_shift_b (hord ▸ addOrderOf_nsmul_eq_zero _) (i, j)).symm) x
+
+private lemma orbitEquiv_cycle_shift {hm_eq : m = d₁ * e₁}
+    {hb_zero : (b : ZMod d₁) = 0} {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
+    {hord : addOrderOf (b : ZMod m) = e₁} (x : ZMod m) :
+    ((orbitEquiv hm_eq hb_zero hba_unit hord).symm (x + ↑(b - a))).1 =
+    ((orbitEquiv hm_eq hb_zero hba_unit hord).symm x).1 + 1 := by
+  have hd1_dvd : d₁ ∣ m := hm_eq ▸ dvd_mul_right d₁ e₁
+  haveI : NeZero d₁ := ⟨by rintro rfl; exact absurd (by simp [hm_eq]) (NeZero.ne m)⟩
+  let u_ba := hba_unit.choose
+  have hu_ba : ↑u_ba = ((b - a : ℤ) : ZMod d₁) := hba_unit.choose_spec
+  let α : ZMod m → ZMod d₁ := fun x => ZMod.castHom hd1_dvd (ZMod d₁) x * u_ba⁻¹
+  have hΦ_cycle := equiv_symm_fst_eq (orbitEquiv hm_eq hb_zero hba_unit hord) α
+    (orbitMap_cycle_index hd1_dvd hb_zero u_ba hu_ba)
+  rw [hΦ_cycle (x + ↑(b - a))]
+  dsimp only [α]
+  rw [cycle_index_shift_ba hd1_dvd u_ba hu_ba]
+  congr 1
+  exact (hΦ_cycle x).symm
+
+omit [NeZero m] in
 /-- **Key infrastructure for Case 2.** Polychromaticity from an orbit coloring:
     given an orbit equivalence Φ with shift properties and a coloring f,
     if f covers all colors at any translate, then f ∘ Φ.symm is polychromatic.
     All four Case 2 subcases use this as their final step. -/
-private lemma orbit_coloring_polychrom {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
-    [NeZero m] [NeZero d₁] [NeZero e₁]
+private lemma orbit_coloring_polychrom
     (Φ : ZMod d₁ × ZMod e₁ ≃ ZMod m)
     (hΦ_add_b : ∀ x : ZMod m, Φ.symm (x + ↑b) = ((Φ.symm x).1, (Φ.symm x).2 + 1))
     (hΦ_cycle_shift : ∀ x : ZMod m, (Φ.symm (x + ↑(b - a))).1 = (Φ.symm x).1 + 1)
@@ -229,6 +272,8 @@ private lemma orbit_coloring_polychrom {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ}
   · grind
   · grind
 
+end OrbitFramework
+
 /-! ### Subcase (2a): e₁ even -/
 
 /-- **Subcase (2a).** $e_1$ is even. Each cycle uses two alternating colors;
@@ -249,32 +294,16 @@ lemma case_two_e1_even (hm : m ≥ 289)
   haveI : NeZero d₁ := ⟨by grind⟩
   haveI : NeZero e₁ := ⟨by grind⟩
   have hb_zero : (Int.cast b : ZMod d₁) = 0 := b_zero_mod_d1 rfl
-  have hba_unit : IsUnit (Int.cast (b - a) : ZMod d₁) :=
-    isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 hd₁_dvd h_gcd_coprime)
-  -- addOrderOf b in ZMod m is e₁
+  have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 hd₁_dvd h_gcd_coprime)
   have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind) rfl
-  have he1_b : e₁ • (b : ZMod m) = 0 := hord ▸ addOrderOf_nsmul_eq_zero _
-  -- Define the cycle map φ = orbitMap and derive bijectivity from shared infrastructure
-  let φ := orbitMap m a b d₁ e₁
-  have hφ_add_b : ∀ i : ZMod d₁, ∀ j : ZMod e₁,
-      φ (i, j + 1) = φ (i, j) + ↑b := by
-    intro i j; exact (orbitMap_shift_b he1_b (i, j)).symm
-  -- φ is bijective (from shared orbitMap infrastructure)
-  let Φ := Equiv.ofBijective φ (orbitMap_bijective hm_eq hd₁_dvd hb_zero hba_unit hord)
-  -- Cycle index function α : ZMod m → ZMod d₁
-  obtain ⟨u_ba, hu_ba⟩ := hba_unit
-  let α : ZMod m → ZMod d₁ := fun x => ZMod.castHom hd₁_dvd (ZMod d₁) x * u_ba⁻¹
-  have hα_ba : ∀ x, α (x + ↑(b - a)) = α x + 1 := cycle_index_shift_ba hd₁_dvd u_ba hu_ba
-  have hα_φ : ∀ i : ZMod d₁, ∀ j : ZMod e₁, α (φ (i, j)) = i :=
-    orbitMap_cycle_index hd₁_dvd hb_zero u_ba hu_ba
-  have hΦ_add_b := equiv_symm_shift_b Φ hφ_add_b
-  have hΦ_cycle := equiv_symm_fst_eq Φ α hα_φ
+  let Φ := orbitEquiv hm_eq hb_zero hba_unit hord
   have hd₁_ge2 : d₁ ≥ 2 := by grind
-  have hparity : ∀ j : ZMod e₁, j.val % 2 ≠ (j + 1).val % 2 := parity_flip_even e₁ he1_even he₁_ge2
-  exact orbit_coloring_polychrom Φ hΦ_add_b
-    (fun x => by rw [hΦ_cycle, hα_ba, ← hΦ_cycle])
+  have he₁_ge2 : e₁ ≥ 2 := by
+    have : 0 < e₁ := Nat.div_pos (Nat.le_of_dvd (by grind) hd₁_dvd) (by grind)
+    grind
+  exact orbit_coloring_polychrom Φ orbitEquiv_shift_b orbitEquiv_cycle_shift
     (cycle_coloring d₁ e₁)
-    (fun n k => color_covers_even d₁ e₁ hd₁_ge2 hparity _ _ _ k)
+    (fun n k => color_covers_even d₁ e₁ hd₁_ge2 (parity_flip_even e₁ he1_even he₁_ge2) _ _ _ k)
 
 /-! ### Subcase (2b) construction: d₁ even, e₁ odd
 
@@ -335,20 +364,7 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
   have hba_unit : IsUnit (Int.cast (b - a) : ZMod d₁) :=
     isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 hd₁_dvd h_gcd_coprime)
   have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind) rfl
-  have he1_b : e₁ • (b : ZMod m) = 0 := hord ▸ addOrderOf_nsmul_eq_zero _
-  -- Define the cycle map φ = orbitMap and derive bijectivity from shared infrastructure
-  let φ := orbitMap m a b d₁ e₁
-  let Φ := Equiv.ofBijective φ (orbitMap_bijective hm_eq hd₁_dvd hb_zero hba_unit hord)
-  have hφ_add_b : ∀ i : ZMod d₁, ∀ j : ZMod e₁,
-      φ (i, j + 1) = φ (i, j) + ↑b := by intro i j; exact (orbitMap_shift_b he1_b (i, j)).symm
-  -- Cycle index function α : ZMod m → ZMod d₁
-  obtain ⟨u_ba, hu_ba⟩ := hba_unit
-  let α : ZMod m → ZMod d₁ := fun x => ZMod.castHom hd₁_dvd (ZMod d₁) x * u_ba⁻¹
-  have hα_ba : ∀ x, α (x + ↑(b - a)) = α x + 1 := cycle_index_shift_ba hd₁_dvd u_ba hu_ba
-  have hα_φ : ∀ i : ZMod d₁, ∀ j : ZMod e₁, α (φ (i, j)) = i :=
-    orbitMap_cycle_index hd₁_dvd hb_zero u_ba hu_ba
-  have hΦ_add_b := equiv_symm_shift_b Φ hφ_add_b
-  have hΦ_cycle := equiv_symm_fst_eq Φ α hα_φ
+  let Φ := orbitEquiv hm_eq hb_zero hba_unit hord
   -- d₂ properties for the compatibility argument
   set d₂ := Nat.gcd (b - a).natAbs m
   have hd₂_dvd : d₂ ∣ m := Nat.gcd_dvd_right _ _
@@ -361,8 +377,10 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
   -- Projection: π(φ(i,j)) = j.val * π(b) since π(b-a) = 0
   haveI : NeZero d₂ := ⟨by grind⟩
   let π : ZMod m → ZMod d₂ := ZMod.castHom hd₂_dvd (ZMod d₂)
-  have hπ_φ : ∀ i : ZMod d₁, ∀ j : ZMod e₁, π (φ (i, j)) = (j.val : ZMod d₂) * π (↑b) := by
-    intro i j; simp only [φ, orbitMap, π, map_add, map_mul, map_natCast, map_intCast]
+  have hπ_Φ : ∀ i : ZMod d₁, ∀ j : ZMod e₁, π (Φ (i, j)) = (j.val : ZMod d₂) * π (↑b) := by
+    intro i j
+    change π (orbitMap m a b d₁ e₁ (i, j)) = _
+    simp only [orbitMap, π, map_add, map_mul, map_natCast, map_intCast]
     rw [(ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mpr hd₂_dvd_ba]; ring
   -- π(b) is a unit in ZMod d₂
   have hπ_b_unit : IsUnit (π (↑b)) := by
@@ -382,18 +400,14 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
       have h := Nat.dvd_sub hd₂_dvd_e₁ hd₂_dvd_diff
       have : e₁ - (e₁ - 2) = 2 := by grind
       rwa [this] at h
-    obtain ⟨_, hk⟩ := hd₂_dvd_e₁
-    obtain ⟨_, hl⟩ := he1_odd
-    have := Nat.le_of_dvd (by grind) hd₂_dvd_2
-    grind
-  -- Define coloring and prove polychromaticity via orbit helper
-  have hΦ_cycle_shift : ∀ x, (Φ.symm (x + ↑(b - a))).1 = (Φ.symm x).1 + 1 := fun x => by
-    rw [hΦ_cycle, hα_ba, ← hΦ_cycle]
+    obtain ⟨_, hk⟩ := hd₂_dvd_e₁; obtain ⟨_, hl⟩ := he1_odd
+    have := Nat.le_of_dvd (by grind) hd₂_dvd_2; grind
   -- π(n) and π(n+(b-a)) give the same ZMod d₂ value
   have hπ_eq : ∀ n : ZMod m, π (n + ↑(b - a)) = π n := fun n => by
     simp only [π, map_add, map_intCast]
     rw [(ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mpr hd₂_dvd_ba, add_zero]
-  exact orbit_coloring_polychrom Φ hΦ_add_b hΦ_cycle_shift (case2b_coloring d₁ e₁) (fun n k => by
+  exact orbit_coloring_polychrom Φ orbitEquiv_shift_b orbitEquiv_cycle_shift
+    (case2b_coloring d₁ e₁) (fun n k => by
       set p := Φ.symm n; set j := p.2
       set j' := (Φ.symm (n + ↑(b - a))).2
       have hπn : π n = (j.val : ZMod d₂) * π (↑b) := by
@@ -567,8 +581,7 @@ private lemma case2d_wrap_shift {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero 
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) (hord : addOrderOf (b : ZMod m) = e₁)
     (hm_eq : m = d₁ * e₁) :
     ∃ k₀ : ZMod e₁, (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m) := by
-  have hbij := orbitMap_bijective hm_eq hd1_dvd hb_zero hba_unit hord
-  set Φ := Equiv.ofBijective _ hbij
+  set Φ := orbitEquiv hm_eq hb_zero hba_unit hord
   set q := Φ.symm ((d₁ : ℕ) • ((b - a : ℤ) : ZMod m))
   have hq_i : q.1 = 0 := by
     set f := ZMod.castHom hd1_dvd (ZMod d₁)
@@ -746,7 +759,7 @@ private lemma case2d_coloring_works {m : ℕ} {a b : ℤ} (hm : m ≥ 289)
   have hb_zero : (b : ZMod d₁) = 0 := b_zero_mod_d1 hd1_def
   have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 hd1_dvd (by rwa [hd1_def]))
   have he1_b_zero : e₁ • (b : ZMod m) = 0 := hord ▸ addOrderOf_nsmul_eq_zero _
-  set Φ := Equiv.ofBijective _ (orbitMap_bijective hm_eq hd1_dvd hb_zero hba_unit hord)
+  let Φ := orbitEquiv hm_eq hb_zero hba_unit hord
   obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hd1_dvd hb_zero hba_unit hord hm_eq
   -- d₁ is odd, > 1, and ¬(3∣d₁), so d₁ ≥ 5
   have hd1_ge5 : d₁ ≥ 5 := by grind
@@ -842,8 +855,7 @@ lemma case_two_odd_small (hm : m ≥ 289)
   have hb_zero : (b : ZMod d₁) = 0 := b_zero_mod_d1 hd1_def
   have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 hd1_dvd (by rwa [hd1_def]))
   have he1_b_zero : e₁ • (b : ZMod m) = 0 := hord ▸ addOrderOf_nsmul_eq_zero _
-  have hbij := orbitMap_bijective hm_eq hd1_dvd hb_zero hba_unit hord
-  set Φ := Equiv.ofBijective _ hbij
+  let Φ := orbitEquiv hm_eq hb_zero hba_unit hord
   obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hd1_dvd hb_zero hba_unit hord hm_eq
   have hd1_ge3 : d₁ ≥ 3 := by grind
   -- Coloring: χ(x) = (j + pattern(i)) mod 3 where (i,j) = Φ⁻¹(x)

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -137,7 +137,6 @@ private lemma orbitMap_j_eq [NeZero m] {j₁ j₂ : ZMod e₁}
 
 private lemma orbitMap_injective [NeZero m] (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) :
     Function.Injective (orbitMap m a b : ZMod d₁ × ZMod e₁ → ZMod m) := by
-  have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   intro ⟨i₁, j₁⟩ ⟨i₂, j₂⟩ heq
   have hi := orbitMap_i_eq hba_unit heq
   subst hi
@@ -146,11 +145,11 @@ private lemma orbitMap_injective [NeZero m] (hba_unit : IsUnit ((b - a : ℤ) : 
   exact Prod.ext rfl (orbitMap_j_eq hj_smul)
 
 private lemma orbitMap_bijective [NeZero m] (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) :
-    Function.Bijective (orbitMap m a b : ZMod d₁ × ZMod e₁ → ZMod m) := by
-  have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
-  exact (Fintype.bijective_iff_injective_and_card _).mpr
-    ⟨orbitMap_injective hba_unit,
-     by simp only [Fintype.card_prod, ZMod.card]; linarith [hm_eq]⟩
+    Function.Bijective (orbitMap m a b : ZMod d₁ × ZMod e₁ → ZMod m) :=
+  (Fintype.bijective_iff_injective_and_card _).mpr
+    ⟨orbitMap_injective hba_unit, by
+      simp only [Fintype.card_prod, ZMod.card]
+      linarith [m_eq_d₁_mul_e₁ (m := m) (b := b)]⟩
 
 private lemma orbitMap_shift_b [NeZero m] (he1_b_zero : e₁ • (b : ZMod m) = 0) :
     ∀ p : ZMod d₁ × ZMod e₁, orbitMap m a b p + (b : ZMod m) = orbitMap m a b (p.1, p.2 + 1) := by
@@ -214,16 +213,14 @@ private noncomputable def orbitEquiv [NeZero m]
 private lemma orbitEquiv_shift_b [NeZero m] {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
     (x : ZMod m) :
     (orbitEquiv hba_unit).symm (x + ↑b) =
-    (((orbitEquiv hba_unit).symm x).1, ((orbitEquiv hba_unit).symm x).2 + 1) := by
-  have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
-  exact equiv_symm_shift_b _ (fun i j =>
+    (((orbitEquiv hba_unit).symm x).1, ((orbitEquiv hba_unit).symm x).2 + 1) :=
+  equiv_symm_shift_b _ (fun i j =>
     (orbitMap_shift_b (addOrderOf_b_eq (b := b) (m := m) ▸
       addOrderOf_nsmul_eq_zero _) (i, j)).symm) x
 
 private lemma orbitEquiv_cycle_shift [NeZero m] {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
     (x : ZMod m) :
     ((orbitEquiv hba_unit).symm (x + ↑(b - a))).1 = ((orbitEquiv hba_unit).symm x).1 + 1 := by
-  have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   let u_ba := hba_unit.choose
   have hu_ba : ↑u_ba = ((b - a : ℤ) : ZMod d₁) := hba_unit.choose_spec
   let α : ZMod m → ZMod d₁ := fun x => ZMod.castHom d₁_dvd_m (ZMod d₁) x * u_ba⁻¹
@@ -290,8 +287,7 @@ private lemma orbit_coloring_polychrom (Φ : ZMod d₁ × ZMod e₁ ≃ ZMod m)
 lemma case_two_e1_even (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
     (h_min : min d₁ d₂ > 1) (he1_even : Even e₁) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
-  have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
-  haveI : NeZero m := ⟨by grind⟩
+  haveI : NeZero m := ⟨by grind [m_eq_d₁_mul_e₁ (m := m) (b := b)]⟩
   have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   exact orbit_coloring_polychrom (orbitEquiv hba_unit) orbitEquiv_shift_b
     orbitEquiv_cycle_shift (cycle_coloring d₁ e₁)
@@ -734,8 +730,7 @@ private lemma case2d_coloring_works (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d�
     (h_min : min d₁ d₂ > 1) (hd1_odd : Odd d₁) (he1_odd : Odd e₁)
     (he1_ge : e₁ ≥ 19) (h3 : ¬ (3 ∣ d₁)) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
-  have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
-  haveI : NeZero m := ⟨by grind⟩
+  haveI : NeZero m := ⟨by grind [m_eq_d₁_mul_e₁ (m := m) (b := b)]⟩
   have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   have he1_b_zero : e₁ • (b : ZMod m) = 0 :=
     addOrderOf_b_eq (b := b) (m := m) ▸ addOrderOf_nsmul_eq_zero _
@@ -802,8 +797,7 @@ private lemma case2c_mod3 (h3e : 3 ∣ e₁) (x y : ℕ) : (x % e₁ + y) % 3 = 
 lemma case_two_odd_small (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
     (h_min : min d₁ d₂ > 1) (hd1_odd : Odd d₁) (he1_div3 : 3 ∣ e₁) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
-  have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
-  haveI : NeZero m := ⟨by grind⟩
+  haveI : NeZero m := ⟨by grind [m_eq_d₁_mul_e₁ (m := m) (b := b)]⟩
   have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   have he1_b_zero : e₁ • (b : ZMod m) = 0 :=
     addOrderOf_b_eq (b := b) (m := m) ▸ addOrderOf_nsmul_eq_zero _

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -336,8 +336,7 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d�
     rcases (by grind : e₁ = 1 ∨ e₁ = 2) with he | he
     · have : d₂ ∣ d₁ := by
         have : m = d₁ := by grind
-        rw [← this]
-        exact Nat.gcd_dvd_right _ _
+        grind
       exact absurd (Nat.eq_one_of_dvd_one
         (h_gcd_coprime ▸ Nat.dvd_gcd this (dvd_refl _))) (by grind)
     · grind
@@ -746,7 +745,7 @@ private lemma case2d_coloring_works (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d�
       rcases covers with h | h | h | h
       · left; exact h
       · right; left; rw [h]; simp only [f]; congr 1; exact (pos_shift_one j (rot i)).symm
-      · right; right; left; rw [h]; simp only [f]; congr 1; exact hpos.symm
+      · right; right; left; rw [h]; simp only [f]; grind
       · right
         right
         right
@@ -815,12 +814,12 @@ lemma case_two_odd_small (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1
       have hp : p = case2c_pattern d₁ k₀.val i.val := rfl
       have hp' : p' = case2c_pattern d₁ k₀.val (i.val + 1) := by simp [p', hi'_eq]
       rcases cover_mod3_general p p' j.val j.val hhyp k with h | h | h | h
-      · left; exact h
+      · grind
       · right
         left
         rw [h, hp]
         exact Fin.ext (by simp [f, ZMod.val_add_one, case2c_mod3 he1_div3])
-      · right; right; left; exact h
+      · grind
       · right
         right
         right
@@ -841,7 +840,7 @@ lemma case_two_odd_small (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1
       have hp : p = case2c_pattern d₁ k₀.val i.val := rfl
       have hp₀_val : (↑p₀ : ℕ) = ↑(case2c_pattern d₁ k₀.val 0) := rfl
       rcases cover_mod3_general p p₀ j.val (j.val + k₀.val) hhyp k with h | h | h | h
-      · left; exact h
+      · grind
       · right
         left
         rw [h, hp]

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -825,7 +825,8 @@ lemma case_two_odd_small (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1
       have hp' : p' = case2c_pattern d₁ k₀.val (i.val + 1) := by simp [p', hi'_eq]
       rcases cover_mod3_general p p' j.val j.val hhyp k with h | h | h | h
       · left; exact h
-      · right; left
+      · right
+        left
         rw [h, hp]
         exact Fin.ext (by simp [f, ZMod.val_add_one, case2c_mod3 he1_div3])
       · right; right; left; exact h
@@ -850,7 +851,8 @@ lemma case_two_odd_small (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1
       have hp₀_val : (↑p₀ : ℕ) = ↑(case2c_pattern d₁ k₀.val 0) := rfl
       rcases cover_mod3_general p p₀ j.val (j.val + k₀.val) hhyp k with h | h | h | h
       · left; exact h
-      · right; left
+      · right
+        left
         rw [h, hp]
         exact Fin.ext (by simp [f, ZMod.val_add_one, case2c_mod3 he1_div3])
       · right

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -767,7 +767,10 @@ private lemma case2d_coloring_works (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d�
       · left; exact h
       · right; left; rw [h]; simp only [f]; congr 1; exact (pos_shift_one j (rot i)).symm
       · right; right; left; rw [h]; simp only [f]; congr 1; exact hpos.symm
-      · right; right; right; rw [h]; simp only [f]; congr 1
+      · right; right; right
+        rw [h]
+        simp only [f]
+        congr 1
         calc (p + vals i + 1) % e₁
             = ((p + vals i) % e₁ + 1) % e₁ := (Nat.mod_add_mod (p + vals i) e₁ 1).symm
           _ = ((j'.val + rot (i + 1)) % e₁ + 1) % e₁ := by rw [hpos]
@@ -831,10 +834,12 @@ lemma case_two_odd_small (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1
       have hp' : p' = case2c_pattern d₁ k₀.val (i.val + 1) := by simp [p', hi'_eq]
       rcases cover_mod3_general p p' j.val j.val hhyp k with h | h | h | h
       · left; exact h
-      · right; left; rw [h, hp]
+      · right; left
+        rw [h, hp]
         exact Fin.ext (by simp [f, ZMod.val_add_one, case2c_mod3 he1_div3])
       · right; right; left; exact h
-      · right; right; right; rw [h, hp']
+      · right; right; right
+        rw [h, hp']
         exact Fin.ext (by
           simp [f, ZMod.val_add_one, case2c_mod3 he1_div3, Nat.mod_eq_of_lt hi])
     · have hi_eq : i.val = d₁ - 1 := by grind [ZMod.val_lt]
@@ -851,14 +856,17 @@ lemma case_two_odd_small (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1
       have hp₀_val : (↑p₀ : ℕ) = ↑(case2c_pattern d₁ k₀.val 0) := rfl
       rcases cover_mod3_general p p₀ j.val (j.val + k₀.val) hhyp k with h | h | h | h
       · left; exact h
-      · right; left; rw [h, hp]
+      · right; left
+        rw [h, hp]
         exact Fin.ext (by simp [f, ZMod.val_add_one, case2c_mod3 he1_div3])
-      · right; right; left; rw [h]
+      · right; right; left
+        rw [h]
         refine Fin.ext ?_
         simp only [f, hi1_val]
         rw [hj'_val]
         exact (case2c_mod3 he1_div3 (j.val + k₀.val) p₀.val).symm
-      · right; right; right; rw [h]
+      · right; right; right
+        rw [h]
         refine Fin.ext ?_
         simp only [f, hi1_val, ZMod.val_add_one]
         rw [hj'_val, hp₀_val]

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -24,7 +24,7 @@ The proof splits into subcases based on the parity of $d_1$ and $e_1$:
 
 section Case2_MultipleCycles
 
-variable (m : ℕ) (a b : ℤ)
+variable {m : ℕ} {a b : ℤ}
 
 /-! ### Arithmetic helpers for cycle decomposition
 
@@ -67,15 +67,21 @@ private lemma color_covers_even (d₁ e₁ : ℕ) [NeZero d₁] [NeZero e₁] (h
     k = cycle_coloring d₁ e₁ (i + 1, j₂ + 1) := by
   grind [cycle_coloring, Fin.ext_iff, zmod_val_add_one]
 
+/-! ### Orbit coloring framework -/
+
+section OrbitFramework
+variable {d₁ e₁ : ℕ} [NeZero m]
+
 /--
 The orbit map $\phi : \mathbb{Z}_{d_1} \times \mathbb{Z}_{e_1} \to \mathbb{Z}_m$ defined by
 $\phi(i, j) = i(b-a) + jb \pmod m$. This map is a bijection when $\gcd(b-a, b, m) = 1$.
 It provides the coordinate system used to analyze the "Multiple Cycles" case.
 -/
-private def orbitMap (m : ℕ) (a b : ℤ) (d₁ e₁ : ℕ) : ZMod d₁ × ZMod e₁ → ZMod m :=
+private def orbitMap (m : ℕ) (a b : ℤ) : ZMod d₁ × ZMod e₁ → ZMod m :=
   fun p => (p.1.val : ZMod m) * ↑(b - a) + (p.2.val : ZMod m) * ↑b
 
-private lemma addOrderOf_b_eq {m : ℕ} {b : ℤ} {d₁ : ℕ} (hm : 0 < m)
+omit [NeZero m] in
+private lemma addOrderOf_b_eq (hm : 0 < m)
     (hd1_def : Nat.gcd b.natAbs m = d₁) :
     addOrderOf (b : ZMod m) = m / d₁ := by
   have key : addOrderOf (b.natAbs : ZMod m) = m / d₁ := by
@@ -86,20 +92,23 @@ private lemma addOrderOf_b_eq {m : ℕ} {b : ℤ} {d₁ : ℕ} (hm : 0 < m)
   · have : (b : ZMod m) = -(b.natAbs : ZMod m) := by rw [h]; simp
     rw [this, addOrderOf_neg]; exact key
 
-private lemma b_zero_mod_d1 {m : ℕ} {b : ℤ} {d₁ : ℕ}
+omit [NeZero m] in
+private lemma b_zero_mod_d1
     (hd1_def : Nat.gcd b.natAbs m = d₁) [NeZero d₁] : (b : ZMod d₁) = 0 := by
   rw [ZMod.intCast_zmod_eq_zero_iff_dvd]
   exact Int.natCast_dvd.mpr (hd1_def ▸ Nat.gcd_dvd_left b.natAbs m)
 
-private lemma ba_coprime_d1 {m : ℕ} {a b : ℤ} {d₁ : ℕ} (hd1_dvd : d₁ ∣ m)
+omit [NeZero m] in
+private lemma ba_coprime_d1 (hd1_dvd : d₁ ∣ m)
     (h_gcd_coprime : d₁.gcd (Nat.gcd (b - a).natAbs m) = 1) : Nat.Coprime (b - a).natAbs d₁ :=
   Nat.dvd_one.mp (h_gcd_coprime ▸ Nat.dvd_gcd (Nat.gcd_dvd_right _ _)
       (Nat.dvd_gcd (Nat.gcd_dvd_left _ _) (dvd_trans (Nat.gcd_dvd_right _ _) hd1_dvd)))
 
-private lemma orbitMap_i_eq {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero m] [NeZero d₁]
+omit [NeZero m] in
+private lemma orbitMap_i_eq [NeZero d₁]
     (hd1_dvd : d₁ ∣ m) (hb_zero : (b : ZMod d₁) = 0)
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) {i₁ i₂ : ZMod d₁} {j₁ j₂ : ZMod e₁}
-    (heq : orbitMap m a b d₁ e₁ (i₁, j₁) = orbitMap m a b d₁ e₁ (i₂, j₂)) :
+    (heq : orbitMap m a b (i₁, j₁) = orbitMap m a b (i₂, j₂)) :
     i₁ = i₂ := by
   simp only [orbitMap] at heq
   have := congr_arg (ZMod.castHom hd1_dvd (ZMod d₁)) heq
@@ -107,7 +116,7 @@ private lemma orbitMap_i_eq {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero m] [
   simp only [hb_zero, mul_zero, add_zero, ZMod.natCast_val, ZMod.cast_id] at this
   exact hba_unit.mul_right_cancel this
 
-private lemma orbitMap_j_eq {m : ℕ} {b : ℤ} {e₁ : ℕ} [NeZero e₁]
+private lemma orbitMap_j_eq [NeZero e₁]
     (hord : addOrderOf (b : ZMod m) = e₁)
     {j₁ j₂ : ZMod e₁}
     (hj_smul : (j₁.val : ℕ) • (b : ZMod m) = (j₂.val : ℕ) • (b : ZMod m)) :
@@ -121,10 +130,11 @@ private lemma orbitMap_j_eq {m : ℕ} {b : ℤ} {e₁ : ℕ} [NeZero e₁]
       (by grind [j₁.val_lt (n := e₁), j₂.val_lt (n := e₁)])
     exact ZMod.val_injective _ (by grind)
 
-private lemma orbitMap_injective {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero m]
+private lemma orbitMap_injective
     (hm_eq : m = d₁ * e₁) (hb_zero : (b : ZMod d₁) = 0)
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
-    (hord : addOrderOf (b : ZMod m) = e₁) : Function.Injective (orbitMap m a b d₁ e₁) := by
+    (hord : addOrderOf (b : ZMod m) = e₁) :
+    Function.Injective (orbitMap m a b : ZMod d₁ × ZMod e₁ → ZMod m) := by
   have hd1_dvd : d₁ ∣ m := hm_eq ▸ dvd_mul_right d₁ e₁
   haveI : NeZero d₁ := ⟨by rintro rfl; exact absurd (by simp [hm_eq]) (NeZero.ne m)⟩
   haveI : NeZero e₁ := ⟨by rintro rfl; exact absurd (by simp [hm_eq]) (NeZero.ne m)⟩
@@ -135,20 +145,22 @@ private lemma orbitMap_injective {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero
   have hj_smul : (j₁.val : ℕ) • (b : ZMod m) = (j₂.val : ℕ) • (b : ZMod m) := by grind
   exact Prod.ext rfl (orbitMap_j_eq hord hj_smul)
 
-private lemma orbitMap_bijective {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero m]
+private lemma orbitMap_bijective
     (hm_eq : m = d₁ * e₁) (hb_zero : (b : ZMod d₁) = 0)
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
-    (hord : addOrderOf (b : ZMod m) = e₁) : Function.Bijective (orbitMap m a b d₁ e₁) := by
+    (hord : addOrderOf (b : ZMod m) = e₁) :
+    Function.Bijective (orbitMap m a b : ZMod d₁ × ZMod e₁ → ZMod m) := by
   haveI : NeZero d₁ := ⟨by rintro rfl; exact absurd (by simp [hm_eq]) (NeZero.ne m)⟩
   haveI : NeZero e₁ := ⟨by rintro rfl; exact absurd (by simp [hm_eq]) (NeZero.ne m)⟩
   exact (Fintype.bijective_iff_injective_and_card _).mpr
     ⟨orbitMap_injective hm_eq hb_zero hba_unit hord,
      by simp [Fintype.card_prod, ZMod.card, hm_eq]⟩
 
-private lemma orbitMap_shift_b {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero e₁]
+omit [NeZero m] in
+private lemma orbitMap_shift_b [NeZero e₁]
     (he1_b_zero : e₁ • (b : ZMod m) = 0) :
     ∀ p : ZMod d₁ × ZMod e₁,
-      orbitMap m a b d₁ e₁ p + (b : ZMod m) = orbitMap m a b d₁ e₁ (p.1, p.2 + 1) := by
+      orbitMap m a b p + (b : ZMod m) = orbitMap m a b (p.1, p.2 + 1) := by
   intro ⟨i, j⟩
   simp only [orbitMap]
   by_cases hj : j.val + 1 < e₁
@@ -163,53 +175,53 @@ private lemma orbitMap_shift_b {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero e
       rw [this, hje, he1_b_zero]
     rw [hv, Nat.cast_zero, zero_mul, add_zero, add_assoc, h1, add_zero]
 
-private lemma orbitMap_shift_ba {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero d₁]
+omit [NeZero m] in
+private lemma orbitMap_shift_ba [NeZero d₁]
     (i : ZMod d₁) (j : ZMod e₁) (hi : i.val + 1 < d₁) :
-    orbitMap m a b d₁ e₁ (i, j) + ((b - a : ℤ) : ZMod m) = orbitMap m a b d₁ e₁ (i + 1, j) := by
+    orbitMap m a b (i, j) + ((b - a : ℤ) : ZMod m) = orbitMap m a b (i + 1, j) := by
   simp only [orbitMap]
   have : (i + 1).val = i.val + 1 := by rw [ZMod.val_add_one]; exact Nat.mod_eq_of_lt hi
   rw [this]
   grind
 
+omit [NeZero m] in
 /-- The cycle index α(x) = castHom(x) * u⁻¹ satisfies α(φ(i,j)) = i. -/
-private lemma orbitMap_cycle_index {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero m] [NeZero d₁]
+private lemma orbitMap_cycle_index [NeZero d₁]
     (hd1_dvd : d₁ ∣ m) (hb_zero : (b : ZMod d₁) = 0)
     (u : (ZMod d₁)ˣ) (hu : ↑u = ((b - a : ℤ) : ZMod d₁)) (i : ZMod d₁) (j : ZMod e₁) :
-    ZMod.castHom hd1_dvd (ZMod d₁) (orbitMap m a b d₁ e₁ (i, j)) * u⁻¹ = i := by
+    ZMod.castHom hd1_dvd (ZMod d₁) (orbitMap m a b (i, j)) * u⁻¹ = i := by
   simp only [orbitMap]
   rw [map_add, map_mul, map_mul, map_natCast, map_intCast,
     map_natCast, map_intCast, hb_zero, mul_zero, add_zero, mul_assoc, ← hu, u.mul_inv, mul_one]
   simp [ZMod.natCast_val]
 
+omit [NeZero m] in
 /-- The cycle index α shifts by 1 when (b-a) is added. -/
-private lemma cycle_index_shift_ba {m : ℕ} {a b : ℤ} {d₁ : ℕ} [NeZero m] [NeZero d₁]
+private lemma cycle_index_shift_ba [NeZero d₁]
     (hd1_dvd : d₁ ∣ m) (u : (ZMod d₁)ˣ) (hu : ↑u = ((b - a : ℤ) : ZMod d₁)) (x : ZMod m) :
     ZMod.castHom hd1_dvd (ZMod d₁) (x + ↑(b - a)) * u⁻¹ =
     ZMod.castHom hd1_dvd (ZMod d₁) x * u⁻¹ + 1 := by
   simp only [map_add, map_intCast, add_mul]
   rw [← hu]; ring_nf; rw [u.inv_mul]; ring
 
+omit [NeZero m] in
 /-- If Φ(i, j+1) = Φ(i, j) + b, then Φ⁻¹(x+b) = (same_i, j+1). -/
-private lemma equiv_symm_shift_b {d₁ e₁ : ℕ} {γ : Type*} [AddCommMonoid γ]
+private lemma equiv_symm_shift_b {γ : Type*} [AddCommMonoid γ]
     (Φ : ZMod d₁ × ZMod e₁ ≃ γ) {b : γ}
     (hΦ : ∀ i : ZMod d₁, ∀ j : ZMod e₁, Φ (i, j + 1) = Φ (i, j) + b) (x : γ) :
     Φ.symm (x + b) = ((Φ.symm x).1, (Φ.symm x).2 + 1) := by grind
 
+omit [NeZero m] in
 /-- If α(Φ(i,j)) = i for all i,j, then (Φ⁻¹(x)).1 = α(x). -/
-private lemma equiv_symm_fst_eq {d₁ e₁ : ℕ} {γ : Type*}
+private lemma equiv_symm_fst_eq {γ : Type*}
     (Φ : ZMod d₁ × ZMod e₁ ≃ γ) (α : γ → ZMod d₁)
     (hα : ∀ i : ZMod d₁, ∀ j : ZMod e₁, α (Φ (i, j)) = i) (x : γ) : (Φ.symm x).1 = α x := by grind
-
-/-! ### Orbit coloring framework -/
-
-section OrbitFramework
-variable {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero m]
 
 /-- Build the orbit equivalence from the standard hypotheses. -/
 private noncomputable def orbitEquiv (hm_eq : m = d₁ * e₁)
     (hb_zero : (b : ZMod d₁) = 0) (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
     (hord : addOrderOf (b : ZMod m) = e₁) : ZMod d₁ × ZMod e₁ ≃ ZMod m :=
-  Equiv.ofBijective (orbitMap m a b d₁ e₁) (orbitMap_bijective hm_eq hb_zero hba_unit hord)
+  Equiv.ofBijective (orbitMap m a b) (orbitMap_bijective hm_eq hb_zero hba_unit hord)
 
 private lemma orbitEquiv_shift_b {hm_eq : m = d₁ * e₁}
     {hb_zero : (b : ZMod d₁) = 0} {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
@@ -272,10 +284,9 @@ private lemma orbit_coloring_polychrom
   · grind
   · grind
 
-end OrbitFramework
-
 /-! ### Subcase (2a): e₁ even -/
 
+omit [NeZero m] in
 /-- **Subcase (2a).** $e_1$ is even. Each cycle uses two alternating colors;
     adjacent cycles skip different colors. The simplest of the four subcases. -/
 lemma case_two_e1_even (hm : m ≥ 289)
@@ -336,6 +347,7 @@ private lemma case2b_coverage_gen (d₁ e₁ : ℕ) [NeZero d₁] [NeZero e₁]
 
 /-! ### Subcase (2b) main lemma -/
 
+omit [NeZero m] in
 /-- **Subcase (2b).** $d_1$ is even and $e_1$ is odd.
     Alternating patterns with a "degenerate" position fixup at different positions
     for even and odd cycles, ensuring they do not overlap across adjacent cycles. -/
@@ -379,7 +391,7 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
   let π : ZMod m → ZMod d₂ := ZMod.castHom hd₂_dvd (ZMod d₂)
   have hπ_Φ : ∀ i : ZMod d₁, ∀ j : ZMod e₁, π (Φ (i, j)) = (j.val : ZMod d₂) * π (↑b) := by
     intro i j
-    change π (orbitMap m a b d₁ e₁ (i, j)) = _
+    change π (orbitMap m a b (i, j)) = _
     simp only [orbitMap, π, map_add, map_mul, map_natCast, map_intCast]
     rw [(ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mpr hd₂_dvd_ba]; ring
   -- π(b) is a unit in ZMod d₂
@@ -473,7 +485,7 @@ private def case2d_u (e₁ : ℕ) : ℕ := e₁ / 3 + e₁ % 3
     r=0: v = k   r=1: v = k+1   r=2: v = k -/
 private def case2d_v (e₁ : ℕ) : ℕ := if e₁ % 3 = 1 then e₁ / 3 + 1 else e₁ / 3
 
-private lemma case2d_uv_le {e₁ : ℕ} (hge : e₁ ≥ 19) : case2d_u e₁ + case2d_v e₁ ≤ e₁ := by
+private lemma case2d_uv_le (hge : e₁ ≥ 19) : case2d_u e₁ + case2d_v e₁ ≤ e₁ := by
   grind [case2d_u, case2d_v]
 
 /-- The base pattern: three alternating bicolor intervals on {0,...,e₁-1}.
@@ -576,7 +588,7 @@ private lemma basePattern_rotation_covers {e₁ j : ℕ} (he : Odd e₁) (hge : 
       simp_all [intervalColors, Finset.mem_insert, Finset.mem_singleton]
   grind
 
-private lemma case2d_wrap_shift {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero m] [NeZero d₁] [NeZero e₁]
+private lemma case2d_wrap_shift [NeZero d₁] [NeZero e₁]
     (hd1_dvd : d₁ ∣ m) (hb_zero : (b : ZMod d₁) = 0)
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) (hord : addOrderOf (b : ZMod m) = e₁)
     (hm_eq : m = d₁ * e₁) :
@@ -586,7 +598,7 @@ private lemma case2d_wrap_shift {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero 
   have hq_i : q.1 = 0 := by
     set f := ZMod.castHom hd1_dvd (ZMod d₁)
     have hfφ : f (Φ q) = q.1 * ((b - a : ℤ) : ZMod d₁) := by
-      change f (orbitMap m a b d₁ e₁ q) = _
+      change f (orbitMap m a b q) = _
       simp only [orbitMap, map_add, map_mul, map_natCast, map_intCast, hb_zero, mul_zero, add_zero]
       rw [ZMod.natCast_val, ZMod.cast_id]
     rw [Equiv.apply_symm_apply] at hfφ
@@ -596,18 +608,20 @@ private lemma case2d_wrap_shift {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero 
     exact hba_unit.mul_left_eq_zero.mp hfφ.symm
   refine ⟨q.2, ?_⟩
   have hφq := Equiv.apply_symm_apply Φ ((d₁ : ℕ) • ((b - a : ℤ) : ZMod m))
-  change orbitMap m a b d₁ e₁ q = _ at hφq
+  change orbitMap m a b q = _ at hφq
   simp only [orbitMap] at hφq
   rw [(Prod.eta q).symm] at hφq
   simp only [hq_i, ZMod.val_zero, Nat.cast_zero, zero_mul, zero_add] at hφq
   grind
 
-private lemma case2d_shift_ba_wrap {m : ℕ} {a b : ℤ} {d₁ e₁ : ℕ} [NeZero e₁] [NeZero d₁]
+omit [NeZero m] in
+private lemma case2d_shift_ba_wrap [NeZero e₁] [NeZero d₁]
     (he1_b_zero : e₁ • (b : ZMod m) = 0) (k₀ : ZMod e₁)
     (hk₀ : (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m))
     (i : ZMod d₁) (hi : i.val = d₁ - 1) :
     ∀ (j : ZMod e₁),
-      orbitMap m a b d₁ e₁ (i, j) + ((b - a : ℤ) : ZMod m) = orbitMap m a b d₁ e₁ (0, j + k₀) := by
+      orbitMap m a b (i, j) + ((b - a : ℤ) : ZMod m) =
+        orbitMap m a b ((0 : ZMod d₁), j + k₀) := by
   intro j
   simp only [orbitMap, ZMod.val_zero, Nat.cast_zero, zero_mul, zero_add]
   have hpred : (d₁ - 1 + 1 : ℕ) = d₁ := Nat.succ_pred (NeZero.ne d₁)
@@ -740,9 +754,10 @@ private lemma pos_shift_wrap' (j S V k₀ n : ℕ) (hsum : (S + V) % n = k₀ % 
     (j + k₀) % n = ((j + S % n) % n + V) % n := by
   rw [← Nat.add_mod_mod j k₀ n, ← hsum, pos_shift_succ']
 
+omit [NeZero m] in
 /-- **Subcase (2d) assembled.** Constructs the coloring for the case when both d₁
     and e₁ are odd with e₁ ≥ 19, using rotated interval patterns. -/
-private lemma case2d_coloring_works {m : ℕ} {a b : ℤ} (hm : m ≥ 289)
+private lemma case2d_coloring_works (hm : m ≥ 289)
     (h_gcd_coprime : (Nat.gcd b.natAbs m).gcd (Nat.gcd (b - a).natAbs m) = 1)
     (h_min : min (Nat.gcd b.natAbs m) (Nat.gcd (b - a).natAbs m) > 1)
     (hd1_odd : Odd (Nat.gcd b.natAbs m)) (he1_odd : Odd (m / Nat.gcd b.natAbs m))
@@ -833,9 +848,10 @@ private lemma case2d_coloring_works {m : ℕ} {a b : ℤ} (hm : m ≥ 289)
         (by rw [zmod_filter_sum_last vals i hi_eq, hvals_sum])
 
 -- Mod 3 arithmetic: (a % e₁ + b) % 3 = (a + b) % 3 when 3 ∣ e₁
-private lemma case2c_mod3 {e₁ : ℕ} (h3e : 3 ∣ e₁) (x y : ℕ) : (x % e₁ + y) % 3 = (x + y) % 3 := by
+private lemma case2c_mod3 (h3e : 3 ∣ e₁) (x y : ℕ) : (x % e₁ + y) % 3 = (x + y) % 3 := by
   rw [Nat.add_mod, Nat.mod_mod_of_dvd x h3e, ← Nat.add_mod]
 
+omit [NeZero m] in
 /-- **Subcase (2c):** d₁ and e₁ are both odd, with e₁ ≤ 17 and 3 ∣ e₁.
     Uses shifted periodic 012-patterns with different shifts for adjacent cycles. -/
 lemma case_two_odd_small (hm : m ≥ 289)
@@ -957,6 +973,7 @@ private lemma no_both_e_small {m d₁ d₂ : ℕ} (hm : m ≥ 289) (hcop : Nat.g
 
 /-! ### Aggregation of Case 2 -/
 
+omit [NeZero m] in
 /-- **Main Case 2 (Multiple Cycles).** Aggregates all subcases (2a)–(2d).
     First applies WLOG to ensure 3 ∤ d₁, then dispatches on parity of d₁ and e₁. -/
 lemma main_case_two (hm : m ≥ 289)
@@ -964,9 +981,9 @@ lemma main_case_two (hm : m ≥ 289)
     (h_min : min (Nat.gcd b.natAbs m) (Nat.gcd (b - a).natAbs m) > 1) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   rcases Nat.even_or_odd (m / Nat.gcd b.natAbs m) with he | ho
-  · exact case_two_e1_even m a b hm h_gcd_coprime h_min he
+  · exact case_two_e1_even hm h_gcd_coprime h_min he
   · rcases Nat.even_or_odd (Nat.gcd b.natAbs m) with hd | hd
-    · exact case_two_d1_even_e1_odd m a b hm h_gcd_coprime h_min hd ho
+    · exact case_two_d1_even_e1_odd hm h_gcd_coprime h_min hd ho
     · -- Both d₁ and e₁ odd.
       -- Paper: "Choose the smallest of d₁,d₂ not a multiple of 3, WLOG d₁."
       -- Swap if 3 ∣ d₁, then dispatch with 3 ∤ d₁.
@@ -988,9 +1005,9 @@ lemma main_case_two (hm : m ≥ 289)
             intro h3d'; have := Nat.dvd_gcd h3 h3d'
             grind
           rcases Nat.even_or_odd (m / Nat.gcd b'.natAbs m) with he' | ho'
-          · exact case_two_e1_even m a' b' hm hcop' hmin' he'
+          · exact case_two_e1_even hm hcop' hmin' he'
           · rcases Nat.even_or_odd (Nat.gcd b'.natAbs m) with hd' | hd'
-            · exact case_two_d1_even_e1_odd m a' b' hm hcop' hmin' hd' ho'
+            · exact case_two_d1_even_e1_odd hm hcop' hmin' hd' ho'
             · exact dispatch a' b' hcop' hmin' hd' ho' h3'
         · exact dispatch a b h_gcd_coprime h_min hd ho h3
       -- Prove dispatch: given ¬(3 ∣ d₁), split on e₁ size
@@ -1009,7 +1026,7 @@ lemma main_case_two (hm : m ≥ 289)
           have h3e₁ : 3 ∣ e₁ :=
             ((Nat.Prime.coprime_iff_not_dvd (by decide)).mpr h3_nd₁).dvd_of_dvd_mul_left
               (Nat.mul_div_cancel' hd₁_dvd ▸ h3m)
-          exact case_two_odd_small m a' b' hm hcop hmin hd₁_odd he₁_odd he_le h3e₁
+          exact case_two_odd_small hm hcop hmin hd₁_odd he₁_odd he_le h3e₁
         · -- 3 ∤ d₁ and 3 ∤ d₂ and e₁ ≤ 17: swap and show new e₁ ≥ 19.
           -- After swap, new e₁' = m/d₂. If e₁' ≤ 17 too, contradiction.
           rw [← zmod_set_swap m a' b']
@@ -1019,9 +1036,9 @@ lemma main_case_two (hm : m ≥ 289)
           have hmin' : min (Nat.gcd b''.natAbs m) (Nat.gcd (b'' - a'').natAbs m) > 1 := by grind
           -- Dispatch on parity
           rcases Nat.even_or_odd (m / Nat.gcd b''.natAbs m) with he' | ho'
-          · exact case_two_e1_even m a'' b'' hm hcop' hmin' he'
+          · exact case_two_e1_even hm hcop' hmin' he'
           · rcases Nat.even_or_odd (Nat.gcd b''.natAbs m) with hd' | hd'
-            · exact case_two_d1_even_e1_odd m a'' b'' hm hcop' hmin' hd' ho'
+            · exact case_two_d1_even_e1_odd hm hcop' hmin' hd' ho'
             · -- Both odd after swap. Show e₁' ≥ 19 by contradiction.
               have he₁'_ge : m / Nat.gcd b''.natAbs m ≥ 19 := by
                 by_contra hlt; push_neg at hlt
@@ -1030,5 +1047,7 @@ lemma main_case_two (hm : m ≥ 289)
               exact case2d_coloring_works hm hcop' hmin' hd' ho' he₁'_ge h3d₂
       · have he₁_ge : e₁ ≥ 19 := by grind
         exact case2d_coloring_works hm hcop hmin hd₁_odd he₁_odd he₁_ge h3_nd₁
+
+end OrbitFramework
 
 end Case2_MultipleCycles

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -85,21 +85,19 @@ It provides the coordinate system used to analyze the "Multiple Cycles" case.
 private def orbitMap (m : ℕ) (a b : ℤ) : ZMod d₁ × ZMod e₁ → ZMod m :=
   fun p => (p.1.val : ZMod m) * ↑(b - a) + (p.2.val : ZMod m) * ↑b
 
-private lemma addOrderOf_b_eq (hm : 0 < m)
-    (hd1_def : Nat.gcd b.natAbs m = d₁) :
-    addOrderOf (b : ZMod m) = m / d₁ := by
-  have key : addOrderOf (b.natAbs : ZMod m) = m / d₁ := by
-    rw [ZMod.addOrderOf_coe b.natAbs (by grind), Nat.gcd_comm, hd1_def]
+private lemma addOrderOf_b_eq (hm : 0 < m) :
+    addOrderOf (b : ZMod m) = e₁ := by
+  have key : addOrderOf (b.natAbs : ZMod m) = e₁ := by
+    rw [ZMod.addOrderOf_coe b.natAbs (by grind), Nat.gcd_comm]
   rcases Int.natAbs_eq b with h | h
   · have : (b : ZMod m) = (b.natAbs : ZMod m) := by rw [h]; simp
     grind
   · have : (b : ZMod m) = -(b.natAbs : ZMod m) := by rw [h]; simp
     rw [this, addOrderOf_neg]; exact key
 
-private lemma b_zero_mod_d1
-    (hd1_def : Nat.gcd b.natAbs m = d₁) [NeZero d₁] : (b : ZMod d₁) = 0 := by
+private lemma b_zero_mod_d1 [NeZero d₁] : (b : ZMod d₁) = 0 := by
   rw [ZMod.intCast_zmod_eq_zero_iff_dvd]
-  exact Int.natCast_dvd.mpr (hd1_def ▸ Nat.gcd_dvd_left b.natAbs m)
+  exact Int.natCast_dvd.mpr (Nat.gcd_dvd_left b.natAbs m)
 
 private lemma ba_coprime_d1
     (h_gcd_coprime : Nat.gcd d₁ (Nat.gcd (b - a).natAbs m) = 1) :
@@ -301,9 +299,9 @@ private lemma orbit_coloring_polychrom
 /-- **Subcase (2a).** $e_1$ is even. Each cycle uses two alternating colors;
     adjacent cycles skip different colors. The simplest of the four subcases. -/
 lemma case_two_e1_even (hm : m ≥ 289)
-    (h_gcd_coprime : (Nat.gcd b.natAbs m).gcd (Nat.gcd (b - a).natAbs m) = 1)
-    (h_min : min (Nat.gcd b.natAbs m) (Nat.gcd (b - a).natAbs m) > 1)
-    (he1_even : Even (m / Nat.gcd b.natAbs m)) :
+    (h_gcd_coprime : Nat.gcd d₁ (Nat.gcd (b - a).natAbs m) = 1)
+    (h_min : min d₁ (Nat.gcd (b - a).natAbs m) > 1)
+    (he1_even : Even e₁) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   have he₁_ge2 : e₁ ≥ 2 := by
@@ -312,9 +310,9 @@ lemma case_two_e1_even (hm : m ≥ 289)
   haveI : NeZero m := ⟨by grind⟩
   haveI : NeZero d₁ := ⟨by grind⟩
   haveI : NeZero e₁ := ⟨by grind⟩
-  have hb_zero : (Int.cast b : ZMod d₁) = 0 := b_zero_mod_d1 rfl
+  have hb_zero : (Int.cast b : ZMod d₁) = 0 := b_zero_mod_d1
   have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
-  have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind) rfl
+  have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind)
   let Φ := orbitEquiv hm_eq hb_zero hba_unit hord
   have hd₁_ge2 : d₁ ≥ 2 := by grind
   have he₁_ge2 : e₁ ≥ 2 := by
@@ -360,9 +358,9 @@ private lemma case2b_coverage_gen (d e : ℕ) [NeZero d] [NeZero e]
     Alternating patterns with a "degenerate" position fixup at different positions
     for even and odd cycles, ensuring they do not overlap across adjacent cycles. -/
 lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
-    (h_gcd_coprime : (Nat.gcd b.natAbs m).gcd (Nat.gcd (b - a).natAbs m) = 1)
-    (h_min : min (Nat.gcd b.natAbs m) (Nat.gcd (b - a).natAbs m) > 1)
-    (hd1_even : Even (Nat.gcd b.natAbs m)) (he1_odd : Odd (m / Nat.gcd b.natAbs m)) :
+    (h_gcd_coprime : Nat.gcd d₁ (Nat.gcd (b - a).natAbs m) = 1)
+    (h_min : min d₁ (Nat.gcd (b - a).natAbs m) > 1)
+    (hd1_even : Even d₁) (he1_odd : Odd e₁) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   -- e₁ ≥ 3: e₁ is odd and e₁ = 1 would give d₁ = m, contradicting gcd(d₁,d₂) = 1
@@ -378,10 +376,10 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
   haveI : NeZero m := ⟨by grind⟩
   haveI : NeZero d₁ := ⟨by grind⟩
   haveI : NeZero e₁ := ⟨by grind⟩
-  have hb_zero : (Int.cast b : ZMod d₁) = 0 := b_zero_mod_d1 rfl
+  have hb_zero : (Int.cast b : ZMod d₁) = 0 := b_zero_mod_d1
   have hba_unit : IsUnit (Int.cast (b - a) : ZMod d₁) :=
     isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
-  have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind) rfl
+  have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind)
   let Φ := orbitEquiv hm_eq hb_zero hba_unit hord
   -- d₂ properties for the compatibility argument
   set d₂ := Nat.gcd (b - a).natAbs m
@@ -782,17 +780,17 @@ private lemma pos_shift_wrap' (j S V k₀ n : ℕ) (hsum : (S + V) % n = k₀ % 
 /-- **Subcase (2d) assembled.** Constructs the coloring for the case when both d₁
     and e₁ are odd with e₁ ≥ 19, using rotated interval patterns. -/
 private lemma case2d_coloring_works (hm : m ≥ 289)
-    (h_gcd_coprime : (Nat.gcd b.natAbs m).gcd (Nat.gcd (b - a).natAbs m) = 1)
-    (h_min : min (Nat.gcd b.natAbs m) (Nat.gcd (b - a).natAbs m) > 1)
-    (hd1_odd : Odd (Nat.gcd b.natAbs m)) (he1_odd : Odd (m / Nat.gcd b.natAbs m))
-    (he1_ge : m / Nat.gcd b.natAbs m ≥ 19) (h3 : ¬ (3 ∣ Nat.gcd b.natAbs m)) :
+    (h_gcd_coprime : Nat.gcd d₁ (Nat.gcd (b - a).natAbs m) = 1)
+    (h_min : min d₁ (Nat.gcd (b - a).natAbs m) > 1)
+    (hd1_odd : Odd d₁) (he1_odd : Odd e₁)
+    (he1_ge : e₁ ≥ 19) (h3 : ¬ (3 ∣ d₁)) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   haveI : NeZero m := ⟨by grind⟩
   haveI : NeZero d₁ := ⟨by grind⟩
   haveI : NeZero e₁ := ⟨by grind⟩
-  have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind) rfl
-  have hb_zero : (b : ZMod d₁) = 0 := b_zero_mod_d1 rfl
+  have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind)
+  have hb_zero : (b : ZMod d₁) = 0 := b_zero_mod_d1
   have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   have he1_b_zero : e₁ • (b : ZMod m) = 0 := hord ▸ addOrderOf_nsmul_eq_zero _
   let Φ := orbitEquiv hm_eq hb_zero hba_unit hord
@@ -851,17 +849,17 @@ private lemma case2c_mod3 (h3e : 3 ∣ e₁) (x y : ℕ) : (x % e₁ + y) % 3 = 
 /-- **Subcase (2c):** d₁ and e₁ are both odd, with e₁ ≤ 17 and 3 ∣ e₁.
     Uses shifted periodic 012-patterns with different shifts for adjacent cycles. -/
 lemma case_two_odd_small (hm : m ≥ 289)
-    (h_gcd_coprime : (Nat.gcd b.natAbs m).gcd (Nat.gcd (b - a).natAbs m) = 1)
-    (h_min : min (Nat.gcd b.natAbs m) (Nat.gcd (b - a).natAbs m) > 1)
-    (hd1_odd : Odd (Nat.gcd b.natAbs m))
-    (he1_div3 : 3 ∣ m / Nat.gcd b.natAbs m) :
+    (h_gcd_coprime : Nat.gcd d₁ (Nat.gcd (b - a).natAbs m) = 1)
+    (h_min : min d₁ (Nat.gcd (b - a).natAbs m) > 1)
+    (hd1_odd : Odd d₁)
+    (he1_div3 : 3 ∣ e₁) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   haveI : NeZero m := ⟨by grind⟩
   haveI : NeZero d₁ := ⟨by grind⟩
   haveI : NeZero e₁ := ⟨by grind⟩
-  have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind) rfl
-  have hb_zero : (b : ZMod d₁) = 0 := b_zero_mod_d1 rfl
+  have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind)
+  have hb_zero : (b : ZMod d₁) = 0 := b_zero_mod_d1
   have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   have he1_b_zero : e₁ • (b : ZMod m) = 0 := hord ▸ addOrderOf_nsmul_eq_zero _
   let Φ := orbitEquiv hm_eq hb_zero hba_unit hord
@@ -936,12 +934,12 @@ private lemma no_both_e_small {m' d d' : ℕ} (hm : m' ≥ 289) (hcop : Nat.gcd 
 /-- **Main Case 2 (Multiple Cycles).** Aggregates all subcases (2a)–(2d).
     First applies WLOG to ensure 3 ∤ d₁, then dispatches on parity of d₁ and e₁. -/
 lemma main_case_two (hm : m ≥ 289)
-    (h_gcd_coprime : (Nat.gcd b.natAbs m).gcd (Nat.gcd (b - a).natAbs m) = 1)
-    (h_min : min (Nat.gcd b.natAbs m) (Nat.gcd (b - a).natAbs m) > 1) :
+    (h_gcd_coprime : Nat.gcd d₁ (Nat.gcd (b - a).natAbs m) = 1)
+    (h_min : min d₁ (Nat.gcd (b - a).natAbs m) > 1) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
-  rcases Nat.even_or_odd (m / Nat.gcd b.natAbs m) with he | ho
+  rcases Nat.even_or_odd e₁ with he | ho
   · exact case_two_e1_even hm h_gcd_coprime h_min he
-  · rcases Nat.even_or_odd (Nat.gcd b.natAbs m) with hd | hd
+  · rcases Nat.even_or_odd d₁ with hd | hd
     · exact case_two_d1_even_e1_odd hm h_gcd_coprime h_min hd ho
     · -- Both d₁ and e₁ odd.
       -- Paper: "Choose the smallest of d₁,d₂ not a multiple of 3, WLOG d₁."
@@ -953,7 +951,7 @@ lemma main_case_two (hm : m ≥ 289)
           Odd (m / Nat.gcd b'.natAbs m) →
           ¬ (3 ∣ Nat.gcd b'.natAbs m) →
           HasPolychromColouring (Fin 3) (zmod_set m a' b') by
-        by_cases h3 : 3 ∣ Nat.gcd b.natAbs m
+        by_cases h3 : 3 ∣ d₁
         · -- Swap roles of b and b-a
           rw [← zmod_set_swap m a b]
           set a' := (-a : ℤ); set b' := (b - a : ℤ)

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -100,8 +100,7 @@ private lemma addOrderOf_b_eq [NeZero m] : addOrderOf (b : ZMod m) = e₁ := by
   · have : (b : ZMod m) = (b.natAbs : ZMod m) := by rw [h]; simp
     grind
   · have : (b : ZMod m) = -(b.natAbs : ZMod m) := by rw [h]; simp
-    rw [this, addOrderOf_neg]
-    exact key
+    rwa [this, addOrderOf_neg]
 
 private lemma d₁_dvd_b : (d₁ : ℤ) ∣ b :=
   Int.natCast_dvd.mpr (Nat.gcd_dvd_left b.natAbs m)
@@ -224,8 +223,7 @@ private lemma orbitEquiv_cycle_shift [NeZero m] {hba_unit : IsUnit ((b - a : ℤ
   let u_ba := hba_unit.choose
   have hu_ba : ↑u_ba = ((b - a : ℤ) : ZMod d₁) := hba_unit.choose_spec
   let α : ZMod m → ZMod d₁ := fun x => ZMod.castHom d₁_dvd_m (ZMod d₁) x * u_ba⁻¹
-  have hΦ_cycle := equiv_symm_fst_eq (orbitEquiv hba_unit) α
-    (orbitMap_cycle_index u_ba hu_ba)
+  have hΦ_cycle := equiv_symm_fst_eq (orbitEquiv hba_unit) α (orbitMap_cycle_index u_ba hu_ba)
   rw [hΦ_cycle (x + ↑(b - a))]
   dsimp only [α]
   rw [cycle_index_shift_ba u_ba hu_ba]
@@ -946,7 +944,7 @@ lemma main_case_two (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
             · exact case_two_d1_even_e1_odd hm hcop' hmin' hd' ho'
             · -- Both odd after swap. Show e₁' ≥ 19 by contradiction.
               have he₁'_ge : m / Nat.gcd b''.natAbs m ≥ 19 := by
-                by_contra hlt; push_neg at hlt
+                by_contra! hlt
                 rw [Nat.gcd_comm] at hcop
                 exact no_both_e_small hm hcop (by grind) (by grind) hd₂_dvd hd_dvd (by grind) he_le
               exact case2d_coloring_works hm hcop' hmin' hd' ho' he₁'_ge h3d₂

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -356,8 +356,7 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d�
   -- d₂ properties for the compatibility argument
   have hd₂_dvd : d₂ ∣ m := Nat.gcd_dvd_right _ _
   have hd₂_gt1 : d₂ > 1 := by grind
-  have hd₂_dvd_ba : (d₂ : ℤ) ∣ (b - a) := by
-    simpa [Int.gcd] using Int.gcd_dvd_left (b - a) (m : ℤ)
+  have hd₂_dvd_ba : (d₂ : ℤ) ∣ (b - a) := by simpa [Int.gcd] using Int.gcd_dvd_left (b - a) (m : ℤ)
   have hd₂_dvd_e₁ : d₂ ∣ e₁ := by
     exact (by rwa [Nat.Coprime, Nat.gcd_comm] : Nat.Coprime d₂ d₁).dvd_of_dvd_mul_right
       (mul_comm d₁ e₁ ▸ hm_eq ▸ hd₂_dvd)
@@ -697,18 +696,6 @@ private lemma case2d_rotation_sum_exists {e d : ℕ} [NeZero d]
     rw [Nat.add_sub_cancel' (le_add_left (le_trans (Nat.mul_le_mul_left d (le_of_lt hu_lt))
       (by rw [Nat.mul_comm]))), Nat.add_mul_mod_self_left]
 
-private lemma zero_mem_zmod_set (m : ℕ) (a b : ℤ) : (0 : ZMod m) ∈ zmod_set m a b := by
-  simp [zmod_set]
-
-private lemma intCast_b_mem_zmod_set (m : ℕ) (a b : ℤ) : ((b : ℤ) : ZMod m) ∈ zmod_set m a b := by
-  simp [zmod_set]
-
-private lemma intCast_ba_mem_zmod_set (m : ℕ) (a b : ℤ) :
-    ((b - a : ℤ) : ZMod m) ∈ zmod_set m a b := by simp [zmod_set]
-
-private lemma intCast_2ba_mem_zmod_set (m : ℕ) (a b : ℤ) :
-    ((2 * b - a : ℤ) : ZMod m) ∈ zmod_set m a b := by simp [zmod_set]
-
 /-- Splitting a ZMod filter sum at a boundary -/
 private lemma zmod_filter_sum_succ {n : ℕ} [NeZero n] (f : ZMod n → ℕ) (i : ZMod n) :
     (Finset.univ.filter (fun k : ZMod n => k.val < i.val + 1)).sum f =
@@ -797,10 +784,8 @@ private lemma case2d_coloring_works (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d�
       have hj'_eq : j' = j + k₀ :=
         orbitEquiv_snd_shift_ba_wrap he1_b_zero k₀ hk₀ n hi_eq
       rw [hj'_eq]
-      have hi1_zero : (i + 1 : ZMod d₁) = 0 := by
-        apply ZMod.val_injective
-        rw [ZMod.val_add_one, hi_eq, ZMod.val_zero]
-        grind [Nat.mod_self]
+      have hi1_zero : (i + 1 : ZMod d₁) = 0 :=
+        ZMod.val_injective _ (by rw [ZMod.val_add_one, hi_eq, ZMod.val_zero]; grind [Nat.mod_self])
       have hrot0 : rot (0 : ZMod d₁) = 0 := by simp [rot, ZMod.val_zero]
       rw [hi1_zero, hrot0, Nat.add_zero, ZMod.val_add, Nat.mod_mod_of_dvd _ (dvd_refl e₁)]
       exact pos_shift_wrap' j.val _ (vals i) k₀.val e₁
@@ -833,8 +818,7 @@ lemma case_two_odd_small (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1
     · have hj'_eq : j' = j := orbitEquiv_snd_shift_ba n hi
       rw [hj'_eq]
       set p' := case2c_pattern d₁ k₀.val (i + 1).val
-      have hi'_eq : (i + 1).val = i.val + 1 := by
-        rw [ZMod.val_add_one]; exact Nat.mod_eq_of_lt hi
+      have hi'_eq : (i + 1).val = i.val + 1 := by rw [ZMod.val_add_one]; exact Nat.mod_eq_of_lt hi
       have hhyp : (j.val + p.val) % 3 ≠ (j.val + p'.val) % 3 := by
         change (j.val + (case2c_pattern d₁ k₀.val i.val).val) % 3 ≠
           (j.val + (case2c_pattern d₁ k₀.val (i + 1).val).val) % 3

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -74,6 +74,12 @@ private lemma color_covers_even (d e : ℕ) [NeZero d] [NeZero e] (hd_ge2 : d �
 private lemma d₁_dvd_m : d₁ ∣ m := Nat.gcd_dvd_right _ _
 private lemma m_eq_d₁_mul_e₁ : m = d₁ * e₁ := (Nat.mul_div_cancel' (d₁_dvd_m (b := b))).symm
 
+instance neZero_d₁ [NeZero m] : NeZero d₁ :=
+  ⟨fun h => absurd (by rw [m_eq_d₁_mul_e₁ (m := m) (b := b), h, zero_mul]) (NeZero.ne m)⟩
+
+instance neZero_e₁ [NeZero m] : NeZero e₁ :=
+  ⟨fun h => absurd (by rw [m_eq_d₁_mul_e₁ (m := m) (b := b), h, mul_zero]) (NeZero.ne m)⟩
+
 /-! ### Orbit coloring framework -/
 
 section OrbitFramework
@@ -99,7 +105,7 @@ private lemma addOrderOf_b_eq [NeZero m] :
 private lemma d₁_dvd_b : (d₁ : ℤ) ∣ b :=
   Int.natCast_dvd.mpr (Nat.gcd_dvd_left b.natAbs m)
 
-private lemma b_zero_mod_d1 [NeZero d₁] : (b : ZMod d₁) = 0 :=
+private lemma b_zero_mod_d1 [NeZero m] : (b : ZMod d₁) = 0 :=
   (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mpr (d₁_dvd_b (b := b))
 
 private lemma ba_coprime_d1
@@ -108,7 +114,7 @@ private lemma ba_coprime_d1
   Nat.dvd_one.mp (h_gcd_coprime ▸ Nat.dvd_gcd (Nat.gcd_dvd_right _ _)
       (Nat.dvd_gcd (Nat.gcd_dvd_left _ _) (dvd_trans (Nat.gcd_dvd_right _ _) d₁_dvd_m)))
 
-private lemma orbitMap_i_eq [NeZero d₁]
+private lemma orbitMap_i_eq [NeZero m]
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) {i₁ i₂ : ZMod d₁} {j₁ j₂ : ZMod e₁}
     (heq : orbitMap m a b (i₁, j₁) = orbitMap m a b (i₂, j₂)) :
     i₁ = i₂ := by
@@ -118,7 +124,7 @@ private lemma orbitMap_i_eq [NeZero d₁]
   simp only [b_zero_mod_d1, mul_zero, add_zero, ZMod.natCast_val, ZMod.cast_id] at this
   exact hba_unit.mul_right_cancel this
 
-private lemma orbitMap_j_eq [NeZero m] [NeZero e₁]
+private lemma orbitMap_j_eq [NeZero m]
     {j₁ j₂ : ZMod e₁}
     (hj_smul : (j₁.val : ℕ) • (b : ZMod m) = (j₂.val : ℕ) • (b : ZMod m)) :
     j₁ = j₂ := by
@@ -136,8 +142,6 @@ private lemma orbitMap_injective [NeZero m]
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) :
     Function.Injective (orbitMap m a b : ZMod d₁ × ZMod e₁ → ZMod m) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
-  haveI : NeZero d₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, zero_mul]) (NeZero.ne m)⟩
-  haveI : NeZero e₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, mul_zero]) (NeZero.ne m)⟩
   intro ⟨i₁, j₁⟩ ⟨i₂, j₂⟩ heq
   have hi := orbitMap_i_eq hba_unit heq
   subst hi
@@ -149,13 +153,11 @@ private lemma orbitMap_bijective [NeZero m]
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) :
     Function.Bijective (orbitMap m a b : ZMod d₁ × ZMod e₁ → ZMod m) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
-  haveI : NeZero d₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, zero_mul]) (NeZero.ne m)⟩
-  haveI : NeZero e₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, mul_zero]) (NeZero.ne m)⟩
   exact (Fintype.bijective_iff_injective_and_card _).mpr
     ⟨orbitMap_injective hba_unit,
      by simp only [Fintype.card_prod, ZMod.card]; linarith [hm_eq]⟩
 
-private lemma orbitMap_shift_b [NeZero e₁]
+private lemma orbitMap_shift_b [NeZero m]
     (he1_b_zero : e₁ • (b : ZMod m) = 0) :
     ∀ p : ZMod d₁ × ZMod e₁,
       orbitMap m a b p + (b : ZMod m) = orbitMap m a b (p.1, p.2 + 1) := by
@@ -173,7 +175,7 @@ private lemma orbitMap_shift_b [NeZero e₁]
       rw [this, hje, he1_b_zero]
     rw [hv, Nat.cast_zero, zero_mul, add_zero, add_assoc, h1, add_zero]
 
-private lemma orbitMap_shift_ba [NeZero d₁]
+private lemma orbitMap_shift_ba [NeZero m]
     (i : ZMod d₁) (j : ZMod e₁) (hi : i.val + 1 < d₁) :
     orbitMap m a b (i, j) + ((b - a : ℤ) : ZMod m) = orbitMap m a b (i + 1, j) := by
   simp only [orbitMap]
@@ -182,7 +184,7 @@ private lemma orbitMap_shift_ba [NeZero d₁]
   grind
 
 /-- The cycle index α(x) = castHom(x) * u⁻¹ satisfies α(φ(i,j)) = i. -/
-private lemma orbitMap_cycle_index [NeZero d₁]
+private lemma orbitMap_cycle_index [NeZero m]
     (u : (ZMod d₁)ˣ) (hu : ↑u = ((b - a : ℤ) : ZMod d₁)) (i : ZMod d₁) (j : ZMod e₁) :
     ZMod.castHom d₁_dvd_m (ZMod d₁) (orbitMap m a b (i, j)) * u⁻¹ = i := by
   simp only [orbitMap]
@@ -191,7 +193,7 @@ private lemma orbitMap_cycle_index [NeZero d₁]
   simp [ZMod.natCast_val]
 
 /-- The cycle index α shifts by 1 when (b-a) is added. -/
-private lemma cycle_index_shift_ba [NeZero d₁]
+private lemma cycle_index_shift_ba [NeZero m]
     (u : (ZMod d₁)ˣ) (hu : ↑u = ((b - a : ℤ) : ZMod d₁)) (x : ZMod m) :
     ZMod.castHom d₁_dvd_m (ZMod d₁) (x + ↑(b - a)) * u⁻¹ =
     ZMod.castHom d₁_dvd_m (ZMod d₁) x * u⁻¹ + 1 := by
@@ -220,7 +222,6 @@ private lemma orbitEquiv_shift_b [NeZero m]
     (((orbitEquiv hba_unit).symm x).1,
      ((orbitEquiv hba_unit).symm x).2 + 1) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
-  haveI : NeZero e₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, mul_zero]) (NeZero.ne m)⟩
   exact equiv_symm_shift_b _ (fun i j =>
     (orbitMap_shift_b (addOrderOf_b_eq (b := b) (m := m) ▸
       addOrderOf_nsmul_eq_zero _) (i, j)).symm) x
@@ -230,7 +231,6 @@ private lemma orbitEquiv_cycle_shift [NeZero m]
     ((orbitEquiv hba_unit).symm (x + ↑(b - a))).1 =
     ((orbitEquiv hba_unit).symm x).1 + 1 := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
-  haveI : NeZero d₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, zero_mul]) (NeZero.ne m)⟩
   let u_ba := hba_unit.choose
   have hu_ba : ↑u_ba = ((b - a : ℤ) : ZMod d₁) := hba_unit.choose_spec
   let α : ZMod m → ZMod d₁ := fun x => ZMod.castHom d₁_dvd_m (ZMod d₁) x * u_ba⁻¹
@@ -243,7 +243,7 @@ private lemma orbitEquiv_cycle_shift [NeZero m]
   exact (hΦ_cycle x).symm
 
 /-- In the non-wrap case, the second coordinate is preserved by the (b-a) shift. -/
-private lemma orbitEquiv_snd_shift_ba [NeZero m] [NeZero d₁]
+private lemma orbitEquiv_snd_shift_ba [NeZero m]
     {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
     (n : ZMod m) (hi : (orbitEquiv hba_unit).symm n |>.1.val + 1 < d₁) :
     ((orbitEquiv hba_unit).symm (n + ↑(b - a))).2 =
@@ -302,8 +302,6 @@ lemma case_two_e1_even (hm : m ≥ 289)
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   haveI : NeZero m := ⟨by grind⟩
-  haveI : NeZero d₁ := ⟨by grind⟩
-  haveI : NeZero e₁ := ⟨by grind⟩
   have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   exact orbit_coloring_polychrom (orbitEquiv hba_unit) orbitEquiv_shift_b
     orbitEquiv_cycle_shift (cycle_coloring d₁ e₁)
@@ -361,8 +359,6 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
         (h_gcd_coprime ▸ Nat.dvd_gcd this (dvd_refl _))) (by grind)
     · grind
   haveI : NeZero m := ⟨by grind⟩
-  haveI : NeZero d₁ := ⟨by grind⟩
-  haveI : NeZero e₁ := ⟨by grind⟩
   have hb_zero : (Int.cast b : ZMod d₁) = 0 := b_zero_mod_d1
   have hba_unit : IsUnit (Int.cast (b - a) : ZMod d₁) :=
     isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
@@ -577,7 +573,7 @@ private lemma basePattern_rotation_covers {e j : ℕ} (he : Odd e) (hge : e ≥ 
       simp_all [intervalColors, Finset.mem_insert, Finset.mem_singleton]
   grind
 
-private lemma case2d_wrap_shift [NeZero m] [NeZero d₁] [NeZero e₁]
+private lemma case2d_wrap_shift [NeZero m]
     (hb_zero : (b : ZMod d₁) = 0)
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) :
     ∃ k₀ : ZMod e₁, (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m) := by
@@ -602,7 +598,7 @@ private lemma case2d_wrap_shift [NeZero m] [NeZero d₁] [NeZero e₁]
   simp only [hq_i, ZMod.val_zero, Nat.cast_zero, zero_mul, zero_add] at hφq
   grind
 
-private lemma case2d_shift_ba_wrap [NeZero e₁] [NeZero d₁]
+private lemma case2d_shift_ba_wrap [NeZero m]
     (he1_b_zero : e₁ • (b : ZMod m) = 0) (k₀ : ZMod e₁)
     (hk₀ : (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m))
     (i : ZMod d₁) (hi : i.val = d₁ - 1) :
@@ -628,7 +624,7 @@ private lemma case2d_shift_ba_wrap [NeZero e₁] [NeZero d₁]
   rw [add_nsmul, mul_nsmul, he1_b_zero, smul_zero, zero_add, nsmul_eq_mul]
 
 /-- In the wrap case, the second coordinate shifts by k₀. -/
-private lemma orbitEquiv_snd_shift_ba_wrap [NeZero m] [NeZero d₁] [NeZero e₁]
+private lemma orbitEquiv_snd_shift_ba_wrap [NeZero m]
     {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
     (he1_b_zero : e₁ • (b : ZMod m) = 0) (k₀ : ZMod e₁)
     (hk₀ : (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m))
@@ -769,8 +765,6 @@ private lemma case2d_coloring_works (hm : m ≥ 289)
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   haveI : NeZero m := ⟨by grind⟩
-  haveI : NeZero d₁ := ⟨by grind⟩
-  haveI : NeZero e₁ := ⟨by grind⟩
   have hb_zero : (b : ZMod d₁) = 0 := b_zero_mod_d1
   have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   have he1_b_zero : e₁ • (b : ZMod m) = 0 :=
@@ -809,8 +803,8 @@ private lemma case2d_coloring_works (hm : m ≥ 289)
         (fun k : ZMod d₁ => k.val < (i + 1).val)).sum vals) % e₁) % e₁ =
         ((j.val + ((Finset.univ.filter
         (fun k : ZMod d₁ => k.val < i.val)).sum vals) % e₁) % e₁ + vals i) % e₁
-      rw [show (i + 1).val = i.val + 1 from by rw [ZMod.val_add_one]; exact Nat.mod_eq_of_lt hi,
-          zmod_filter_sum_succ vals i]
+      have : (i + 1).val = i.val + 1 := by rw [ZMod.val_add_one]; exact Nat.mod_eq_of_lt hi
+      rw [this, zmod_filter_sum_succ vals i]
       exact pos_shift_succ' j.val _ (vals i) e₁
     · have hi_eq : i.val = d₁ - 1 := by grind [ZMod.val_lt]
       have hj'_eq : j' = j + k₀ :=
@@ -838,8 +832,6 @@ lemma case_two_odd_small (hm : m ≥ 289)
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   haveI : NeZero m := ⟨by grind⟩
-  haveI : NeZero d₁ := ⟨by grind⟩
-  haveI : NeZero e₁ := ⟨by grind⟩
   have hb_zero : (b : ZMod d₁) = 0 := b_zero_mod_d1
   have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   have he1_b_zero : e₁ • (b : ZMod m) = 0 :=

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -878,8 +878,7 @@ private lemma no_both_e_small {m' d d' : ℕ} (hm : m' ≥ 289) (hcop : Nat.gcd 
 
 /-- **Main Case 2 (Multiple Cycles).** Aggregates all subcases (2a)–(2d).
     First applies WLOG to ensure 3 ∤ d₁, then dispatches on parity of d₁ and e₁. -/
-lemma main_case_two (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
-    (h_min : min d₁ d₂ > 1) :
+lemma main_case_two (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1) (h_min : min d₁ d₂ > 1) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   rcases Nat.even_or_odd e₁ with he | ho
   · exact case_two_e1_even hm h_gcd_coprime h_min he

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -823,13 +823,14 @@ lemma case_two_odd_small (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1
         change (j.val + (case2c_pattern d₁ k₀.val i.val).val) % 3 ≠
           (j.val + (case2c_pattern d₁ k₀.val (i + 1).val).val) % 3
         rw [hi'_eq]; exact case2c_nonwrap_hyp d₁ k₀.val i.val j.val hd1_ge3 hd1_odd hi
+      have hp : p = case2c_pattern d₁ k₀.val i.val := rfl
+      have hp' : p' = case2c_pattern d₁ k₀.val (i.val + 1) := by simp [p', hi'_eq]
       rcases cover_mod3_general p p' j.val j.val hhyp k with h | h | h | h
       · left; exact h
-      · right; left; rw [h, show p = case2c_pattern d₁ k₀.val i.val from rfl]
+      · right; left; rw [h, hp]
         exact Fin.ext (by simp [f, ZMod.val_add_one, case2c_mod3 he1_div3])
       · right; right; left; exact h
-      · right; right; right
-        rw [h, show p' = case2c_pattern d₁ k₀.val (i.val + 1) from by simp [p', hi'_eq]]
+      · right; right; right; rw [h, hp']
         exact Fin.ext (by
           simp [f, ZMod.val_add_one, case2c_mod3 he1_div3, Nat.mod_eq_of_lt hi])
     · have hi_eq : i.val = d₁ - 1 := by grind [ZMod.val_lt]
@@ -842,9 +843,11 @@ lemma case_two_odd_small (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1
         rw [hp_eq]; exact case2c_wrap_hyp d₁ k₀.val j.val hd1_ge3 hd1_odd
       have hj'_val : (j + k₀).val = (j.val + k₀.val) % e₁ := ZMod.val_add j k₀
       have hi1_val : (i + 1).val = 0 := by rw [ZMod.val_add_one, hi_eq]; grind [Nat.mod_self]
+      have hp : p = case2c_pattern d₁ k₀.val i.val := rfl
+      have hp₀_val : (↑p₀ : ℕ) = ↑(case2c_pattern d₁ k₀.val 0) := rfl
       rcases cover_mod3_general p p₀ j.val (j.val + k₀.val) hhyp k with h | h | h | h
       · left; exact h
-      · right; left; rw [h, show p = case2c_pattern d₁ k₀.val i.val from rfl]
+      · right; left; rw [h, hp]
         exact Fin.ext (by simp [f, ZMod.val_add_one, case2c_mod3 he1_div3])
       · right; right; left; rw [h]
         refine Fin.ext ?_
@@ -854,7 +857,7 @@ lemma case_two_odd_small (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1
       · right; right; right; rw [h]
         refine Fin.ext ?_
         simp only [f, hi1_val, ZMod.val_add_one]
-        rw [hj'_val, show (↑p₀ : ℕ) = ↑(case2c_pattern d₁ k₀.val 0) from rfl]
+        rw [hj'_val, hp₀_val]
         simp only [case2c_mod3 he1_div3, Nat.add_assoc])
 
 /-- Auxiliary: rules out both cycle lengths being ≤ 17 when m ≥ 289. -/

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -767,7 +767,9 @@ private lemma case2d_coloring_works (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d�
       · left; exact h
       · right; left; rw [h]; simp only [f]; congr 1; exact (pos_shift_one j (rot i)).symm
       · right; right; left; rw [h]; simp only [f]; congr 1; exact hpos.symm
-      · right; right; right
+      · right
+        right
+        right
         rw [h]
         simp only [f]
         congr 1
@@ -829,7 +831,8 @@ lemma case_two_odd_small (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1
       have hhyp : (j.val + p.val) % 3 ≠ (j.val + p'.val) % 3 := by
         change (j.val + (case2c_pattern d₁ k₀.val i.val).val) % 3 ≠
           (j.val + (case2c_pattern d₁ k₀.val (i + 1).val).val) % 3
-        rw [hi'_eq]; exact case2c_nonwrap_hyp d₁ k₀.val i.val j.val hd1_ge3 hd1_odd hi
+        rw [hi'_eq]
+        exact case2c_nonwrap_hyp d₁ k₀.val i.val j.val hd1_ge3 hd1_odd hi
       have hp : p = case2c_pattern d₁ k₀.val i.val := rfl
       have hp' : p' = case2c_pattern d₁ k₀.val (i.val + 1) := by simp [p', hi'_eq]
       rcases cover_mod3_general p p' j.val j.val hhyp k with h | h | h | h
@@ -838,7 +841,9 @@ lemma case_two_odd_small (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1
         rw [h, hp]
         exact Fin.ext (by simp [f, ZMod.val_add_one, case2c_mod3 he1_div3])
       · right; right; left; exact h
-      · right; right; right
+      · right
+        right
+        right
         rw [h, hp']
         exact Fin.ext (by
           simp [f, ZMod.val_add_one, case2c_mod3 he1_div3, Nat.mod_eq_of_lt hi])
@@ -849,7 +854,8 @@ lemma case_two_odd_small (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1
       set p₀ := case2c_pattern d₁ k₀.val 0
       have hp_eq : p = case2c_pattern d₁ k₀.val (d₁ - 1) := by grind
       have hhyp : (j.val + p.val) % 3 ≠ (j.val + k₀.val + p₀.val) % 3 := by
-        rw [hp_eq]; exact case2c_wrap_hyp d₁ k₀.val j.val hd1_ge3 hd1_odd
+        rw [hp_eq]
+        exact case2c_wrap_hyp d₁ k₀.val j.val hd1_ge3 hd1_odd
       have hj'_val : (j + k₀).val = (j.val + k₀.val) % e₁ := ZMod.val_add j k₀
       have hi1_val : (i + 1).val = 0 := by rw [ZMod.val_add_one, hi_eq]; grind [Nat.mod_self]
       have hp : p = case2c_pattern d₁ k₀.val i.val := rfl
@@ -859,13 +865,17 @@ lemma case_two_odd_small (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1
       · right; left
         rw [h, hp]
         exact Fin.ext (by simp [f, ZMod.val_add_one, case2c_mod3 he1_div3])
-      · right; right; left
+      · right
+        right
+        left
         rw [h]
         refine Fin.ext ?_
         simp only [f, hi1_val]
         rw [hj'_val]
         exact (case2c_mod3 he1_div3 (j.val + k₀.val) p₀.val).symm
-      · right; right; right
+      · right
+        right
+        right
         rw [h]
         refine Fin.ext ?_
         simp only [f, hi1_val, ZMod.val_add_one]

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -109,14 +109,13 @@ private lemma ba_coprime_d1
       (Nat.dvd_gcd (Nat.gcd_dvd_left _ _) (dvd_trans (Nat.gcd_dvd_right _ _) d₁_dvd_m)))
 
 private lemma orbitMap_i_eq [NeZero d₁]
-    (hb_zero : (b : ZMod d₁) = 0)
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) {i₁ i₂ : ZMod d₁} {j₁ j₂ : ZMod e₁}
     (heq : orbitMap m a b (i₁, j₁) = orbitMap m a b (i₂, j₂)) :
     i₁ = i₂ := by
   simp only [orbitMap] at heq
   have := congr_arg (ZMod.castHom d₁_dvd_m (ZMod d₁)) heq
   simp only [map_add, map_mul, map_natCast, map_intCast] at this
-  simp only [hb_zero, mul_zero, add_zero, ZMod.natCast_val, ZMod.cast_id] at this
+  simp only [b_zero_mod_d1, mul_zero, add_zero, ZMod.natCast_val, ZMod.cast_id] at this
   exact hba_unit.mul_right_cancel this
 
 private lemma orbitMap_j_eq [NeZero e₁]
@@ -134,28 +133,28 @@ private lemma orbitMap_j_eq [NeZero e₁]
     exact ZMod.val_injective _ (by grind)
 
 private lemma orbitMap_injective [NeZero m]
-    (hm_eq : m = d₁ * e₁)
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
     (hord : addOrderOf (b : ZMod m) = e₁) :
     Function.Injective (orbitMap m a b : ZMod d₁ × ZMod e₁ → ZMod m) := by
+  have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   haveI : NeZero d₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, zero_mul]) (NeZero.ne m)⟩
   haveI : NeZero e₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, mul_zero]) (NeZero.ne m)⟩
   intro ⟨i₁, j₁⟩ ⟨i₂, j₂⟩ heq
-  have hi := orbitMap_i_eq b_zero_mod_d1 hba_unit heq
+  have hi := orbitMap_i_eq hba_unit heq
   subst hi
   simp only [orbitMap] at heq
   have hj_smul : (j₁.val : ℕ) • (b : ZMod m) = (j₂.val : ℕ) • (b : ZMod m) := by grind
   exact Prod.ext rfl (orbitMap_j_eq hord hj_smul)
 
 private lemma orbitMap_bijective [NeZero m]
-    (hm_eq : m = d₁ * e₁) (hb_zero : (b : ZMod d₁) = 0)
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
     (hord : addOrderOf (b : ZMod m) = e₁) :
     Function.Bijective (orbitMap m a b : ZMod d₁ × ZMod e₁ → ZMod m) := by
+  have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   haveI : NeZero d₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, zero_mul]) (NeZero.ne m)⟩
   haveI : NeZero e₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, mul_zero]) (NeZero.ne m)⟩
   exact (Fintype.bijective_iff_injective_and_card _).mpr
-    ⟨orbitMap_injective hm_eq hba_unit hord,
+    ⟨orbitMap_injective hba_unit hord,
      by simp only [Fintype.card_prod, ZMod.card]; linarith [hm_eq]⟩
 
 private lemma orbitMap_shift_b [NeZero e₁]
@@ -214,32 +213,34 @@ private lemma equiv_symm_fst_eq {γ : Type*}
     (hα : ∀ i : ZMod d₁, ∀ j : ZMod e₁, α (Φ (i, j)) = i) (x : γ) : (Φ.symm x).1 = α x := by grind
 
 /-- Build the orbit equivalence from the standard hypotheses. -/
-private noncomputable def orbitEquiv [NeZero m] (hm_eq : m = d₁ * e₁)
-    (hb_zero : (b : ZMod d₁) = 0) (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
+private noncomputable def orbitEquiv [NeZero m]
+    (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
     (hord : addOrderOf (b : ZMod m) = e₁) : ZMod d₁ × ZMod e₁ ≃ ZMod m :=
-  Equiv.ofBijective (orbitMap m a b) (orbitMap_bijective hm_eq hb_zero hba_unit hord)
+  Equiv.ofBijective (orbitMap m a b) (orbitMap_bijective hba_unit hord)
 
-private lemma orbitEquiv_shift_b [NeZero m] {hm_eq : m = d₁ * e₁}
-    {hb_zero : (b : ZMod d₁) = 0} {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
+private lemma orbitEquiv_shift_b [NeZero m]
+    {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
     {hord : addOrderOf (b : ZMod m) = e₁} (x : ZMod m) :
-    (orbitEquiv hm_eq hb_zero hba_unit hord).symm (x + ↑b) =
-    (((orbitEquiv hm_eq hb_zero hba_unit hord).symm x).1,
-     ((orbitEquiv hm_eq hb_zero hba_unit hord).symm x).2 + 1) := by
+    (orbitEquiv hba_unit hord).symm (x + ↑b) =
+    (((orbitEquiv hba_unit hord).symm x).1,
+     ((orbitEquiv hba_unit hord).symm x).2 + 1) := by
+  have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   haveI : NeZero e₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, mul_zero]) (NeZero.ne m)⟩
   exact equiv_symm_shift_b _ (fun i j =>
     (orbitMap_shift_b (hord ▸ addOrderOf_nsmul_eq_zero _) (i, j)).symm) x
 
-private lemma orbitEquiv_cycle_shift [NeZero m] {hm_eq : m = d₁ * e₁}
-    {hb_zero : (b : ZMod d₁) = 0} {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
+private lemma orbitEquiv_cycle_shift [NeZero m]
+    {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
     {hord : addOrderOf (b : ZMod m) = e₁} (x : ZMod m) :
-    ((orbitEquiv hm_eq hb_zero hba_unit hord).symm (x + ↑(b - a))).1 =
-    ((orbitEquiv hm_eq hb_zero hba_unit hord).symm x).1 + 1 := by
+    ((orbitEquiv hba_unit hord).symm (x + ↑(b - a))).1 =
+    ((orbitEquiv hba_unit hord).symm x).1 + 1 := by
+  have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   haveI : NeZero d₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, zero_mul]) (NeZero.ne m)⟩
   let u_ba := hba_unit.choose
   have hu_ba : ↑u_ba = ((b - a : ℤ) : ZMod d₁) := hba_unit.choose_spec
   let α : ZMod m → ZMod d₁ := fun x => ZMod.castHom d₁_dvd_m (ZMod d₁) x * u_ba⁻¹
-  have hΦ_cycle := equiv_symm_fst_eq (orbitEquiv hm_eq hb_zero hba_unit hord) α
-    (orbitMap_cycle_index hb_zero u_ba hu_ba)
+  have hΦ_cycle := equiv_symm_fst_eq (orbitEquiv hba_unit hord) α
+    (orbitMap_cycle_index b_zero_mod_d1 u_ba hu_ba)
   rw [hΦ_cycle (x + ↑(b - a))]
   dsimp only [α]
   rw [cycle_index_shift_ba u_ba hu_ba]
@@ -248,13 +249,12 @@ private lemma orbitEquiv_cycle_shift [NeZero m] {hm_eq : m = d₁ * e₁}
 
 /-- In the non-wrap case, the second coordinate is preserved by the (b-a) shift. -/
 private lemma orbitEquiv_snd_shift_ba [NeZero m] [NeZero d₁]
-    {hm_eq : m = d₁ * e₁} {hb_zero : (b : ZMod d₁) = 0}
     {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
     {hord : addOrderOf (b : ZMod m) = e₁}
-    (n : ZMod m) (hi : (orbitEquiv hm_eq hb_zero hba_unit hord).symm n |>.1.val + 1 < d₁) :
-    ((orbitEquiv hm_eq hb_zero hba_unit hord).symm (n + ↑(b - a))).2 =
-    ((orbitEquiv hm_eq hb_zero hba_unit hord).symm n).2 := by
-  set Φ := orbitEquiv hm_eq hb_zero hba_unit hord
+    (n : ZMod m) (hi : (orbitEquiv hba_unit hord).symm n |>.1.val + 1 < d₁) :
+    ((orbitEquiv hba_unit hord).symm (n + ↑(b - a))).2 =
+    ((orbitEquiv hba_unit hord).symm n).2 := by
+  set Φ := orbitEquiv hba_unit hord
   set i := (Φ.symm n).1; set j := (Φ.symm n).2
   have hshift := orbitMap_shift_ba (a := a) i j hi
   have hn : Φ (i, j) = n := Prod.eta (Φ.symm n) ▸ Equiv.apply_symm_apply Φ n
@@ -307,23 +307,14 @@ lemma case_two_e1_even (hm : m ≥ 289)
     (he1_even : Even e₁) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
-  have he₁_ge2 : e₁ ≥ 2 := by
-    have : 0 < e₁ := Nat.div_pos (Nat.le_of_dvd (by grind) d₁_dvd_m) (by grind)
-    grind
   haveI : NeZero m := ⟨by grind⟩
   haveI : NeZero d₁ := ⟨by grind⟩
   haveI : NeZero e₁ := ⟨by grind⟩
-  have hb_zero : (Int.cast b : ZMod d₁) = 0 := b_zero_mod_d1
   have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind)
-  let Φ := orbitEquiv hm_eq hb_zero hba_unit hord
-  have hd₁_ge2 : d₁ ≥ 2 := by grind
-  have he₁_ge2 : e₁ ≥ 2 := by
-    have : 0 < e₁ := Nat.div_pos (Nat.le_of_dvd (by grind) d₁_dvd_m) (by grind)
-    grind
-  exact orbit_coloring_polychrom Φ orbitEquiv_shift_b orbitEquiv_cycle_shift
-    (cycle_coloring d₁ e₁)
-    (fun n k => color_covers_even d₁ e₁ hd₁_ge2 (parity_flip_even e₁ he1_even) _ _ _ k)
+  exact orbit_coloring_polychrom (orbitEquiv hba_unit hord) orbitEquiv_shift_b
+    orbitEquiv_cycle_shift (cycle_coloring d₁ e₁)
+    (fun n k => color_covers_even d₁ e₁ (by grind) (parity_flip_even e₁ he1_even) _ _ _ k)
 
 /-! ### Subcase (2b) construction: d₁ even, e₁ odd
 
@@ -383,7 +374,7 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
   have hba_unit : IsUnit (Int.cast (b - a) : ZMod d₁) :=
     isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind)
-  let Φ := orbitEquiv hm_eq hb_zero hba_unit hord
+  let Φ := orbitEquiv hba_unit hord
   -- d₂ properties for the compatibility argument
   have hd₂_dvd : d₂ ∣ m := Nat.gcd_dvd_right _ _
   have hd₂_gt1 : d₂ > 1 := by grind
@@ -596,10 +587,9 @@ private lemma basePattern_rotation_covers {e j : ℕ} (he : Odd e) (hge : e ≥ 
 
 private lemma case2d_wrap_shift [NeZero m] [NeZero d₁] [NeZero e₁]
     (hb_zero : (b : ZMod d₁) = 0)
-    (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) (hord : addOrderOf (b : ZMod m) = e₁)
-    (hm_eq : m = d₁ * e₁) :
+    (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) (hord : addOrderOf (b : ZMod m) = e₁) :
     ∃ k₀ : ZMod e₁, (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m) := by
-  set Φ := orbitEquiv hm_eq hb_zero hba_unit hord
+  set Φ := orbitEquiv hba_unit hord
   set q := Φ.symm ((d₁ : ℕ) • ((b - a : ℤ) : ZMod m))
   have hq_i : q.1 = 0 := by
     set f := ZMod.castHom d₁_dvd_m (ZMod d₁)
@@ -647,15 +637,14 @@ private lemma case2d_shift_ba_wrap [NeZero e₁] [NeZero d₁]
 
 /-- In the wrap case, the second coordinate shifts by k₀. -/
 private lemma orbitEquiv_snd_shift_ba_wrap [NeZero m] [NeZero d₁] [NeZero e₁]
-    {hm_eq : m = d₁ * e₁} {hb_zero : (b : ZMod d₁) = 0}
     {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
     {hord : addOrderOf (b : ZMod m) = e₁}
     (he1_b_zero : e₁ • (b : ZMod m) = 0) (k₀ : ZMod e₁)
     (hk₀ : (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m))
-    (n : ZMod m) (hi : (orbitEquiv hm_eq hb_zero hba_unit hord).symm n |>.1.val = d₁ - 1) :
-    ((orbitEquiv hm_eq hb_zero hba_unit hord).symm (n + ↑(b - a))).2 =
-    ((orbitEquiv hm_eq hb_zero hba_unit hord).symm n).2 + k₀ := by
-  set Φ := orbitEquiv hm_eq hb_zero hba_unit hord
+    (n : ZMod m) (hi : (orbitEquiv hba_unit hord).symm n |>.1.val = d₁ - 1) :
+    ((orbitEquiv hba_unit hord).symm (n + ↑(b - a))).2 =
+    ((orbitEquiv hba_unit hord).symm n).2 + k₀ := by
+  set Φ := orbitEquiv hba_unit hord
   set i := (Φ.symm n).1; set j := (Φ.symm n).2
   have hshift := case2d_shift_ba_wrap he1_b_zero k₀ hk₀ i hi
   have hn : Φ (i, j) = n := Prod.eta (Φ.symm n) ▸ Equiv.apply_symm_apply Φ n
@@ -795,8 +784,8 @@ private lemma case2d_coloring_works (hm : m ≥ 289)
   have hb_zero : (b : ZMod d₁) = 0 := b_zero_mod_d1
   have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   have he1_b_zero : e₁ • (b : ZMod m) = 0 := hord ▸ addOrderOf_nsmul_eq_zero _
-  let Φ := orbitEquiv hm_eq hb_zero hba_unit hord
-  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hb_zero hba_unit hord hm_eq
+  let Φ := orbitEquiv hba_unit hord
+  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hb_zero hba_unit hord
   have hd1_ge5 : d₁ ≥ 5 := by grind
   obtain ⟨vals, hvals_bound, hvals_sum⟩ := case2d_rotation_sum_exists hd1_ge5 he1_ge he1_odd k₀.val
   let rot : ZMod d₁ → ℕ := fun i =>
@@ -864,8 +853,8 @@ lemma case_two_odd_small (hm : m ≥ 289)
   have hb_zero : (b : ZMod d₁) = 0 := b_zero_mod_d1
   have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
   have he1_b_zero : e₁ • (b : ZMod m) = 0 := hord ▸ addOrderOf_nsmul_eq_zero _
-  let Φ := orbitEquiv hm_eq hb_zero hba_unit hord
-  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hb_zero hba_unit hord hm_eq
+  let Φ := orbitEquiv hba_unit hord
+  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hb_zero hba_unit hord
   have hd1_ge3 : d₁ ≥ 3 := by grind
   let f : ZMod d₁ × ZMod e₁ → Fin 3 := fun ⟨i, j⟩ =>
     ⟨(j.val + (case2c_pattern d₁ k₀.val i.val).val) % 3, Nat.mod_lt _ (by grind)⟩

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -645,6 +645,27 @@ private lemma case2d_shift_ba_wrap [NeZero e₁] [NeZero d₁]
   conv_lhs => rw [(Nat.div_add_mod n e₁).symm]
   rw [add_nsmul, mul_nsmul, he1_b_zero, smul_zero, zero_add, nsmul_eq_mul]
 
+/-- In the wrap case, the second coordinate shifts by k₀. -/
+private lemma orbitEquiv_snd_shift_ba_wrap [NeZero m] [NeZero d₁] [NeZero e₁]
+    {hm_eq : m = d₁ * e₁} {hb_zero : (b : ZMod d₁) = 0}
+    {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
+    {hord : addOrderOf (b : ZMod m) = e₁}
+    (he1_b_zero : e₁ • (b : ZMod m) = 0) (k₀ : ZMod e₁)
+    (hk₀ : (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m))
+    (n : ZMod m) (hi : (orbitEquiv hm_eq hb_zero hba_unit hord).symm n |>.1.val = d₁ - 1) :
+    ((orbitEquiv hm_eq hb_zero hba_unit hord).symm (n + ↑(b - a))).2 =
+    ((orbitEquiv hm_eq hb_zero hba_unit hord).symm n).2 + k₀ := by
+  set Φ := orbitEquiv hm_eq hb_zero hba_unit hord
+  set i := (Φ.symm n).1; set j := (Φ.symm n).2
+  have hshift := case2d_shift_ba_wrap he1_b_zero k₀ hk₀ i hi
+  have hn : Φ (i, j) = n := Prod.eta (Φ.symm n) ▸ Equiv.apply_symm_apply Φ n
+  have hΦ : Φ ((0 : ZMod d₁), j + k₀) = n + ↑(b - a) := by
+    simp only [Φ, orbitEquiv, Equiv.ofBijective_apply] at hn ⊢
+    rw [← hn]; exact (hshift j).symm
+  have h := congrArg Prod.snd (show Φ.symm (n + ↑(b - a)) = (0, j + k₀) by
+    rw [← hΦ, Φ.symm_apply_apply])
+  exact h
+
 /-- Given d₁ ≥ 3 values each in [u, e₁-u] can sum to any target mod e₁,
     since the range has width ≥ e₁/3 and d₁ ≥ 3. -/
 private lemma case2d_rotation_sum_exists {e₁ d₁ : ℕ} [NeZero d₁]
@@ -816,14 +837,8 @@ private lemma case2d_coloring_works (hm : m ≥ 289)
           zmod_filter_sum_succ vals i]
       exact pos_shift_succ' j.val _ (vals i) e₁
     · have hi_eq : i.val = d₁ - 1 := by grind [ZMod.val_lt]
-      have hj'_eq : j' = j + k₀ := by
-        have hshift := case2d_shift_ba_wrap he1_b_zero k₀ hk₀ i hi_eq
-        have hn : Φ (i, j) = n := Prod.eta (Φ.symm n) ▸ Equiv.apply_symm_apply Φ n
-        have hΦ : Φ ((0 : ZMod d₁), j + k₀) = n + ↑(b - a) := by
-          simp only [Φ, orbitEquiv, Equiv.ofBijective_apply] at hn ⊢
-          rw [← hn]; exact (hshift j).symm
-        change (Φ.symm (n + ↑(b - a))).2 = j + k₀
-        rw [← hΦ, Φ.symm_apply_apply]
+      have hj'_eq : j' = j + k₀ :=
+        orbitEquiv_snd_shift_ba_wrap he1_b_zero k₀ hk₀ n hi_eq
       rw [hj'_eq]
       have hi1_zero : (i + 1 : ZMod d₁) = 0 := by
         apply ZMod.val_injective; rw [ZMod.val_add_one, hi_eq, ZMod.val_zero]
@@ -885,14 +900,8 @@ lemma case_two_odd_small (hm : m ≥ 289)
         exact Fin.ext (by
           simp [f, ZMod.val_add_one, case2c_mod3 he1_div3, Nat.mod_eq_of_lt hi])
     · have hi_eq : i.val = d₁ - 1 := by grind [ZMod.val_lt]
-      have hj'_eq : j' = j + k₀ := by
-        have hshift := case2d_shift_ba_wrap he1_b_zero k₀ hk₀ i hi_eq j
-        have hn : Φ (i, j) = n := Prod.eta (Φ.symm n) ▸ Equiv.apply_symm_apply Φ n
-        have : Φ ((0 : ZMod d₁), j + k₀) = n + ↑(b - a) := by
-          simp only [Φ, orbitEquiv, Equiv.ofBijective_apply] at hn ⊢
-          rw [← hn]; exact hshift.symm
-        change (Φ.symm (n + ↑(b - a))).2 = j + k₀
-        rw [← this, Φ.symm_apply_apply]
+      have hj'_eq : j' = j + k₀ :=
+        orbitEquiv_snd_shift_ba_wrap he1_b_zero k₀ hk₀ n hi_eq
       rw [hj'_eq]
       set p₀ := case2c_pattern d₁ k₀.val 0
       have hp_eq : p = case2c_pattern d₁ k₀.val (d₁ - 1) := by grind

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -86,10 +86,10 @@ It provides the coordinate system used to analyze the "Multiple Cycles" case.
 private def orbitMap (m : ℕ) (a b : ℤ) : ZMod d₁ × ZMod e₁ → ZMod m :=
   fun p => (p.1.val : ZMod m) * ↑(b - a) + (p.2.val : ZMod m) * ↑b
 
-private lemma addOrderOf_b_eq (hm : 0 < m) :
+private lemma addOrderOf_b_eq [NeZero m] :
     addOrderOf (b : ZMod m) = e₁ := by
   have key : addOrderOf (b.natAbs : ZMod m) = e₁ := by
-    rw [ZMod.addOrderOf_coe b.natAbs (by grind), Nat.gcd_comm]
+    rw [ZMod.addOrderOf_coe b.natAbs (NeZero.ne m), Nat.gcd_comm]
   rcases Int.natAbs_eq b with h | h
   · have : (b : ZMod m) = (b.natAbs : ZMod m) := by rw [h]; simp
     grind
@@ -118,23 +118,22 @@ private lemma orbitMap_i_eq [NeZero d₁]
   simp only [b_zero_mod_d1, mul_zero, add_zero, ZMod.natCast_val, ZMod.cast_id] at this
   exact hba_unit.mul_right_cancel this
 
-private lemma orbitMap_j_eq [NeZero e₁]
-    (hord : addOrderOf (b : ZMod m) = e₁)
+private lemma orbitMap_j_eq [NeZero m] [NeZero e₁]
     {j₁ j₂ : ZMod e₁}
     (hj_smul : (j₁.val : ℕ) • (b : ZMod m) = (j₂.val : ℕ) • (b : ZMod m)) :
     j₁ = j₂ := by
   wlog h : j₁.val ≤ j₂.val with H
-  · exact (H hord hj_smul.symm (Nat.le_of_not_le h)).symm
+  · exact (H hj_smul.symm (Nat.le_of_not_le h)).symm
   · have h3 : (j₂.val - j₁.val) • (b : ZMod m) = 0 :=
       add_left_cancel (a := j₁.val • (b : ZMod m))
         (by rw [add_zero, ← add_nsmul, Nat.add_sub_cancel' h]; exact hj_smul.symm)
-    have := Nat.eq_zero_of_dvd_of_lt (hord ▸ addOrderOf_dvd_of_nsmul_eq_zero h3)
+    have := Nat.eq_zero_of_dvd_of_lt
+      ((addOrderOf_b_eq (b := b) (m := m)) ▸ addOrderOf_dvd_of_nsmul_eq_zero h3)
       (by grind [ZMod.val_lt j₁, ZMod.val_lt j₂])
     exact ZMod.val_injective _ (by grind)
 
 private lemma orbitMap_injective [NeZero m]
-    (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
-    (hord : addOrderOf (b : ZMod m) = e₁) :
+    (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) :
     Function.Injective (orbitMap m a b : ZMod d₁ × ZMod e₁ → ZMod m) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   haveI : NeZero d₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, zero_mul]) (NeZero.ne m)⟩
@@ -144,17 +143,16 @@ private lemma orbitMap_injective [NeZero m]
   subst hi
   simp only [orbitMap] at heq
   have hj_smul : (j₁.val : ℕ) • (b : ZMod m) = (j₂.val : ℕ) • (b : ZMod m) := by grind
-  exact Prod.ext rfl (orbitMap_j_eq hord hj_smul)
+  exact Prod.ext rfl (orbitMap_j_eq hj_smul)
 
 private lemma orbitMap_bijective [NeZero m]
-    (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
-    (hord : addOrderOf (b : ZMod m) = e₁) :
+    (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) :
     Function.Bijective (orbitMap m a b : ZMod d₁ × ZMod e₁ → ZMod m) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   haveI : NeZero d₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, zero_mul]) (NeZero.ne m)⟩
   haveI : NeZero e₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, mul_zero]) (NeZero.ne m)⟩
   exact (Fintype.bijective_iff_injective_and_card _).mpr
-    ⟨orbitMap_injective hba_unit hord,
+    ⟨orbitMap_injective hba_unit,
      by simp only [Fintype.card_prod, ZMod.card]; linarith [hm_eq]⟩
 
 private lemma orbitMap_shift_b [NeZero e₁]
@@ -185,12 +183,11 @@ private lemma orbitMap_shift_ba [NeZero d₁]
 
 /-- The cycle index α(x) = castHom(x) * u⁻¹ satisfies α(φ(i,j)) = i. -/
 private lemma orbitMap_cycle_index [NeZero d₁]
-    (hb_zero : (b : ZMod d₁) = 0)
     (u : (ZMod d₁)ˣ) (hu : ↑u = ((b - a : ℤ) : ZMod d₁)) (i : ZMod d₁) (j : ZMod e₁) :
     ZMod.castHom d₁_dvd_m (ZMod d₁) (orbitMap m a b (i, j)) * u⁻¹ = i := by
   simp only [orbitMap]
-  rw [map_add, map_mul, map_mul, map_natCast, map_intCast,
-    map_natCast, map_intCast, hb_zero, mul_zero, add_zero, mul_assoc, ← hu, u.mul_inv, mul_one]
+  rw [map_add, map_mul, map_mul, map_natCast, map_intCast, map_natCast, map_intCast,
+    b_zero_mod_d1, mul_zero, add_zero, mul_assoc, ← hu, u.mul_inv, mul_one]
   simp [ZMod.natCast_val]
 
 /-- The cycle index α shifts by 1 when (b-a) is added. -/
@@ -214,33 +211,31 @@ private lemma equiv_symm_fst_eq {γ : Type*}
 
 /-- Build the orbit equivalence from the standard hypotheses. -/
 private noncomputable def orbitEquiv [NeZero m]
-    (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
-    (hord : addOrderOf (b : ZMod m) = e₁) : ZMod d₁ × ZMod e₁ ≃ ZMod m :=
-  Equiv.ofBijective (orbitMap m a b) (orbitMap_bijective hba_unit hord)
+    (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) : ZMod d₁ × ZMod e₁ ≃ ZMod m :=
+  Equiv.ofBijective (orbitMap m a b) (orbitMap_bijective hba_unit)
 
 private lemma orbitEquiv_shift_b [NeZero m]
-    {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
-    {hord : addOrderOf (b : ZMod m) = e₁} (x : ZMod m) :
-    (orbitEquiv hba_unit hord).symm (x + ↑b) =
-    (((orbitEquiv hba_unit hord).symm x).1,
-     ((orbitEquiv hba_unit hord).symm x).2 + 1) := by
+    {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)} (x : ZMod m) :
+    (orbitEquiv hba_unit).symm (x + ↑b) =
+    (((orbitEquiv hba_unit).symm x).1,
+     ((orbitEquiv hba_unit).symm x).2 + 1) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   haveI : NeZero e₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, mul_zero]) (NeZero.ne m)⟩
   exact equiv_symm_shift_b _ (fun i j =>
-    (orbitMap_shift_b (hord ▸ addOrderOf_nsmul_eq_zero _) (i, j)).symm) x
+    (orbitMap_shift_b (addOrderOf_b_eq (b := b) (m := m) ▸
+      addOrderOf_nsmul_eq_zero _) (i, j)).symm) x
 
 private lemma orbitEquiv_cycle_shift [NeZero m]
-    {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
-    {hord : addOrderOf (b : ZMod m) = e₁} (x : ZMod m) :
-    ((orbitEquiv hba_unit hord).symm (x + ↑(b - a))).1 =
-    ((orbitEquiv hba_unit hord).symm x).1 + 1 := by
+    {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)} (x : ZMod m) :
+    ((orbitEquiv hba_unit).symm (x + ↑(b - a))).1 =
+    ((orbitEquiv hba_unit).symm x).1 + 1 := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   haveI : NeZero d₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, zero_mul]) (NeZero.ne m)⟩
   let u_ba := hba_unit.choose
   have hu_ba : ↑u_ba = ((b - a : ℤ) : ZMod d₁) := hba_unit.choose_spec
   let α : ZMod m → ZMod d₁ := fun x => ZMod.castHom d₁_dvd_m (ZMod d₁) x * u_ba⁻¹
-  have hΦ_cycle := equiv_symm_fst_eq (orbitEquiv hba_unit hord) α
-    (orbitMap_cycle_index b_zero_mod_d1 u_ba hu_ba)
+  have hΦ_cycle := equiv_symm_fst_eq (orbitEquiv hba_unit) α
+    (orbitMap_cycle_index u_ba hu_ba)
   rw [hΦ_cycle (x + ↑(b - a))]
   dsimp only [α]
   rw [cycle_index_shift_ba u_ba hu_ba]
@@ -250,11 +245,10 @@ private lemma orbitEquiv_cycle_shift [NeZero m]
 /-- In the non-wrap case, the second coordinate is preserved by the (b-a) shift. -/
 private lemma orbitEquiv_snd_shift_ba [NeZero m] [NeZero d₁]
     {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
-    {hord : addOrderOf (b : ZMod m) = e₁}
-    (n : ZMod m) (hi : (orbitEquiv hba_unit hord).symm n |>.1.val + 1 < d₁) :
-    ((orbitEquiv hba_unit hord).symm (n + ↑(b - a))).2 =
-    ((orbitEquiv hba_unit hord).symm n).2 := by
-  set Φ := orbitEquiv hba_unit hord
+    (n : ZMod m) (hi : (orbitEquiv hba_unit).symm n |>.1.val + 1 < d₁) :
+    ((orbitEquiv hba_unit).symm (n + ↑(b - a))).2 =
+    ((orbitEquiv hba_unit).symm n).2 := by
+  set Φ := orbitEquiv hba_unit
   set i := (Φ.symm n).1; set j := (Φ.symm n).2
   have hshift := orbitMap_shift_ba (a := a) i j hi
   have hn : Φ (i, j) = n := Prod.eta (Φ.symm n) ▸ Equiv.apply_symm_apply Φ n
@@ -311,8 +305,7 @@ lemma case_two_e1_even (hm : m ≥ 289)
   haveI : NeZero d₁ := ⟨by grind⟩
   haveI : NeZero e₁ := ⟨by grind⟩
   have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
-  have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind)
-  exact orbit_coloring_polychrom (orbitEquiv hba_unit hord) orbitEquiv_shift_b
+  exact orbit_coloring_polychrom (orbitEquiv hba_unit) orbitEquiv_shift_b
     orbitEquiv_cycle_shift (cycle_coloring d₁ e₁)
     (fun n k => color_covers_even d₁ e₁ (by grind) (parity_flip_even e₁ he1_even) _ _ _ k)
 
@@ -373,8 +366,7 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
   have hb_zero : (Int.cast b : ZMod d₁) = 0 := b_zero_mod_d1
   have hba_unit : IsUnit (Int.cast (b - a) : ZMod d₁) :=
     isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
-  have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind)
-  let Φ := orbitEquiv hba_unit hord
+  let Φ := orbitEquiv hba_unit
   -- d₂ properties for the compatibility argument
   have hd₂_dvd : d₂ ∣ m := Nat.gcd_dvd_right _ _
   have hd₂_gt1 : d₂ > 1 := by grind
@@ -587,9 +579,9 @@ private lemma basePattern_rotation_covers {e j : ℕ} (he : Odd e) (hge : e ≥ 
 
 private lemma case2d_wrap_shift [NeZero m] [NeZero d₁] [NeZero e₁]
     (hb_zero : (b : ZMod d₁) = 0)
-    (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) (hord : addOrderOf (b : ZMod m) = e₁) :
+    (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) :
     ∃ k₀ : ZMod e₁, (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m) := by
-  set Φ := orbitEquiv hba_unit hord
+  set Φ := orbitEquiv hba_unit
   set q := Φ.symm ((d₁ : ℕ) • ((b - a : ℤ) : ZMod m))
   have hq_i : q.1 = 0 := by
     set f := ZMod.castHom d₁_dvd_m (ZMod d₁)
@@ -638,13 +630,12 @@ private lemma case2d_shift_ba_wrap [NeZero e₁] [NeZero d₁]
 /-- In the wrap case, the second coordinate shifts by k₀. -/
 private lemma orbitEquiv_snd_shift_ba_wrap [NeZero m] [NeZero d₁] [NeZero e₁]
     {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
-    {hord : addOrderOf (b : ZMod m) = e₁}
     (he1_b_zero : e₁ • (b : ZMod m) = 0) (k₀ : ZMod e₁)
     (hk₀ : (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m))
-    (n : ZMod m) (hi : (orbitEquiv hba_unit hord).symm n |>.1.val = d₁ - 1) :
-    ((orbitEquiv hba_unit hord).symm (n + ↑(b - a))).2 =
-    ((orbitEquiv hba_unit hord).symm n).2 + k₀ := by
-  set Φ := orbitEquiv hba_unit hord
+    (n : ZMod m) (hi : (orbitEquiv hba_unit).symm n |>.1.val = d₁ - 1) :
+    ((orbitEquiv hba_unit).symm (n + ↑(b - a))).2 =
+    ((orbitEquiv hba_unit).symm n).2 + k₀ := by
+  set Φ := orbitEquiv hba_unit
   set i := (Φ.symm n).1; set j := (Φ.symm n).2
   have hshift := case2d_shift_ba_wrap he1_b_zero k₀ hk₀ i hi
   have hn : Φ (i, j) = n := Prod.eta (Φ.symm n) ▸ Equiv.apply_symm_apply Φ n
@@ -780,12 +771,12 @@ private lemma case2d_coloring_works (hm : m ≥ 289)
   haveI : NeZero m := ⟨by grind⟩
   haveI : NeZero d₁ := ⟨by grind⟩
   haveI : NeZero e₁ := ⟨by grind⟩
-  have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind)
   have hb_zero : (b : ZMod d₁) = 0 := b_zero_mod_d1
   have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
-  have he1_b_zero : e₁ • (b : ZMod m) = 0 := hord ▸ addOrderOf_nsmul_eq_zero _
-  let Φ := orbitEquiv hba_unit hord
-  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hb_zero hba_unit hord
+  have he1_b_zero : e₁ • (b : ZMod m) = 0 :=
+    addOrderOf_b_eq (b := b) (m := m) ▸ addOrderOf_nsmul_eq_zero _
+  let Φ := orbitEquiv hba_unit
+  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hb_zero hba_unit
   have hd1_ge5 : d₁ ≥ 5 := by grind
   obtain ⟨vals, hvals_bound, hvals_sum⟩ := case2d_rotation_sum_exists hd1_ge5 he1_ge he1_odd k₀.val
   let rot : ZMod d₁ → ℕ := fun i =>
@@ -849,12 +840,12 @@ lemma case_two_odd_small (hm : m ≥ 289)
   haveI : NeZero m := ⟨by grind⟩
   haveI : NeZero d₁ := ⟨by grind⟩
   haveI : NeZero e₁ := ⟨by grind⟩
-  have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind)
   have hb_zero : (b : ZMod d₁) = 0 := b_zero_mod_d1
   have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 h_gcd_coprime)
-  have he1_b_zero : e₁ • (b : ZMod m) = 0 := hord ▸ addOrderOf_nsmul_eq_zero _
-  let Φ := orbitEquiv hba_unit hord
-  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hb_zero hba_unit hord
+  have he1_b_zero : e₁ • (b : ZMod m) = 0 :=
+    addOrderOf_b_eq (b := b) (m := m) ▸ addOrderOf_nsmul_eq_zero _
+  let Φ := orbitEquiv hba_unit
+  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hb_zero hba_unit
   have hd1_ge3 : d₁ ≥ 3 := by grind
   let f : ZMod d₁ × ZMod e₁ → Fin 3 := fun ⟨i, j⟩ =>
     ⟨(j.val + (case2c_pattern d₁ k₀.val i.val).val) % 3, Nat.mod_lt _ (by grind)⟩

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -852,8 +852,8 @@ private lemma case2c_mod3 (h3e : 3 ∣ e₁) (x y : ℕ) : (x % e₁ + y) % 3 = 
 lemma case_two_odd_small (hm : m ≥ 289)
     (h_gcd_coprime : (Nat.gcd b.natAbs m).gcd (Nat.gcd (b - a).natAbs m) = 1)
     (h_min : min (Nat.gcd b.natAbs m) (Nat.gcd (b - a).natAbs m) > 1)
-    (hd1_odd : Odd (Nat.gcd b.natAbs m)) (_he1_odd : Odd (m / Nat.gcd b.natAbs m))
-    (_he1_le : m / Nat.gcd b.natAbs m ≤ 17) (he1_div3 : 3 ∣ m / Nat.gcd b.natAbs m) :
+    (hd1_odd : Odd (Nat.gcd b.natAbs m))
+    (he1_div3 : 3 ∣ m / Nat.gcd b.natAbs m) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   haveI : NeZero m := ⟨by grind⟩
@@ -984,7 +984,7 @@ lemma main_case_two (hm : m ≥ 289)
           have h3e : 3 ∣ e :=
             ((Nat.Prime.coprime_iff_not_dvd (by decide)).mpr h3_nd₁).dvd_of_dvd_mul_left
               (Nat.mul_div_cancel' hd_dvd ▸ h3m)
-          exact case_two_odd_small hm hcop hmin hd₁_odd he₁_odd he_le h3e
+          exact case_two_odd_small hm hcop hmin hd₁_odd h3e
         · -- 3 ∤ d and 3 ∤ d₂ and e ≤ 17: swap and show new e ≥ 19.
           -- After swap, new e₁' = m/d₂. If e₁' ≤ 17 too, contradiction.
           rw [← zmod_set_swap m a' b']

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -44,7 +44,8 @@ private lemma ZMod.val_add_one {n : ℕ} [NeZero n] (x : ZMod n) : (x + 1).val =
 
 private lemma zmod_val_add_one (d : ℕ) [NeZero d] (i : ZMod d) :
     (i + 1).val = if i.val + 1 < d then i.val + 1 else 0 := by
-  rw [ZMod.val_add_one]; split_ifs with h
+  rw [ZMod.val_add_one]
+  split_ifs with h
   · exact Nat.mod_eq_of_lt h
   · grind [Nat.mod_self]
 
@@ -100,7 +101,8 @@ private lemma addOrderOf_b_eq [NeZero m] :
   · have : (b : ZMod m) = (b.natAbs : ZMod m) := by rw [h]; simp
     grind
   · have : (b : ZMod m) = -(b.natAbs : ZMod m) := by rw [h]; simp
-    rw [this, addOrderOf_neg]; exact key
+    rw [this, addOrderOf_neg]
+    exact key
 
 private lemma d₁_dvd_b : (d₁ : ℤ) ∣ b :=
   Int.natCast_dvd.mpr (Nat.gcd_dvd_left b.natAbs m)
@@ -198,7 +200,10 @@ private lemma cycle_index_shift_ba [NeZero m]
     ZMod.castHom d₁_dvd_m (ZMod d₁) (x + ↑(b - a)) * u⁻¹ =
     ZMod.castHom d₁_dvd_m (ZMod d₁) x * u⁻¹ + 1 := by
   simp only [map_add, map_intCast, add_mul]
-  rw [← hu]; ring_nf; rw [u.inv_mul]; ring
+  rw [← hu]
+  ring_nf
+  rw [u.inv_mul]
+  ring
 
 /-- If Φ(i, j+1) = Φ(i, j) + b, then Φ⁻¹(x+b) = (same_i, j+1). -/
 private lemma equiv_symm_shift_b {γ : Type*} [AddCommMonoid γ]
@@ -396,8 +401,10 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
       have h := Nat.dvd_sub hd₂_dvd_e₁ hd₂_dvd_diff
       have : e₁ - (e₁ - 2) = 2 := by grind
       rwa [this] at h
-    obtain ⟨_, hk⟩ := hd₂_dvd_e₁; obtain ⟨_, hl⟩ := he1_odd
-    have := Nat.le_of_dvd (by grind) hd₂_dvd_2; grind
+    obtain ⟨_, hk⟩ := hd₂_dvd_e₁
+    obtain ⟨_, hl⟩ := he1_odd
+    have := Nat.le_of_dvd (by grind) hd₂_dvd_2
+    grind
   -- π(n) and π(n+(b-a)) give the same ZMod d₂ value
   have hπ_eq : ∀ n : ZMod m, π (n + ↑(b - a)) = π n := fun n => by
     simp only [π, map_add, map_intCast]
@@ -441,14 +448,16 @@ private lemma cover_mod3_general (p₁ p₂ : Fin 3) (j₁ j₂ : ℕ)
 private lemma case2c_nonwrap_hyp (d k₀ i j : ℕ) (hd : d ≥ 3)
     (hd_odd : Odd d) (hi : i + 1 < d) : (j + (case2c_pattern d k₀ i).val) % 3 ≠
     (j + (case2c_pattern d k₀ (i + 1)).val) % 3 := by
-  obtain ⟨k, hk⟩ := hd_odd; subst hk
+  obtain ⟨k, hk⟩ := hd_odd
+  subst hk
   grind [case2c_pattern]
 
 -- Wrap coverage hypothesis: j₂ = j₁ + k₀, pattern chosen to avoid conflict.
 private lemma case2c_wrap_hyp (d k₀ j : ℕ) (hd : d ≥ 3) (hd_odd : Odd d) :
     (j + (case2c_pattern d k₀ (d - 1)).val) % 3 ≠
     (j + k₀ + (case2c_pattern d k₀ 0).val) % 3 := by
-  obtain ⟨k, hk⟩ := hd_odd; subst hk
+  obtain ⟨k, hk⟩ := hd_odd
+  subst hk
   grind [case2c_pattern]
 
 /-! ### Subcase (2d): d₁, e₁ both odd, e₁ ≥ 19
@@ -650,7 +659,8 @@ private lemma case2d_rotation_sum_exists {e d : ℕ} [NeZero d]
   have hu_lt : case2d_u e < e := by grind [case2d_u]
   have hdw' : d * (e - 2 * case2d_u e) ≥ e := by
     change d * (e - 2 * (e / 3 + e % 3)) ≥ e
-    obtain ⟨k, hk⟩ := he_odd; subst hk
+    obtain ⟨k, hk⟩ := he_odd
+    subst hk
     have h5w : 5 * ((2 * k + 1) - 2 * ((2 * k + 1) / 3 + (2 * k + 1) % 3)) ≥ 2 * k + 1 := by grind
     exact le_trans h5w (by gcongr)
   set u := case2d_u e
@@ -739,7 +749,8 @@ private lemma zmod_filter_sum_last {n : ℕ} [NeZero n] (f : ZMod n → ℕ) (i 
 /-- Position shift by 1: adding 1 to ZMod coordinate shifts position by 1 mod n. -/
 private lemma pos_shift_one {n : ℕ} [NeZero n] (j : ZMod n) (c : ℕ) :
     ((j + 1).val + c) % n = ((j.val + c) % n + 1) % n := by
-  rw [ZMod.val_add_one, Nat.mod_add_mod, Nat.mod_add_mod]; grind
+  rw [ZMod.val_add_one, Nat.mod_add_mod, Nat.mod_add_mod]
+  grind
 
 /-- (j + (S + V) % n) % n = ((j + S % n) % n + V) % n -/
 private lemma pos_shift_succ' (j S V n : ℕ) :
@@ -808,7 +819,8 @@ private lemma case2d_coloring_works (hm : m ≥ 289)
         orbitEquiv_snd_shift_ba_wrap he1_b_zero k₀ hk₀ n hi_eq
       rw [hj'_eq]
       have hi1_zero : (i + 1 : ZMod d₁) = 0 := by
-        apply ZMod.val_injective; rw [ZMod.val_add_one, hi_eq, ZMod.val_zero]
+        apply ZMod.val_injective
+        rw [ZMod.val_add_one, hi_eq, ZMod.val_zero]
         grind [Nat.mod_self]
       have hrot0 : rot (0 : ZMod d₁) = 0 := by simp [rot, ZMod.val_zero]
       rw [hi1_zero, hrot0, Nat.add_zero, ZMod.val_add, Nat.mod_mod_of_dvd _ (dvd_refl e₁)]
@@ -875,13 +887,18 @@ lemma case_two_odd_small (hm : m ≥ 289)
         exact Fin.ext (by simp [f, ZMod.val_add_one, case2c_mod3 he1_div3])
       · right; right; left; rw [h]
         have hi1_val : (i + 1).val = 0 := by
-          rw [ZMod.val_add_one, hi_eq]; grind [Nat.mod_self]
-        refine Fin.ext ?_; simp only [f, hi1_val]
-        rw [hj'_val]; exact (case2c_mod3 he1_div3 (j.val + k₀.val) p₀.val).symm
+          rw [ZMod.val_add_one, hi_eq]
+          grind [Nat.mod_self]
+        refine Fin.ext ?_
+        simp only [f, hi1_val]
+        rw [hj'_val]
+        exact (case2c_mod3 he1_div3 (j.val + k₀.val) p₀.val).symm
       · right; right; right; rw [h]
         have hi1_val : (i + 1).val = 0 := by
-          rw [ZMod.val_add_one, hi_eq]; grind [Nat.mod_self]
-        refine Fin.ext ?_; simp only [f, hi1_val, ZMod.val_add_one]
+          rw [ZMod.val_add_one, hi_eq]
+          grind [Nat.mod_self]
+        refine Fin.ext ?_
+        simp only [f, hi1_val, ZMod.val_add_one]
         rw [hj'_val, show (↑p₀ : ℕ) = ↑(case2c_pattern d₁ k₀.val 0) from rfl]
         simp only [case2c_mod3 he1_div3, Nat.add_assoc])
 

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -70,7 +70,7 @@ private lemma color_covers_even (d₁ e₁ : ℕ) [NeZero d₁] [NeZero e₁] (h
 /-! ### Orbit coloring framework -/
 
 section OrbitFramework
-variable {d₁ e₁ : ℕ} [NeZero m]
+variable {d₁ e₁ : ℕ}
 
 /--
 The orbit map $\phi : \mathbb{Z}_{d_1} \times \mathbb{Z}_{e_1} \to \mathbb{Z}_m$ defined by
@@ -80,7 +80,6 @@ It provides the coordinate system used to analyze the "Multiple Cycles" case.
 private def orbitMap (m : ℕ) (a b : ℤ) : ZMod d₁ × ZMod e₁ → ZMod m :=
   fun p => (p.1.val : ZMod m) * ↑(b - a) + (p.2.val : ZMod m) * ↑b
 
-omit [NeZero m] in
 private lemma addOrderOf_b_eq (hm : 0 < m)
     (hd1_def : Nat.gcd b.natAbs m = d₁) :
     addOrderOf (b : ZMod m) = m / d₁ := by
@@ -92,19 +91,16 @@ private lemma addOrderOf_b_eq (hm : 0 < m)
   · have : (b : ZMod m) = -(b.natAbs : ZMod m) := by rw [h]; simp
     rw [this, addOrderOf_neg]; exact key
 
-omit [NeZero m] in
 private lemma b_zero_mod_d1
     (hd1_def : Nat.gcd b.natAbs m = d₁) [NeZero d₁] : (b : ZMod d₁) = 0 := by
   rw [ZMod.intCast_zmod_eq_zero_iff_dvd]
   exact Int.natCast_dvd.mpr (hd1_def ▸ Nat.gcd_dvd_left b.natAbs m)
 
-omit [NeZero m] in
 private lemma ba_coprime_d1 (hd1_dvd : d₁ ∣ m)
     (h_gcd_coprime : d₁.gcd (Nat.gcd (b - a).natAbs m) = 1) : Nat.Coprime (b - a).natAbs d₁ :=
   Nat.dvd_one.mp (h_gcd_coprime ▸ Nat.dvd_gcd (Nat.gcd_dvd_right _ _)
       (Nat.dvd_gcd (Nat.gcd_dvd_left _ _) (dvd_trans (Nat.gcd_dvd_right _ _) hd1_dvd)))
 
-omit [NeZero m] in
 private lemma orbitMap_i_eq [NeZero d₁]
     (hd1_dvd : d₁ ∣ m) (hb_zero : (b : ZMod d₁) = 0)
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) {i₁ i₂ : ZMod d₁} {j₁ j₂ : ZMod e₁}
@@ -130,7 +126,7 @@ private lemma orbitMap_j_eq [NeZero e₁]
       (by grind [j₁.val_lt (n := e₁), j₂.val_lt (n := e₁)])
     exact ZMod.val_injective _ (by grind)
 
-private lemma orbitMap_injective
+private lemma orbitMap_injective [NeZero m]
     (hm_eq : m = d₁ * e₁) (hb_zero : (b : ZMod d₁) = 0)
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
     (hord : addOrderOf (b : ZMod m) = e₁) :
@@ -145,7 +141,7 @@ private lemma orbitMap_injective
   have hj_smul : (j₁.val : ℕ) • (b : ZMod m) = (j₂.val : ℕ) • (b : ZMod m) := by grind
   exact Prod.ext rfl (orbitMap_j_eq hord hj_smul)
 
-private lemma orbitMap_bijective
+private lemma orbitMap_bijective [NeZero m]
     (hm_eq : m = d₁ * e₁) (hb_zero : (b : ZMod d₁) = 0)
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
     (hord : addOrderOf (b : ZMod m) = e₁) :
@@ -156,7 +152,6 @@ private lemma orbitMap_bijective
     ⟨orbitMap_injective hm_eq hb_zero hba_unit hord,
      by simp [Fintype.card_prod, ZMod.card, hm_eq]⟩
 
-omit [NeZero m] in
 private lemma orbitMap_shift_b [NeZero e₁]
     (he1_b_zero : e₁ • (b : ZMod m) = 0) :
     ∀ p : ZMod d₁ × ZMod e₁,
@@ -175,7 +170,6 @@ private lemma orbitMap_shift_b [NeZero e₁]
       rw [this, hje, he1_b_zero]
     rw [hv, Nat.cast_zero, zero_mul, add_zero, add_assoc, h1, add_zero]
 
-omit [NeZero m] in
 private lemma orbitMap_shift_ba [NeZero d₁]
     (i : ZMod d₁) (j : ZMod e₁) (hi : i.val + 1 < d₁) :
     orbitMap m a b (i, j) + ((b - a : ℤ) : ZMod m) = orbitMap m a b (i + 1, j) := by
@@ -184,7 +178,6 @@ private lemma orbitMap_shift_ba [NeZero d₁]
   rw [this]
   grind
 
-omit [NeZero m] in
 /-- The cycle index α(x) = castHom(x) * u⁻¹ satisfies α(φ(i,j)) = i. -/
 private lemma orbitMap_cycle_index [NeZero d₁]
     (hd1_dvd : d₁ ∣ m) (hb_zero : (b : ZMod d₁) = 0)
@@ -195,7 +188,6 @@ private lemma orbitMap_cycle_index [NeZero d₁]
     map_natCast, map_intCast, hb_zero, mul_zero, add_zero, mul_assoc, ← hu, u.mul_inv, mul_one]
   simp [ZMod.natCast_val]
 
-omit [NeZero m] in
 /-- The cycle index α shifts by 1 when (b-a) is added. -/
 private lemma cycle_index_shift_ba [NeZero d₁]
     (hd1_dvd : d₁ ∣ m) (u : (ZMod d₁)ˣ) (hu : ↑u = ((b - a : ℤ) : ZMod d₁)) (x : ZMod m) :
@@ -204,26 +196,24 @@ private lemma cycle_index_shift_ba [NeZero d₁]
   simp only [map_add, map_intCast, add_mul]
   rw [← hu]; ring_nf; rw [u.inv_mul]; ring
 
-omit [NeZero m] in
 /-- If Φ(i, j+1) = Φ(i, j) + b, then Φ⁻¹(x+b) = (same_i, j+1). -/
 private lemma equiv_symm_shift_b {γ : Type*} [AddCommMonoid γ]
     (Φ : ZMod d₁ × ZMod e₁ ≃ γ) {b : γ}
     (hΦ : ∀ i : ZMod d₁, ∀ j : ZMod e₁, Φ (i, j + 1) = Φ (i, j) + b) (x : γ) :
     Φ.symm (x + b) = ((Φ.symm x).1, (Φ.symm x).2 + 1) := by grind
 
-omit [NeZero m] in
 /-- If α(Φ(i,j)) = i for all i,j, then (Φ⁻¹(x)).1 = α(x). -/
 private lemma equiv_symm_fst_eq {γ : Type*}
     (Φ : ZMod d₁ × ZMod e₁ ≃ γ) (α : γ → ZMod d₁)
     (hα : ∀ i : ZMod d₁, ∀ j : ZMod e₁, α (Φ (i, j)) = i) (x : γ) : (Φ.symm x).1 = α x := by grind
 
 /-- Build the orbit equivalence from the standard hypotheses. -/
-private noncomputable def orbitEquiv (hm_eq : m = d₁ * e₁)
+private noncomputable def orbitEquiv [NeZero m] (hm_eq : m = d₁ * e₁)
     (hb_zero : (b : ZMod d₁) = 0) (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
     (hord : addOrderOf (b : ZMod m) = e₁) : ZMod d₁ × ZMod e₁ ≃ ZMod m :=
   Equiv.ofBijective (orbitMap m a b) (orbitMap_bijective hm_eq hb_zero hba_unit hord)
 
-private lemma orbitEquiv_shift_b {hm_eq : m = d₁ * e₁}
+private lemma orbitEquiv_shift_b [NeZero m] {hm_eq : m = d₁ * e₁}
     {hb_zero : (b : ZMod d₁) = 0} {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
     {hord : addOrderOf (b : ZMod m) = e₁} (x : ZMod m) :
     (orbitEquiv hm_eq hb_zero hba_unit hord).symm (x + ↑b) =
@@ -233,7 +223,7 @@ private lemma orbitEquiv_shift_b {hm_eq : m = d₁ * e₁}
   exact equiv_symm_shift_b _ (fun i j =>
     (orbitMap_shift_b (hord ▸ addOrderOf_nsmul_eq_zero _) (i, j)).symm) x
 
-private lemma orbitEquiv_cycle_shift {hm_eq : m = d₁ * e₁}
+private lemma orbitEquiv_cycle_shift [NeZero m] {hm_eq : m = d₁ * e₁}
     {hb_zero : (b : ZMod d₁) = 0} {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
     {hord : addOrderOf (b : ZMod m) = e₁} (x : ZMod m) :
     ((orbitEquiv hm_eq hb_zero hba_unit hord).symm (x + ↑(b - a))).1 =
@@ -251,7 +241,6 @@ private lemma orbitEquiv_cycle_shift {hm_eq : m = d₁ * e₁}
   congr 1
   exact (hΦ_cycle x).symm
 
-omit [NeZero m] in
 /-- **Key infrastructure for Case 2.** Polychromaticity from an orbit coloring:
     given an orbit equivalence Φ with shift properties and a coloring f,
     if f covers all colors at any translate, then f ∘ Φ.symm is polychromatic.
@@ -286,7 +275,6 @@ private lemma orbit_coloring_polychrom
 
 /-! ### Subcase (2a): e₁ even -/
 
-omit [NeZero m] in
 /-- **Subcase (2a).** $e_1$ is even. Each cycle uses two alternating colors;
     adjacent cycles skip different colors. The simplest of the four subcases. -/
 lemma case_two_e1_even (hm : m ≥ 289)
@@ -347,7 +335,6 @@ private lemma case2b_coverage_gen (d₁ e₁ : ℕ) [NeZero d₁] [NeZero e₁]
 
 /-! ### Subcase (2b) main lemma -/
 
-omit [NeZero m] in
 /-- **Subcase (2b).** $d_1$ is even and $e_1$ is odd.
     Alternating patterns with a "degenerate" position fixup at different positions
     for even and odd cycles, ensuring they do not overlap across adjacent cycles. -/
@@ -588,7 +575,7 @@ private lemma basePattern_rotation_covers {e₁ j : ℕ} (he : Odd e₁) (hge : 
       simp_all [intervalColors, Finset.mem_insert, Finset.mem_singleton]
   grind
 
-private lemma case2d_wrap_shift [NeZero d₁] [NeZero e₁]
+private lemma case2d_wrap_shift [NeZero m] [NeZero d₁] [NeZero e₁]
     (hd1_dvd : d₁ ∣ m) (hb_zero : (b : ZMod d₁) = 0)
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)) (hord : addOrderOf (b : ZMod m) = e₁)
     (hm_eq : m = d₁ * e₁) :
@@ -614,7 +601,6 @@ private lemma case2d_wrap_shift [NeZero d₁] [NeZero e₁]
   simp only [hq_i, ZMod.val_zero, Nat.cast_zero, zero_mul, zero_add] at hφq
   grind
 
-omit [NeZero m] in
 private lemma case2d_shift_ba_wrap [NeZero e₁] [NeZero d₁]
     (he1_b_zero : e₁ • (b : ZMod m) = 0) (k₀ : ZMod e₁)
     (hk₀ : (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m))
@@ -754,7 +740,6 @@ private lemma pos_shift_wrap' (j S V k₀ n : ℕ) (hsum : (S + V) % n = k₀ % 
     (j + k₀) % n = ((j + S % n) % n + V) % n := by
   rw [← Nat.add_mod_mod j k₀ n, ← hsum, pos_shift_succ']
 
-omit [NeZero m] in
 /-- **Subcase (2d) assembled.** Constructs the coloring for the case when both d₁
     and e₁ are odd with e₁ ≥ 19, using rotated interval patterns. -/
 private lemma case2d_coloring_works (hm : m ≥ 289)
@@ -851,7 +836,6 @@ private lemma case2d_coloring_works (hm : m ≥ 289)
 private lemma case2c_mod3 (h3e : 3 ∣ e₁) (x y : ℕ) : (x % e₁ + y) % 3 = (x + y) % 3 := by
   rw [Nat.add_mod, Nat.mod_mod_of_dvd x h3e, ← Nat.add_mod]
 
-omit [NeZero m] in
 /-- **Subcase (2c):** d₁ and e₁ are both odd, with e₁ ≤ 17 and 3 ∣ e₁.
     Uses shifted periodic 012-patterns with different shifts for adjacent cycles. -/
 lemma case_two_odd_small (hm : m ≥ 289)
@@ -973,7 +957,6 @@ private lemma no_both_e_small {m d₁ d₂ : ℕ} (hm : m ≥ 289) (hcop : Nat.g
 
 /-! ### Aggregation of Case 2 -/
 
-omit [NeZero m] in
 /-- **Main Case 2 (Multiple Cycles).** Aggregates all subcases (2a)–(2d).
     First applies WLOG to ensure 3 ∤ d₁, then dispatches on parity of d₁ and e₁. -/
 lemma main_case_two (hm : m ≥ 289)

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -26,6 +26,9 @@ section Case2_MultipleCycles
 
 variable {m : ℕ} {a b : ℤ}
 
+local notation "d₁" => Nat.gcd b.natAbs m
+local notation "e₁" => m / d₁
+
 /-! ### Arithmetic helpers for cycle decomposition
 
 These lemmas set up the orbit map infrastructure. They are not important individually
@@ -52,25 +55,24 @@ A coloring for Case 2a ($e_1$ even).
 Each cycle $i$ uses two colors that alternate based on position parity.
 Cycles are assigned "missing colors" such that no two adjacent cycles miss the same color.
 -/
-private def cycle_coloring (d₁ e₁ : ℕ) : ZMod d₁ × ZMod e₁ → Fin 3 := fun ⟨i, j⟩ =>
-  if i.val = d₁ - 1 ∧ ¬Even d₁ then ⟨1 + j.val % 2, by grind⟩
+private def cycle_coloring (d e : ℕ) : ZMod d × ZMod e → Fin 3 := fun ⟨i, j⟩ =>
+  if i.val = d - 1 ∧ ¬Even d then ⟨1 + j.val % 2, by grind⟩
   else if i.val % 2 = 0 then ⟨j.val % 2, by grind⟩
   else ⟨2 * (j.val % 2), by grind⟩
 
 -- Coverage: adjacent cycles cover all 3 colors.
-private lemma color_covers_even (d₁ e₁ : ℕ) [NeZero d₁] [NeZero e₁] (hd₁_ge2 : d₁ ≥ 2)
-    (hparity : ∀ j : ZMod e₁, j.val % 2 ≠ (j + 1).val % 2)
-    (i : ZMod d₁) (j₁ j₂ : ZMod e₁) (k : Fin 3) :
-    k = cycle_coloring d₁ e₁ (i, j₁) ∨
-    k = cycle_coloring d₁ e₁ (i, j₁ + 1) ∨
-    k = cycle_coloring d₁ e₁ (i + 1, j₂) ∨
-    k = cycle_coloring d₁ e₁ (i + 1, j₂ + 1) := by
+private lemma color_covers_even (d e : ℕ) [NeZero d] [NeZero e] (hd_ge2 : d ≥ 2)
+    (hparity : ∀ j : ZMod e, j.val % 2 ≠ (j + 1).val % 2)
+    (i : ZMod d) (j₁ j₂ : ZMod e) (k : Fin 3) :
+    k = cycle_coloring d e (i, j₁) ∨
+    k = cycle_coloring d e (i, j₁ + 1) ∨
+    k = cycle_coloring d e (i + 1, j₂) ∨
+    k = cycle_coloring d e (i + 1, j₂ + 1) := by
   grind [cycle_coloring, Fin.ext_iff, zmod_val_add_one]
 
 /-! ### Orbit coloring framework -/
 
 section OrbitFramework
-variable {d₁ e₁ : ℕ}
 
 /--
 The orbit map $\phi : \mathbb{Z}_{d_1} \times \mathbb{Z}_{e_1} \to \mathbb{Z}_m$ defined by
@@ -97,7 +99,8 @@ private lemma b_zero_mod_d1
   exact Int.natCast_dvd.mpr (hd1_def ▸ Nat.gcd_dvd_left b.natAbs m)
 
 private lemma ba_coprime_d1 (hd1_dvd : d₁ ∣ m)
-    (h_gcd_coprime : d₁.gcd (Nat.gcd (b - a).natAbs m) = 1) : Nat.Coprime (b - a).natAbs d₁ :=
+    (h_gcd_coprime : Nat.gcd d₁ (Nat.gcd (b - a).natAbs m) = 1) :
+    Nat.Coprime (b - a).natAbs d₁ :=
   Nat.dvd_one.mp (h_gcd_coprime ▸ Nat.dvd_gcd (Nat.gcd_dvd_right _ _)
       (Nat.dvd_gcd (Nat.gcd_dvd_left _ _) (dvd_trans (Nat.gcd_dvd_right _ _) hd1_dvd)))
 
@@ -123,7 +126,7 @@ private lemma orbitMap_j_eq [NeZero e₁]
       add_left_cancel (a := j₁.val • (b : ZMod m))
         (by rw [add_zero, ← add_nsmul, Nat.add_sub_cancel' h]; exact hj_smul.symm)
     have := Nat.eq_zero_of_dvd_of_lt (hord ▸ addOrderOf_dvd_of_nsmul_eq_zero h3)
-      (by grind [j₁.val_lt (n := e₁), j₂.val_lt (n := e₁)])
+      (by grind [ZMod.val_lt j₁, ZMod.val_lt j₂])
     exact ZMod.val_injective _ (by grind)
 
 private lemma orbitMap_injective [NeZero m]
@@ -131,9 +134,9 @@ private lemma orbitMap_injective [NeZero m]
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
     (hord : addOrderOf (b : ZMod m) = e₁) :
     Function.Injective (orbitMap m a b : ZMod d₁ × ZMod e₁ → ZMod m) := by
-  have hd1_dvd : d₁ ∣ m := hm_eq ▸ dvd_mul_right d₁ e₁
-  haveI : NeZero d₁ := ⟨by rintro rfl; exact absurd (by simp [hm_eq]) (NeZero.ne m)⟩
-  haveI : NeZero e₁ := ⟨by rintro rfl; exact absurd (by simp [hm_eq]) (NeZero.ne m)⟩
+  have hd1_dvd : d₁ ∣ m := Nat.gcd_dvd_right _ _
+  haveI : NeZero d₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, zero_mul]) (NeZero.ne m)⟩
+  haveI : NeZero e₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, mul_zero]) (NeZero.ne m)⟩
   intro ⟨i₁, j₁⟩ ⟨i₂, j₂⟩ heq
   have hi := orbitMap_i_eq hd1_dvd hb_zero hba_unit heq
   subst hi
@@ -146,11 +149,11 @@ private lemma orbitMap_bijective [NeZero m]
     (hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁))
     (hord : addOrderOf (b : ZMod m) = e₁) :
     Function.Bijective (orbitMap m a b : ZMod d₁ × ZMod e₁ → ZMod m) := by
-  haveI : NeZero d₁ := ⟨by rintro rfl; exact absurd (by simp [hm_eq]) (NeZero.ne m)⟩
-  haveI : NeZero e₁ := ⟨by rintro rfl; exact absurd (by simp [hm_eq]) (NeZero.ne m)⟩
+  haveI : NeZero d₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, zero_mul]) (NeZero.ne m)⟩
+  haveI : NeZero e₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, mul_zero]) (NeZero.ne m)⟩
   exact (Fintype.bijective_iff_injective_and_card _).mpr
     ⟨orbitMap_injective hm_eq hb_zero hba_unit hord,
-     by simp [Fintype.card_prod, ZMod.card, hm_eq]⟩
+     by simp only [Fintype.card_prod, ZMod.card]; linarith [hm_eq]⟩
 
 private lemma orbitMap_shift_b [NeZero e₁]
     (he1_b_zero : e₁ • (b : ZMod m) = 0) :
@@ -219,7 +222,7 @@ private lemma orbitEquiv_shift_b [NeZero m] {hm_eq : m = d₁ * e₁}
     (orbitEquiv hm_eq hb_zero hba_unit hord).symm (x + ↑b) =
     (((orbitEquiv hm_eq hb_zero hba_unit hord).symm x).1,
      ((orbitEquiv hm_eq hb_zero hba_unit hord).symm x).2 + 1) := by
-  haveI : NeZero e₁ := ⟨by rintro rfl; exact absurd (by simp [hm_eq]) (NeZero.ne m)⟩
+  haveI : NeZero e₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, mul_zero]) (NeZero.ne m)⟩
   exact equiv_symm_shift_b _ (fun i j =>
     (orbitMap_shift_b (hord ▸ addOrderOf_nsmul_eq_zero _) (i, j)).symm) x
 
@@ -228,8 +231,8 @@ private lemma orbitEquiv_cycle_shift [NeZero m] {hm_eq : m = d₁ * e₁}
     {hord : addOrderOf (b : ZMod m) = e₁} (x : ZMod m) :
     ((orbitEquiv hm_eq hb_zero hba_unit hord).symm (x + ↑(b - a))).1 =
     ((orbitEquiv hm_eq hb_zero hba_unit hord).symm x).1 + 1 := by
-  have hd1_dvd : d₁ ∣ m := hm_eq ▸ dvd_mul_right d₁ e₁
-  haveI : NeZero d₁ := ⟨by rintro rfl; exact absurd (by simp [hm_eq]) (NeZero.ne m)⟩
+  have hd1_dvd : d₁ ∣ m := Nat.gcd_dvd_right _ _
+  haveI : NeZero d₁ := ⟨by intro h; exact absurd (by rw [hm_eq, h, zero_mul]) (NeZero.ne m)⟩
   let u_ba := hba_unit.choose
   have hu_ba : ↑u_ba = ((b - a : ℤ) : ZMod d₁) := hba_unit.choose_spec
   let α : ZMod m → ZMod d₁ := fun x => ZMod.castHom hd1_dvd (ZMod d₁) x * u_ba⁻¹
@@ -251,7 +254,7 @@ private lemma orbitEquiv_snd_shift_ba [NeZero m] [NeZero d₁]
     ((orbitEquiv hm_eq hb_zero hba_unit hord).symm n).2 := by
   set Φ := orbitEquiv hm_eq hb_zero hba_unit hord
   set i := (Φ.symm n).1; set j := (Φ.symm n).2
-  have hshift := @orbitMap_shift_ba m a b d₁ e₁ ‹NeZero d₁› i j hi
+  have hshift := orbitMap_shift_ba (a := a) i j hi
   have hn : Φ (i, j) = n := Prod.eta (Φ.symm n) ▸ Equiv.apply_symm_apply Φ n
   have hΦ : Φ (i + 1, j) = n + ↑(b - a) := by
     simp only [Φ, orbitEquiv, Equiv.ofBijective_apply] at hn ⊢
@@ -301,8 +304,6 @@ lemma case_two_e1_even (hm : m ≥ 289)
     (h_min : min (Nat.gcd b.natAbs m) (Nat.gcd (b - a).natAbs m) > 1)
     (he1_even : Even (m / Nat.gcd b.natAbs m)) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
-  set d₁ := Nat.gcd b.natAbs m with hd₁_def
-  set e₁ := m / d₁ with he₁_def
   have hd₁_dvd : d₁ ∣ m := Nat.gcd_dvd_right _ _
   have hm_eq : m = d₁ * e₁ := (Nat.mul_div_cancel' hd₁_dvd).symm
   have he₁_ge2 : e₁ ≥ 2 := by
@@ -334,22 +335,22 @@ are distinct, guaranteeing every 2×2 block contains all three colors.
 -- The coloring function for Case 2b.
 -- Even cycles: 01010...011 (alternating 0,1, last position overridden to 1)
 -- Odd cycles: 22020...020 (first position 2, then: even→0, odd→2)
-private def case2b_coloring (d₁ e₁ : ℕ) : ZMod d₁ × ZMod e₁ → Fin 3 := fun ⟨i, j⟩ =>
+private def case2b_coloring (d e : ℕ) : ZMod d × ZMod e → Fin 3 := fun ⟨i, j⟩ =>
   if i.val % 2 = 0 -- even cycle
-  then if j.val = e₁ - 1 then 1 else if j.val % 2 = 0 then 0 else 1
+  then if j.val = e - 1 then 1 else if j.val % 2 = 0 then 0 else 1
   else if j.val = 0 then 2 else if j.val % 2 = 0 then 0 else 2 -- odd cycle
 
 -- Coverage — any 2×2 block covers all 3 colors.
 -- The compatibility says degenerate positions can't coincide:
 -- odd-degenerate at j=0 and even-degenerate at j=e₁-2 are incompatible.
-private lemma case2b_coverage_gen (d₁ e₁ : ℕ) [NeZero d₁] [NeZero e₁]
-    (hd₁_even : Even d₁) (he₁_odd : Odd e₁) (he₁ : e₁ ≥ 3) (i : ZMod d₁) (j₁ j₂ : ZMod e₁)
-    (h_compat : j₁.val = 0 → j₂.val ≠ e₁ - 2) (h_compat' : j₂.val = 0 → j₁.val ≠ e₁ - 2)
+private lemma case2b_coverage_gen (d e : ℕ) [NeZero d] [NeZero e]
+    (hd_even : Even d) (he_odd : Odd e) (he_ge3 : e ≥ 3) (i : ZMod d) (j₁ j₂ : ZMod e)
+    (h_compat : j₁.val = 0 → j₂.val ≠ e - 2) (h_compat' : j₂.val = 0 → j₁.val ≠ e - 2)
     (k : Fin 3) :
-    k = case2b_coloring d₁ e₁ (i, j₁) ∨
-    k = case2b_coloring d₁ e₁ (i, j₁ + 1) ∨
-    k = case2b_coloring d₁ e₁ (i + 1, j₂) ∨
-    k = case2b_coloring d₁ e₁ (i + 1, j₂ + 1) := by
+    k = case2b_coloring d e (i, j₁) ∨
+    k = case2b_coloring d e (i, j₁ + 1) ∨
+    k = case2b_coloring d e (i + 1, j₂) ∨
+    k = case2b_coloring d e (i + 1, j₂ + 1) := by
   grind [case2b_coloring, Fin.ext_iff, zmod_val_add_one, parity_flip_even]
 
 /-! ### Subcase (2b) main lemma -/
@@ -362,8 +363,6 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
     (h_min : min (Nat.gcd b.natAbs m) (Nat.gcd (b - a).natAbs m) > 1)
     (hd1_even : Even (Nat.gcd b.natAbs m)) (he1_odd : Odd (m / Nat.gcd b.natAbs m)) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
-  set d₁ := Nat.gcd b.natAbs m with hd₁_def
-  set e₁ := m / d₁ with he₁_def
   have hd₁_dvd : d₁ ∣ m := Nat.gcd_dvd_right _ _
   have hm_eq : m = d₁ * e₁ := (Nat.mul_div_cancel' hd₁_dvd).symm
   -- e₁ ≥ 3: e₁ is odd and e₁ = 1 would give d₁ = m, contradicting gcd(d₁,d₂) = 1
@@ -371,7 +370,8 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
     by_contra! h
     rcases (by grind : e₁ = 1 ∨ e₁ = 2) with he | he
     · have : Nat.gcd (b - a).natAbs m ∣ d₁ := by
-        rw [hm_eq, he, mul_one]; exact Nat.gcd_dvd_right _ _
+        have : m = d₁ := by have := hm_eq; rw [he, mul_one] at this; exact this
+        rw [← this]; exact Nat.gcd_dvd_right _ _
       exact absurd (Nat.eq_one_of_dvd_one
         (h_gcd_coprime ▸ Nat.dvd_gcd this (dvd_refl _))) (by grind)
     · grind
@@ -443,8 +443,8 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
 -- Pattern assignment for Case 2c, parametrized by k₀ (the wrap shift).
 -- Variant A (k₀ % 3 ≠ 2): even→0, odd→1, last→2.
 -- Variant B (k₀ % 3 = 2): even→0, odd→2, last→1.
-private def case2c_pattern (d₁ k₀ i : ℕ) : Fin 3 :=
-  if i = d₁ - 1 ∧ d₁ % 2 = 1 then if k₀ % 3 = 2 then 1 else 2
+private def case2c_pattern (d k₀ i : ℕ) : Fin 3 :=
+  if i = d - 1 ∧ d % 2 = 1 then if k₀ % 3 = 2 then 1 else 2
   else if i % 2 = 0 then 0
   else if k₀ % 3 = 2 then 2 else 1
 
@@ -460,17 +460,17 @@ private lemma cover_mod3_general (p₁ p₂ : Fin 3) (j₁ j₂ : ℕ)
   grind [Fin.ext_iff]
 
 -- Non-wrap coverage hypothesis: j₁ = j₂, patterns differ → hypothesis holds.
-private lemma case2c_nonwrap_hyp (d₁ k₀ i j : ℕ) (hd₁ : d₁ ≥ 3)
-    (hd₁_odd : Odd d₁) (hi : i + 1 < d₁) : (j + (case2c_pattern d₁ k₀ i).val) % 3 ≠
-    (j + (case2c_pattern d₁ k₀ (i + 1)).val) % 3 := by
-  obtain ⟨k, hk⟩ := hd₁_odd; subst hk
+private lemma case2c_nonwrap_hyp (d k₀ i j : ℕ) (hd : d ≥ 3)
+    (hd_odd : Odd d) (hi : i + 1 < d) : (j + (case2c_pattern d k₀ i).val) % 3 ≠
+    (j + (case2c_pattern d k₀ (i + 1)).val) % 3 := by
+  obtain ⟨k, hk⟩ := hd_odd; subst hk
   grind [case2c_pattern]
 
 -- Wrap coverage hypothesis: j₂ = j₁ + k₀, pattern chosen to avoid conflict.
-private lemma case2c_wrap_hyp (d₁ k₀ j : ℕ) (hd₁ : d₁ ≥ 3) (hd₁_odd : Odd d₁) :
-    (j + (case2c_pattern d₁ k₀ (d₁ - 1)).val) % 3 ≠
-    (j + k₀ + (case2c_pattern d₁ k₀ 0).val) % 3 := by
-  obtain ⟨k, hk⟩ := hd₁_odd; subst hk
+private lemma case2c_wrap_hyp (d k₀ j : ℕ) (hd : d ≥ 3) (hd_odd : Odd d) :
+    (j + (case2c_pattern d k₀ (d - 1)).val) % 3 ≠
+    (j + k₀ + (case2c_pattern d k₀ 0).val) % 3 := by
+  obtain ⟨k, hk⟩ := hd_odd; subst hk
   grind [case2c_pattern]
 
 /-! ### Subcase (2d): d₁, e₁ both odd, e₁ ≥ 19
@@ -484,29 +484,29 @@ verifying the rotation property; the important result is `case2d_coloring_works`
 /-- Partition parameter: first interval size for case 2d.
     u = e₁/3 + e₁%3 (i.e. k+r where e₁ = 3k+r).
     For e₁ odd: r=0 → u=k (odd), r=1 → u=k+1 (odd), r=2 → u=k+2 (odd). -/
-private def case2d_u (e₁ : ℕ) : ℕ := e₁ / 3 + e₁ % 3
+private def case2d_u (e : ℕ) : ℕ := e / 3 + e % 3
 
 /-- Second interval size for case 2d.
     v = e₁/3 + (1 if e₁%3 = 1 else 0).
     r=0: v = k   r=1: v = k+1   r=2: v = k -/
-private def case2d_v (e₁ : ℕ) : ℕ := if e₁ % 3 = 1 then e₁ / 3 + 1 else e₁ / 3
+private def case2d_v (e : ℕ) : ℕ := if e % 3 = 1 then e / 3 + 1 else e / 3
 
-private lemma case2d_uv_le (hge : e₁ ≥ 19) : case2d_u e₁ + case2d_v e₁ ≤ e₁ := by
+private lemma case2d_uv_le {e : ℕ} (hge : e ≥ 19) : case2d_u e + case2d_v e ≤ e := by
   grind [case2d_u, case2d_v]
 
 /-- The base pattern: three alternating bicolor intervals on {0,...,e₁-1}.
     Positions 0..u-1: alternating 0,1 (starts and ends with 0 since u is odd)
     Positions u..u+v-1: alternating 1,2 (starts and ends with 1)
     Positions u+v..e₁-1: alternating 2,0 (starts and ends with 2) -/
-private def basePattern (e₁ : ℕ) (j : ℕ) : Fin 3 := let u := case2d_u e₁
-  let v := case2d_v e₁
+private def basePattern (e : ℕ) (j : ℕ) : Fin 3 := let u := case2d_u e
+  let v := case2d_v e
   if j < u then if j % 2 = 0 then 0 else 1
   else if j < u + v then if (j - u) % 2 = 0 then 1 else 2
   else if (j - u - v) % 2 = 0 then 2 else 0
 
 /-- Which interval (0, 1, or 2) a position j falls in. -/
-private def whichInterval (e₁ j : ℕ) : Fin 3 := let u := case2d_u e₁
-  let v := case2d_v e₁
+private def whichInterval (e j : ℕ) : Fin 3 := let u := case2d_u e
+  let v := case2d_v e
   if j < u then 0 else if j < u + v then 1 else 2
 
 /-- The color pair for each interval. -/
@@ -518,76 +518,76 @@ private def intervalColors : Fin 3 → Finset (Fin 3)
 
 /-- Combined: for any j, {basePattern(j), basePattern(j+1 mod e₁)} is the
     interval pair of whichInterval(j). -/
-private lemma basePattern_consec_pair {e₁ j : ℕ} (he : Odd e₁) (hge : e₁ ≥ 19) (hj : j < e₁) :
-    intervalColors (whichInterval e₁ j) ⊆ {basePattern e₁ j, basePattern e₁ ((j + 1) % e₁)} := by
-  obtain ⟨ku, hku⟩ : Odd (case2d_u e₁) := by obtain ⟨k, hk⟩ := he; grind [case2d_u]
-  obtain ⟨kv, hkv⟩ : Odd (case2d_v e₁) := by obtain ⟨k, hk⟩ := he; grind [case2d_v]
-  obtain ⟨kw, hkw⟩ : Odd (e₁ - case2d_u e₁ - case2d_v e₁) := by
+private lemma basePattern_consec_pair {e j : ℕ} (he : Odd e) (hge : e ≥ 19) (hj : j < e) :
+    intervalColors (whichInterval e j) ⊆ {basePattern e j, basePattern e ((j + 1) % e)} := by
+  obtain ⟨ku, hku⟩ : Odd (case2d_u e) := by obtain ⟨k, hk⟩ := he; grind [case2d_u]
+  obtain ⟨kv, hkv⟩ : Odd (case2d_v e) := by obtain ⟨k, hk⟩ := he; grind [case2d_v]
+  obtain ⟨kw, hkw⟩ : Odd (e - case2d_u e - case2d_v e) := by
     obtain ⟨k, hk⟩ := he; grind [case2d_u, case2d_v]
   have huv := case2d_uv_le hge
-  by_cases hj1 : j + 1 < e₁
+  by_cases hj1 : j + 1 < e
   · rw [Nat.mod_eq_of_lt hj1]
-    by_cases hsame : whichInterval e₁ j = whichInterval e₁ (j + 1)
+    by_cases hsame : whichInterval e j = whichInterval e (j + 1)
     · -- Same interval: both colors present
-      have : {basePattern e₁ j, basePattern e₁ (j + 1)} = intervalColors (whichInterval e₁ j) := by
+      have : {basePattern e j, basePattern e (j + 1)} = intervalColors (whichInterval e j) := by
         simp only [whichInterval, basePattern, intervalColors] at *; grind
       exact this.ge
     · -- Boundary: last element of interval + first of next
-      have : intervalColors (whichInterval e₁ j) ⊆ {basePattern e₁ j, basePattern e₁ (j + 1)} := by
+      have : intervalColors (whichInterval e j) ⊆ {basePattern e j, basePattern e (j + 1)} := by
         simp only [whichInterval] at hsame ⊢
         grind [basePattern, intervalColors]
       exact this
-  · -- Wrap: j = e₁ - 1
+  · -- Wrap: j = e - 1
     push_neg at hj1
-    have hj_eq : j = e₁ - 1 := by grind
+    have hj_eq : j = e - 1 := by grind
     subst hj_eq
-    have : e₁ - 1 + 1 = e₁ := by grind
+    have : e - 1 + 1 = e := by grind
     rw [this, Nat.mod_self]
-    have : intervalColors (whichInterval e₁ (e₁ - 1)) ⊆
-        {basePattern e₁ (e₁ - 1), basePattern e₁ 0} := by
+    have : intervalColors (whichInterval e (e - 1)) ⊆
+        {basePattern e (e - 1), basePattern e 0} := by
       simp only [whichInterval]
       grind [basePattern, intervalColors]
     exact this
 
 /-- A rotation by r ∈ [u, e₁-u] moves to a different interval:
     whichInterval(j) ≠ whichInterval((j + r) % e₁). -/
-private lemma rotation_changes_interval {e₁ j : ℕ} (hge : e₁ ≥ 19) (hj : j < e₁)
-    {r : ℕ} (hr_lo : case2d_u e₁ ≤ r) (hr_hi : r ≤ e₁ - case2d_u e₁) :
-    whichInterval e₁ j ≠ whichInterval e₁ ((j + r) % e₁) := by
-  have he₁_pos : 0 < e₁ := by grind
+private lemma rotation_changes_interval {e j : ℕ} (hge : e ≥ 19) (hj : j < e)
+    {r : ℕ} (hr_lo : case2d_u e ≤ r) (hr_hi : r ≤ e - case2d_u e) :
+    whichInterval e j ≠ whichInterval e ((j + r) % e) := by
+  have he_pos : 0 < e := by grind
   have huv_bound := case2d_uv_le hge
-  have hv_le_u : case2d_v e₁ ≤ case2d_u e₁ := by grind [case2d_u, case2d_v]
-  have hw_le_u : e₁ - (case2d_u e₁ + case2d_v e₁) ≤ case2d_u e₁ := by grind [case2d_u, case2d_v]
+  have hv_le_u : case2d_v e ≤ case2d_u e := by grind [case2d_u, case2d_v]
+  have hw_le_u : e - (case2d_u e + case2d_v e) ≤ case2d_u e := by grind [case2d_u, case2d_v]
   simp only [whichInterval]
-  have hj'_lt : (j + r) % e₁ < e₁ := Nat.mod_lt _ he₁_pos
+  have hj'_lt : (j + r) % e < e := Nat.mod_lt _ he_pos
   intro heq
-  by_cases hjr_wrap : j + r < e₁
+  by_cases hjr_wrap : j + r < e
   · -- No wrap
     rw [Nat.mod_eq_of_lt hjr_wrap] at heq hj'_lt
     grind
-  · -- Wrap: (j + r) % e₁ = j + r - e₁
+  · -- Wrap: (j + r) % e = j + r - e
     push_neg at hjr_wrap
-    have hmod : (j + r) % e₁ = j + r - e₁ := by
-      have : r < e₁ := by grind
-      have h1 : j + r - e₁ < e₁ := by grind
+    have hmod : (j + r) % e = j + r - e := by
+      have : r < e := by grind
+      have h1 : j + r - e < e := by grind
       rw [Nat.add_mod_eq_sub, Nat.mod_eq_of_lt hj, Nat.mod_eq_of_lt this, if_neg (by grind)]
     grind
 
 /-- Key polychromaticity lemma: if the base pattern is rotated by r ∈ [u, e₁-u],
     then at every position j, the 2×2 block covers all 3 colors. -/
-private lemma basePattern_rotation_covers {e₁ j : ℕ} (he : Odd e₁) (hge : e₁ ≥ 19)
-    {r : ℕ} (hr_lo : case2d_u e₁ ≤ r) (hr_hi : r ≤ e₁ - case2d_u e₁) (hj : j < e₁) :
-    ∀ k : Fin 3, k ∈ ({basePattern e₁ j, basePattern e₁ ((j + 1) % e₁),
-        basePattern e₁ ((j + r) % e₁),
-        basePattern e₁ ((j + r + 1) % e₁)} : Finset (Fin 3)) := by
+private lemma basePattern_rotation_covers {e j : ℕ} (he : Odd e) (hge : e ≥ 19)
+    {r : ℕ} (hr_lo : case2d_u e ≤ r) (hr_hi : r ≤ e - case2d_u e) (hj : j < e) :
+    ∀ k : Fin 3, k ∈ ({basePattern e j, basePattern e ((j + 1) % e),
+        basePattern e ((j + r) % e),
+        basePattern e ((j + r + 1) % e)} : Finset (Fin 3)) := by
   intro k
-  have he₁_pos : 0 < e₁ := by grind
+  have he_pos : 0 < e := by grind
   have hI := rotation_changes_interval hge hj hr_lo hr_hi
   have h1 := basePattern_consec_pair he hge hj
-  have hjr : (j + r) % e₁ < e₁ := Nat.mod_lt _ he₁_pos
+  have hjr : (j + r) % e < e := Nat.mod_lt _ he_pos
   have h2 := basePattern_consec_pair he hge hjr
-  -- Rewrite ((j + r) % e₁ + 1) % e₁ = (j + r + 1) % e₁
-  have hmod : ((j + r) % e₁ + 1) % e₁ = (j + r + 1) % e₁ := Nat.mod_add_mod (j + r) e₁ 1
+  -- Rewrite ((j + r) % e + 1) % e = (j + r + 1) % e
+  have hmod : ((j + r) % e + 1) % e = (j + r + 1) % e := Nat.mod_add_mod (j + r) e 1
   rw [hmod] at h2
   have : ∀ (i₁ i₂ : Fin 3), i₁ ≠ i₂ → k ∈ intervalColors i₁ ∨ k ∈ intervalColors i₂ := by
     intro i₁ i₂; fin_cases i₁ <;> fin_cases i₂ <;> fin_cases k <;>
@@ -668,61 +668,60 @@ private lemma orbitEquiv_snd_shift_ba_wrap [NeZero m] [NeZero d₁] [NeZero e₁
 
 /-- Given d₁ ≥ 3 values each in [u, e₁-u] can sum to any target mod e₁,
     since the range has width ≥ e₁/3 and d₁ ≥ 3. -/
-private lemma case2d_rotation_sum_exists {e₁ d₁ : ℕ} [NeZero d₁]
-    (hd1_ge : d₁ ≥ 5) (he1_ge : e₁ ≥ 19) (he1_odd : Odd e₁) (target : ℕ) :
-    ∃ vals : ZMod d₁ → ℕ,
-      (∀ i, case2d_u e₁ ≤ vals i ∧ vals i ≤ e₁ - case2d_u e₁) ∧
-      (Finset.univ.sum vals) % e₁ = target % e₁ := by
-  have hu_lt : case2d_u e₁ < e₁ := by grind [case2d_u]
-  have hdw' : d₁ * (e₁ - 2 * case2d_u e₁) ≥ e₁ := by
-    change d₁ * (e₁ - 2 * (e₁ / 3 + e₁ % 3)) ≥ e₁
-    obtain ⟨k, hk⟩ := he1_odd; subst hk
+private lemma case2d_rotation_sum_exists {e d : ℕ} [NeZero d]
+    (hd_ge : d ≥ 5) (he_ge : e ≥ 19) (he_odd : Odd e) (target : ℕ) :
+    ∃ vals : ZMod d → ℕ,
+      (∀ i, case2d_u e ≤ vals i ∧ vals i ≤ e - case2d_u e) ∧
+      (Finset.univ.sum vals) % e = target % e := by
+  have hu_lt : case2d_u e < e := by grind [case2d_u]
+  have hdw' : d * (e - 2 * case2d_u e) ≥ e := by
+    change d * (e - 2 * (e / 3 + e % 3)) ≥ e
+    obtain ⟨k, hk⟩ := he_odd; subst hk
     have h5w : 5 * ((2 * k + 1) - 2 * ((2 * k + 1) / 3 + (2 * k + 1) % 3)) ≥ 2 * k + 1 := by grind
     exact le_trans h5w (by gcongr)
-  set u := case2d_u e₁
-  set w := e₁ - 2 * u
+  set u := case2d_u e
+  set w := e - 2 * u
   have hw_pos : 0 < w := by grind
-  set deficit := (target + e₁ * d₁ - d₁ * u) % e₁
-  have hdef_lt : deficit < e₁ := Nat.mod_lt _ (by grind)
+  set deficit := (target + e * d - d * u) % e
+  have hdef_lt : deficit < e := Nat.mod_lt _ (by grind)
   set q := deficit / w
   set r := deficit % w
   have hr_lt : r < w := Nat.mod_lt _ hw_pos
-  have hq_lt : q < d₁ := by
+  have hq_lt : q < d := by
     by_contra! hge
-    have h1 : deficit ≥ d₁ * w :=
+    have h1 : deficit ≥ d * w :=
       calc deficit ≥ deficit / w * w := Nat.div_mul_le_self deficit w
         _ = q * w := rfl
-        _ ≥ d₁ * w := by gcongr
+        _ ≥ d * w := by gcongr
     grind
   have hqr : w * q + r = deficit := Nat.div_add_mod deficit w
-  let f : ZMod d₁ → ℕ := fun i => if i.val < q then e₁ - u else if i.val = q then u + r else u
+  let f : ZMod d → ℕ := fun i => if i.val < q then e - u else if i.val = q then u + r else u
   refine ⟨f, fun i => ?_, ?_⟩
   · grind
-  · let g : ZMod d₁ → ℕ := fun i =>
+  · let g : ZMod d → ℕ := fun i =>
       if i.val < q then w else if i.val = q then r else 0
-    have hfg : ∀ i : ZMod d₁, f i = u + g i := by grind
-    have hsum_f : Finset.univ.sum f = d₁ * u + Finset.univ.sum g := by
+    have hfg : ∀ i : ZMod d, f i = u + g i := by grind
+    have hsum_f : Finset.univ.sum f = d * u + Finset.univ.sum g := by
       conv_lhs => arg 2; ext i; rw [hfg i]
       simp [Finset.sum_add_distrib, Finset.card_univ, ZMod.card]
-    -- Helper: #{i : ZMod d₁ | p(i)} for decidable predicates on ZMod.val
-    have hcard_lt : (Finset.univ.filter (fun i : ZMod d₁ => i.val < q)).card = q := by
-      have : Finset.image ZMod.val (Finset.univ.filter (fun i : ZMod d₁ => i.val < q)) =
+    have hcard_lt : (Finset.univ.filter (fun i : ZMod d => i.val < q)).card = q := by
+      have : Finset.image ZMod.val (Finset.univ.filter (fun i : ZMod d => i.val < q)) =
           Finset.range q := by
         ext j
         simp only [mem_image, mem_filter, mem_univ, true_and, mem_range]
-        exact ⟨fun ⟨_, hx, he⟩ => he ▸ hx, fun hj => ⟨(j : ZMod d₁),
+        exact ⟨fun ⟨_, hx, he⟩ => he ▸ hx, fun hj => ⟨(j : ZMod d),
           by rwa [ZMod.val_natCast_of_lt (lt_trans hj hq_lt)],
           ZMod.val_natCast_of_lt (lt_trans hj hq_lt)⟩⟩
       rw [← Finset.card_image_of_injective _ (ZMod.val_injective _), this, Finset.card_range]
-    have hcard_eq : (Finset.univ.filter (fun i : ZMod d₁ => i.val = q)).card = 1 := by
-      have : Finset.univ.filter (fun i : ZMod d₁ => i.val = q) = {(q : ZMod d₁)} := by
+    have hcard_eq : (Finset.univ.filter (fun i : ZMod d => i.val = q)).card = 1 := by
+      have : Finset.univ.filter (fun i : ZMod d => i.val = q) = {(q : ZMod d)} := by
         ext i
         simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_singleton]
         exact ⟨fun h => ZMod.val_injective _ (by rwa [ZMod.val_natCast_of_lt hq_lt]),
           fun h => by rw [h, ZMod.val_natCast_of_lt hq_lt]⟩
       rw [this, Finset.card_singleton]
     have hsum_g : Finset.univ.sum g = q * w + r := by
-      have : ∀ i : ZMod d₁,
+      have : ∀ i : ZMod d,
           g i = (if i.val < q then w else 0) + (if i.val = q then r else 0) := by grind
       rw [Finset.sum_congr rfl (fun i _ => this i), Finset.sum_add_distrib]
       simp only [Finset.sum_ite, Finset.sum_const_zero, add_zero, Finset.sum_const,
@@ -730,7 +729,7 @@ private lemma case2d_rotation_sum_exists {e₁ d₁ : ℕ} [NeZero d₁]
     rw [hsum_f, hsum_g, Nat.mul_comm q w, hqr]
     simp only [deficit]
     rw [Nat.add_mod_mod]
-    rw [Nat.add_sub_cancel' (le_add_left (le_trans (Nat.mul_le_mul_left d₁ (le_of_lt hu_lt))
+    rw [Nat.add_sub_cancel' (le_add_left (le_trans (Nat.mul_le_mul_left d (le_of_lt hu_lt))
       (by rw [Nat.mul_comm]))), Nat.add_mul_mod_self_left]
 
 private lemma zero_mem_zmod_set (m : ℕ) (a b : ℤ) : (0 : ZMod m) ∈ zmod_set m a b := by
@@ -788,19 +787,17 @@ private lemma case2d_coloring_works (hm : m ≥ 289)
     (hd1_odd : Odd (Nat.gcd b.natAbs m)) (he1_odd : Odd (m / Nat.gcd b.natAbs m))
     (he1_ge : m / Nat.gcd b.natAbs m ≥ 19) (h3 : ¬ (3 ∣ Nat.gcd b.natAbs m)) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
-  set d₁ := Nat.gcd b.natAbs m with hd1_def
-  set e₁ := m / d₁ with he1_def
-  have hd1_dvd : d₁ ∣ m := Nat.gcd_dvd_right _ _
-  have hm_eq : m = d₁ * e₁ := (Nat.mul_div_cancel' hd1_dvd).symm
+  have hd₁_dvd : d₁ ∣ m := Nat.gcd_dvd_right _ _
+  have hm_eq : m = d₁ * e₁ := (Nat.mul_div_cancel' hd₁_dvd).symm
   haveI : NeZero m := ⟨by grind⟩
   haveI : NeZero d₁ := ⟨by grind⟩
   haveI : NeZero e₁ := ⟨by grind⟩
-  have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind) hd1_def
-  have hb_zero : (b : ZMod d₁) = 0 := b_zero_mod_d1 hd1_def
-  have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 hd1_dvd (by rwa [hd1_def]))
+  have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind) rfl
+  have hb_zero : (b : ZMod d₁) = 0 := b_zero_mod_d1 rfl
+  have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 hd₁_dvd h_gcd_coprime)
   have he1_b_zero : e₁ • (b : ZMod m) = 0 := hord ▸ addOrderOf_nsmul_eq_zero _
   let Φ := orbitEquiv hm_eq hb_zero hba_unit hord
-  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hd1_dvd hb_zero hba_unit hord hm_eq
+  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hd₁_dvd hb_zero hba_unit hord hm_eq
   have hd1_ge5 : d₁ ≥ 5 := by grind
   obtain ⟨vals, hvals_bound, hvals_sum⟩ := case2d_rotation_sum_exists hd1_ge5 he1_ge he1_odd k₀.val
   let rot : ZMod d₁ → ℕ := fun i =>
@@ -860,19 +857,17 @@ lemma case_two_odd_small (hm : m ≥ 289)
     (hd1_odd : Odd (Nat.gcd b.natAbs m)) (_he1_odd : Odd (m / Nat.gcd b.natAbs m))
     (_he1_le : m / Nat.gcd b.natAbs m ≤ 17) (he1_div3 : 3 ∣ m / Nat.gcd b.natAbs m) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
-  set d₁ := Nat.gcd b.natAbs m with hd1_def
-  set e₁ := m / d₁ with he1_def
-  have hd1_dvd : d₁ ∣ m := Nat.gcd_dvd_right _ _
-  have hm_eq : m = d₁ * e₁ := (Nat.mul_div_cancel' hd1_dvd).symm
+  have hd₁_dvd : d₁ ∣ m := Nat.gcd_dvd_right _ _
+  have hm_eq : m = d₁ * e₁ := (Nat.mul_div_cancel' hd₁_dvd).symm
   haveI : NeZero m := ⟨by grind⟩
   haveI : NeZero d₁ := ⟨by grind⟩
   haveI : NeZero e₁ := ⟨by grind⟩
-  have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind) hd1_def
-  have hb_zero : (b : ZMod d₁) = 0 := b_zero_mod_d1 hd1_def
-  have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 hd1_dvd (by rwa [hd1_def]))
+  have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind) rfl
+  have hb_zero : (b : ZMod d₁) = 0 := b_zero_mod_d1 rfl
+  have hba_unit := isUnit_intCast_of_natAbs_coprime (ba_coprime_d1 hd₁_dvd h_gcd_coprime)
   have he1_b_zero : e₁ • (b : ZMod m) = 0 := hord ▸ addOrderOf_nsmul_eq_zero _
   let Φ := orbitEquiv hm_eq hb_zero hba_unit hord
-  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hd1_dvd hb_zero hba_unit hord hm_eq
+  obtain ⟨k₀, hk₀⟩ := case2d_wrap_shift hd₁_dvd hb_zero hba_unit hord hm_eq
   have hd1_ge3 : d₁ ≥ 3 := by grind
   let f : ZMod d₁ × ZMod e₁ → Fin 3 := fun ⟨i, j⟩ =>
     ⟨(j.val + (case2c_pattern d₁ k₀.val i.val).val) % 3, Nat.mod_lt _ (by grind)⟩
@@ -925,16 +920,15 @@ lemma case_two_odd_small (hm : m ≥ 289)
         simp only [case2c_mod3 he1_div3, Nat.add_assoc])
 
 /-- Auxiliary: rules out both cycle lengths being ≤ 17 when m ≥ 289. -/
-private lemma no_both_e_small {m d₁ d₂ : ℕ} (hm : m ≥ 289) (hcop : Nat.gcd d₁ d₂ = 1)
-    (hd₁_gt1 : d₁ > 1) (hd₂_gt1 : d₂ > 1) (hd₁_dvd : d₁ ∣ m) (hd₂_dvd : d₂ ∣ m)
-    (he₁_le : m / d₁ ≤ 17) (he₂_le : m / d₂ ≤ 17) : False := by
+private lemma no_both_e_small {m' d d' : ℕ} (hm : m' ≥ 289) (hcop : Nat.gcd d d' = 1)
+    (hd_gt1 : d > 1) (hd'_gt1 : d' > 1) (hd_dvd : d ∣ m') (hd'_dvd : d' ∣ m')
+    (he_le : m' / d ≤ 17) (he'_le : m' / d' ≤ 17) : False := by
   have hprod := Nat.le_of_dvd (by grind)
-    (Nat.Coprime.mul_dvd_of_dvd_of_dvd (by rwa [Nat.Coprime]) hd₁_dvd hd₂_dvd)
-  have h₁ : m ≤ d₁ * 17 := by rw [← Nat.mul_div_cancel' hd₁_dvd]; gcongr
-  have h₂ : m ≤ d₂ * 17 := by rw [← Nat.mul_div_cancel' hd₂_dvd]; gcongr
-  -- d₁*d₂ ≤ m ≤ d₁*17 → d₂ ≤ 17; similarly d₁ ≤ 17
+    (Nat.Coprime.mul_dvd_of_dvd_of_dvd (by rwa [Nat.Coprime]) hd_dvd hd'_dvd)
+  have h₁ : m' ≤ d * 17 := by rw [← Nat.mul_div_cancel' hd_dvd]; gcongr
+  have h₂ : m' ≤ d' * 17 := by rw [← Nat.mul_div_cancel' hd'_dvd]; gcongr
   have := Nat.le_of_mul_le_mul_left (hprod.trans h₁) (by grind)
-  have := Nat.le_of_mul_le_mul_left (mul_comm d₁ d₂ ▸ hprod.trans h₂) (by grind)
+  have := Nat.le_of_mul_le_mul_left (mul_comm d d' ▸ hprod.trans h₂) (by grind)
   -- 289 ≤ m ≤ d₁*17 → d₁ ≥ 17; similarly d₂ ≥ 17
   -- So d₁ = d₂ = 17, gcd(17,17) = 17 ≠ 1.
   grind
@@ -979,22 +973,22 @@ lemma main_case_two (hm : m ≥ 289)
         · exact dispatch a b h_gcd_coprime h_min hd ho h3
       -- Prove dispatch: given ¬(3 ∣ d₁), split on e₁ size
       intro a' b' hcop hmin hd₁_odd he₁_odd h3_nd₁
-      set d₁ := Nat.gcd b'.natAbs m
+      set d := Nat.gcd b'.natAbs m
       set d₂ := Nat.gcd (b' - a').natAbs m
-      set e₁ := m / d₁
-      have hd₁_dvd : d₁ ∣ m := Nat.gcd_dvd_right _ _
+      set e := m / d
+      have hd_dvd : d ∣ m := Nat.gcd_dvd_right _ _
       have hd₂_dvd : d₂ ∣ m := Nat.gcd_dvd_right _ _
-      by_cases he_le : e₁ ≤ 17
-      · -- Case 2c: prove 3 ∣ e₁
-        -- Since gcd(d₁,d₂)=1 and 3 ∤ d₁, if 3 ∣ d₂ then 3 ∣ m hence 3 ∣ e₁.
+      by_cases he_le : e ≤ 17
+      · -- Case 2c: prove 3 ∣ e
+        -- Since gcd(d,d₂)=1 and 3 ∤ d, if 3 ∣ d₂ then 3 ∣ m hence 3 ∣ e.
         -- If 3 ∤ d₂: swap and show e₂ ≥ 19 (contradiction with both ≤ 17).
         by_cases h3d₂ : 3 ∣ d₂
         · have h3m : 3 ∣ m := dvd_trans h3d₂ hd₂_dvd
-          have h3e₁ : 3 ∣ e₁ :=
+          have h3e : 3 ∣ e :=
             ((Nat.Prime.coprime_iff_not_dvd (by decide)).mpr h3_nd₁).dvd_of_dvd_mul_left
-              (Nat.mul_div_cancel' hd₁_dvd ▸ h3m)
-          exact case_two_odd_small hm hcop hmin hd₁_odd he₁_odd he_le h3e₁
-        · -- 3 ∤ d₁ and 3 ∤ d₂ and e₁ ≤ 17: swap and show new e₁ ≥ 19.
+              (Nat.mul_div_cancel' hd_dvd ▸ h3m)
+          exact case_two_odd_small hm hcop hmin hd₁_odd he₁_odd he_le h3e
+        · -- 3 ∤ d and 3 ∤ d₂ and e ≤ 17: swap and show new e ≥ 19.
           -- After swap, new e₁' = m/d₂. If e₁' ≤ 17 too, contradiction.
           rw [← zmod_set_swap m a' b']
           set a'' := (-a' : ℤ); set b'' := (b' - a' : ℤ)
@@ -1010,10 +1004,10 @@ lemma main_case_two (hm : m ≥ 289)
               have he₁'_ge : m / Nat.gcd b''.natAbs m ≥ 19 := by
                 by_contra hlt; push_neg at hlt
                 rw [Nat.gcd_comm] at hcop
-                exact no_both_e_small hm hcop (by grind) (by grind) hd₂_dvd hd₁_dvd (by grind) he_le
+                exact no_both_e_small hm hcop (by grind) (by grind) hd₂_dvd hd_dvd (by grind) he_le
               exact case2d_coloring_works hm hcop' hmin' hd' ho' he₁'_ge h3d₂
-      · have he₁_ge : e₁ ≥ 19 := by grind
-        exact case2d_coloring_works hm hcop hmin hd₁_odd he₁_odd he₁_ge h3_nd₁
+      · have he_ge : e ≥ 19 := by grind
+        exact case2d_coloring_works hm hcop hmin hd₁_odd he₁_odd he_ge h3_nd₁
 
 end OrbitFramework
 

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -41,14 +41,14 @@ private lemma intCast_2ba_eq :
 private lemma ZMod.val_add_one {n : ℕ} [NeZero n] (x : ZMod n) : (x + 1).val = (x.val + 1) % n := by
   rw [ZMod.val_add, ZMod.val_one_eq_one_mod, Nat.add_mod_mod]
 
-private lemma zmod_val_add_one (d : ℕ) [NeZero d] (_hd : d ≥ 2) (i : ZMod d) :
+private lemma zmod_val_add_one (d : ℕ) [NeZero d] (i : ZMod d) :
     (i + 1).val = if i.val + 1 < d then i.val + 1 else 0 := by
   rw [ZMod.val_add_one]; split_ifs with h
   · exact Nat.mod_eq_of_lt h
   · grind [Nat.mod_self]
 
-private lemma parity_flip_even (e : ℕ) [NeZero e] (he : Even e) (he2 : e ≥ 2)
-    (j : ZMod e) : j.val % 2 ≠ (j + 1).val % 2 := by grind [zmod_val_add_one e he2 j]
+private lemma parity_flip_even (e : ℕ) [NeZero e] (he : Even e)
+    (j : ZMod e) : j.val % 2 ≠ (j + 1).val % 2 := by grind [zmod_val_add_one e j]
 
 /--
 A coloring for Case 2a ($e_1$ even).
@@ -322,7 +322,7 @@ lemma case_two_e1_even (hm : m ≥ 289)
     grind
   exact orbit_coloring_polychrom Φ orbitEquiv_shift_b orbitEquiv_cycle_shift
     (cycle_coloring d₁ e₁)
-    (fun n k => color_covers_even d₁ e₁ hd₁_ge2 (parity_flip_even e₁ he1_even he₁_ge2) _ _ _ k)
+    (fun n k => color_covers_even d₁ e₁ hd₁_ge2 (parity_flip_even e₁ he1_even) _ _ _ k)
 
 /-! ### Subcase (2b) construction: d₁ even, e₁ odd
 
@@ -351,7 +351,8 @@ private lemma case2b_coverage_gen (d e : ℕ) [NeZero d] [NeZero e]
     k = case2b_coloring d e (i, j₁ + 1) ∨
     k = case2b_coloring d e (i + 1, j₂) ∨
     k = case2b_coloring d e (i + 1, j₂ + 1) := by
-  grind [case2b_coloring, Fin.ext_iff, zmod_val_add_one, parity_flip_even]
+  grind [case2b_coloring, zmod_val_add_one e j₁, zmod_val_add_one e j₂,
+    parity_flip_even d hd_even i]
 
 /-! ### Subcase (2b) main lemma -/
 

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -27,6 +27,7 @@ section Case2_MultipleCycles
 variable {m : ℕ} {a b : ℤ}
 
 local notation "d₁" => Nat.gcd b.natAbs m
+local notation "d₂" => Nat.gcd (Int.natAbs (b - a)) m
 local notation "e₁" => m / d₁
 
 /-! ### Arithmetic helpers for cycle decomposition
@@ -100,7 +101,7 @@ private lemma b_zero_mod_d1 [NeZero d₁] : (b : ZMod d₁) = 0 := by
   exact Int.natCast_dvd.mpr (Nat.gcd_dvd_left b.natAbs m)
 
 private lemma ba_coprime_d1
-    (h_gcd_coprime : Nat.gcd d₁ (Nat.gcd (b - a).natAbs m) = 1) :
+    (h_gcd_coprime : Nat.gcd d₁ d₂ = 1) :
     Nat.Coprime (b - a).natAbs d₁ :=
   Nat.dvd_one.mp (h_gcd_coprime ▸ Nat.dvd_gcd (Nat.gcd_dvd_right _ _)
       (Nat.dvd_gcd (Nat.gcd_dvd_left _ _) (dvd_trans (Nat.gcd_dvd_right _ _) d₁_dvd_m)))
@@ -299,8 +300,8 @@ private lemma orbit_coloring_polychrom
 /-- **Subcase (2a).** $e_1$ is even. Each cycle uses two alternating colors;
     adjacent cycles skip different colors. The simplest of the four subcases. -/
 lemma case_two_e1_even (hm : m ≥ 289)
-    (h_gcd_coprime : Nat.gcd d₁ (Nat.gcd (b - a).natAbs m) = 1)
-    (h_min : min d₁ (Nat.gcd (b - a).natAbs m) > 1)
+    (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
+    (h_min : min d₁ d₂ > 1)
     (he1_even : Even e₁) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
@@ -358,8 +359,8 @@ private lemma case2b_coverage_gen (d e : ℕ) [NeZero d] [NeZero e]
     Alternating patterns with a "degenerate" position fixup at different positions
     for even and odd cycles, ensuring they do not overlap across adjacent cycles. -/
 lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
-    (h_gcd_coprime : Nat.gcd d₁ (Nat.gcd (b - a).natAbs m) = 1)
-    (h_min : min d₁ (Nat.gcd (b - a).natAbs m) > 1)
+    (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
+    (h_min : min d₁ d₂ > 1)
     (hd1_even : Even d₁) (he1_odd : Odd e₁) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
@@ -367,7 +368,7 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
   have he₁_ge3 : e₁ ≥ 3 := by
     by_contra! h
     rcases (by grind : e₁ = 1 ∨ e₁ = 2) with he | he
-    · have : Nat.gcd (b - a).natAbs m ∣ d₁ := by
+    · have : d₂ ∣ d₁ := by
         have : m = d₁ := by have := hm_eq; rw [he, mul_one] at this; exact this
         rw [← this]; exact Nat.gcd_dvd_right _ _
       exact absurd (Nat.eq_one_of_dvd_one
@@ -382,11 +383,10 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289)
   have hord : addOrderOf (b : ZMod m) = e₁ := addOrderOf_b_eq (by grind)
   let Φ := orbitEquiv hm_eq hb_zero hba_unit hord
   -- d₂ properties for the compatibility argument
-  set d₂ := Nat.gcd (b - a).natAbs m
   have hd₂_dvd : d₂ ∣ m := Nat.gcd_dvd_right _ _
   have hd₂_gt1 : d₂ > 1 := by grind
   have hd₂_dvd_ba : (d₂ : ℤ) ∣ (b - a) := by
-    simpa [Int.gcd, d₂] using Int.gcd_dvd_left (b - a) (m : ℤ)
+    simpa [Int.gcd] using Int.gcd_dvd_left (b - a) (m : ℤ)
   have hd₂_dvd_e₁ : d₂ ∣ e₁ := by
     exact (by rwa [Nat.Coprime, Nat.gcd_comm] : Nat.Coprime d₂ d₁).dvd_of_dvd_mul_right
       (mul_comm d₁ e₁ ▸ hm_eq ▸ hd₂_dvd)
@@ -780,8 +780,8 @@ private lemma pos_shift_wrap' (j S V k₀ n : ℕ) (hsum : (S + V) % n = k₀ % 
 /-- **Subcase (2d) assembled.** Constructs the coloring for the case when both d₁
     and e₁ are odd with e₁ ≥ 19, using rotated interval patterns. -/
 private lemma case2d_coloring_works (hm : m ≥ 289)
-    (h_gcd_coprime : Nat.gcd d₁ (Nat.gcd (b - a).natAbs m) = 1)
-    (h_min : min d₁ (Nat.gcd (b - a).natAbs m) > 1)
+    (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
+    (h_min : min d₁ d₂ > 1)
     (hd1_odd : Odd d₁) (he1_odd : Odd e₁)
     (he1_ge : e₁ ≥ 19) (h3 : ¬ (3 ∣ d₁)) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
@@ -849,8 +849,8 @@ private lemma case2c_mod3 (h3e : 3 ∣ e₁) (x y : ℕ) : (x % e₁ + y) % 3 = 
 /-- **Subcase (2c):** d₁ and e₁ are both odd, with e₁ ≤ 17 and 3 ∣ e₁.
     Uses shifted periodic 012-patterns with different shifts for adjacent cycles. -/
 lemma case_two_odd_small (hm : m ≥ 289)
-    (h_gcd_coprime : Nat.gcd d₁ (Nat.gcd (b - a).natAbs m) = 1)
-    (h_min : min d₁ (Nat.gcd (b - a).natAbs m) > 1)
+    (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
+    (h_min : min d₁ d₂ > 1)
     (hd1_odd : Odd d₁)
     (he1_div3 : 3 ∣ e₁) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
@@ -934,8 +934,8 @@ private lemma no_both_e_small {m' d d' : ℕ} (hm : m' ≥ 289) (hcop : Nat.gcd 
 /-- **Main Case 2 (Multiple Cycles).** Aggregates all subcases (2a)–(2d).
     First applies WLOG to ensure 3 ∤ d₁, then dispatches on parity of d₁ and e₁. -/
 lemma main_case_two (hm : m ≥ 289)
-    (h_gcd_coprime : Nat.gcd d₁ (Nat.gcd (b - a).natAbs m) = 1)
-    (h_min : min d₁ (Nat.gcd (b - a).natAbs m) > 1) :
+    (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
+    (h_min : min d₁ d₂ > 1) :
     HasPolychromColouring (Fin 3) (zmod_set m a b) := by
   rcases Nat.even_or_odd e₁ with he | ho
   · exact case_two_e1_even hm h_gcd_coprime h_min he
@@ -970,15 +970,15 @@ lemma main_case_two (hm : m ≥ 289)
       -- Prove dispatch: given ¬(3 ∣ d₁), split on e₁ size
       intro a' b' hcop hmin hd₁_odd he₁_odd h3_nd₁
       set d := Nat.gcd b'.natAbs m
-      set d₂ := Nat.gcd (b' - a').natAbs m
+      set d₂' := Nat.gcd (b' - a').natAbs m
       set e := m / d
       have hd_dvd : d ∣ m := Nat.gcd_dvd_right _ _
-      have hd₂_dvd : d₂ ∣ m := Nat.gcd_dvd_right _ _
+      have hd₂_dvd : d₂' ∣ m := Nat.gcd_dvd_right _ _
       by_cases he_le : e ≤ 17
       · -- Case 2c: prove 3 ∣ e
-        -- Since gcd(d,d₂)=1 and 3 ∤ d, if 3 ∣ d₂ then 3 ∣ m hence 3 ∣ e.
-        -- If 3 ∤ d₂: swap and show e₂ ≥ 19 (contradiction with both ≤ 17).
-        by_cases h3d₂ : 3 ∣ d₂
+        -- Since gcd(d,d₂')=1 and 3 ∤ d, if 3 ∣ d₂' then 3 ∣ m hence 3 ∣ e.
+        -- If 3 ∤ d₂': swap and show e₂ ≥ 19 (contradiction with both ≤ 17).
+        by_cases h3d₂ : 3 ∣ d₂'
         · have h3m : 3 ∣ m := dvd_trans h3d₂ hd₂_dvd
           have h3e : 3 ∣ e :=
             ((Nat.Prime.coprime_iff_not_dvd (by decide)).mpr h3_nd₁).dvd_of_dvd_mul_left

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -229,8 +229,7 @@ private lemma orbitEquiv_cycle_shift [NeZero m] {hba_unit : IsUnit ((b - a : ℤ
   rw [hΦ_cycle (x + ↑(b - a))]
   dsimp only [α]
   rw [cycle_index_shift_ba u_ba hu_ba]
-  congr 1
-  exact (hΦ_cycle x).symm
+  grind
 
 /-- In the non-wrap case, the second coordinate is preserved by the (b-a) shift. -/
 private lemma orbitEquiv_snd_shift_ba [NeZero m] {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
@@ -243,8 +242,7 @@ private lemma orbitEquiv_snd_shift_ba [NeZero m] {hba_unit : IsUnit ((b - a : �
   have hn : Φ (i, j) = n := Prod.eta (Φ.symm n) ▸ Equiv.apply_symm_apply Φ n
   have hΦ : Φ (i + 1, j) = n + ↑(b - a) := by
     simp only [Φ, orbitEquiv, Equiv.ofBijective_apply] at hn ⊢
-    rw [← hn]
-    exact hshift.symm
+    grind
   have h : Φ.symm (n + ↑(b - a)) = (i + 1, j) := by rw [← hΦ, Φ.symm_apply_apply]
   rw [h]
 
@@ -337,7 +335,7 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d�
     by_contra! h
     rcases (by grind : e₁ = 1 ∨ e₁ = 2) with he | he
     · have : d₂ ∣ d₁ := by
-        have : m = d₁ := by have := hm_eq; rw [he, mul_one] at this; exact this
+        have : m = d₁ := by grind
         rw [← this]
         exact Nat.gcd_dvd_right _ _
       exact absurd (Nat.eq_one_of_dvd_one
@@ -395,13 +393,8 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d�
       set p := Φ.symm n
       set j := p.2
       set j' := (Φ.symm (n + ↑(b - a))).2
-      have hπn : π n = (j.val : ZMod d₂) * π (↑b) := by
-        have : n = Φ p := (Equiv.apply_symm_apply Φ n).symm
-        grind
-      have hπn' : π n = (j'.val : ZMod d₂) * π (↑b) := by
-        rw [← hπ_eq]
-        have : n + ↑(b - a) = Φ (Φ.symm (n + ↑(b - a))) := (Equiv.apply_symm_apply Φ _).symm
-        grind
+      have hπn : π n = (j.val : ZMod d₂) * π (↑b) := by grind
+      have hπn' : π n = (j'.val : ZMod d₂) * π (↑b) := by grind
       have hπ_jj' := hπn.symm.trans hπn'
       exact case2b_coverage_gen d₁ e₁ hd1_even he1_odd he₁_ge3 _ j j'
         (fun hj hj' => h_degenerate_false j j' hπ_jj' hj hj')
@@ -616,10 +609,8 @@ private lemma orbitEquiv_snd_shift_ba_wrap [NeZero m]
   have hn : Φ (i, j) = n := Prod.eta (Φ.symm n) ▸ Equiv.apply_symm_apply Φ n
   have hΦ : Φ ((0 : ZMod d₁), j + k₀) = n + ↑(b - a) := by
     simp only [Φ, orbitEquiv, Equiv.ofBijective_apply] at hn ⊢
-    rw [← hn]
-    exact (hshift j).symm
-  have h : Φ.symm (n + ↑(b - a)) = (0, j + k₀) := by rw [← hΦ, Φ.symm_apply_apply]
-  rw [h]
+    grind
+  grind
 
 /-- Given d₁ ≥ 3 values each in [u, e₁-u] can sum to any target mod e₁,
     since the range has width ≥ e₁/3 and d₁ ≥ 3. -/

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -93,8 +93,7 @@ It provides the coordinate system used to analyze the "Multiple Cycles" case.
 private def orbitMap (m : ℕ) (a b : ℤ) : ZMod d₁ × ZMod e₁ → ZMod m :=
   fun p => (p.1.val : ZMod m) * ↑(b - a) + (p.2.val : ZMod m) * ↑b
 
-private lemma addOrderOf_b_eq [NeZero m] :
-    addOrderOf (b : ZMod m) = e₁ := by
+private lemma addOrderOf_b_eq [NeZero m] : addOrderOf (b : ZMod m) = e₁ := by
   have key : addOrderOf (b.natAbs : ZMod m) = e₁ := by
     rw [ZMod.addOrderOf_coe b.natAbs (NeZero.ne m), Nat.gcd_comm]
   rcases Int.natAbs_eq b with h | h
@@ -154,8 +153,7 @@ private lemma orbitMap_bijective [NeZero m] (hba_unit : IsUnit ((b - a : ℤ) : 
      by simp only [Fintype.card_prod, ZMod.card]; linarith [hm_eq]⟩
 
 private lemma orbitMap_shift_b [NeZero m] (he1_b_zero : e₁ • (b : ZMod m) = 0) :
-    ∀ p : ZMod d₁ × ZMod e₁,
-      orbitMap m a b p + (b : ZMod m) = orbitMap m a b (p.1, p.2 + 1) := by
+    ∀ p : ZMod d₁ × ZMod e₁, orbitMap m a b p + (b : ZMod m) = orbitMap m a b (p.1, p.2 + 1) := by
   intro ⟨i, j⟩
   simp only [orbitMap]
   by_cases hj : j.val + 1 < e₁
@@ -216,8 +214,7 @@ private noncomputable def orbitEquiv [NeZero m]
 private lemma orbitEquiv_shift_b [NeZero m] {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
     (x : ZMod m) :
     (orbitEquiv hba_unit).symm (x + ↑b) =
-    (((orbitEquiv hba_unit).symm x).1,
-     ((orbitEquiv hba_unit).symm x).2 + 1) := by
+    (((orbitEquiv hba_unit).symm x).1, ((orbitEquiv hba_unit).symm x).2 + 1) := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   exact equiv_symm_shift_b _ (fun i j =>
     (orbitMap_shift_b (addOrderOf_b_eq (b := b) (m := m) ▸
@@ -225,8 +222,7 @@ private lemma orbitEquiv_shift_b [NeZero m] {hba_unit : IsUnit ((b - a : ℤ) : 
 
 private lemma orbitEquiv_cycle_shift [NeZero m] {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
     (x : ZMod m) :
-    ((orbitEquiv hba_unit).symm (x + ↑(b - a))).1 =
-    ((orbitEquiv hba_unit).symm x).1 + 1 := by
+    ((orbitEquiv hba_unit).symm (x + ↑(b - a))).1 = ((orbitEquiv hba_unit).symm x).1 + 1 := by
   have hm_eq := m_eq_d₁_mul_e₁ (m := m) (b := b)
   let u_ba := hba_unit.choose
   have hu_ba : ↑u_ba = ((b - a : ℤ) : ZMod d₁) := hba_unit.choose_spec
@@ -242,15 +238,16 @@ private lemma orbitEquiv_cycle_shift [NeZero m] {hba_unit : IsUnit ((b - a : ℤ
 /-- In the non-wrap case, the second coordinate is preserved by the (b-a) shift. -/
 private lemma orbitEquiv_snd_shift_ba [NeZero m] {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
     (n : ZMod m) (hi : (orbitEquiv hba_unit).symm n |>.1.val + 1 < d₁) :
-    ((orbitEquiv hba_unit).symm (n + ↑(b - a))).2 =
-    ((orbitEquiv hba_unit).symm n).2 := by
+    ((orbitEquiv hba_unit).symm (n + ↑(b - a))).2 = ((orbitEquiv hba_unit).symm n).2 := by
   set Φ := orbitEquiv hba_unit
-  set i := (Φ.symm n).1; set j := (Φ.symm n).2
+  set i := (Φ.symm n).1
+  set j := (Φ.symm n).2
   have hshift := orbitMap_shift_ba (a := a) i j hi
   have hn : Φ (i, j) = n := Prod.eta (Φ.symm n) ▸ Equiv.apply_symm_apply Φ n
   have hΦ : Φ (i + 1, j) = n + ↑(b - a) := by
     simp only [Φ, orbitEquiv, Equiv.ofBijective_apply] at hn ⊢
-    rw [← hn]; exact hshift.symm
+    rw [← hn]
+    exact hshift.symm
   have h : Φ.symm (n + ↑(b - a)) = (i + 1, j) := by rw [← hΦ, Φ.symm_apply_apply]
   rw [h]
 
@@ -258,8 +255,7 @@ private lemma orbitEquiv_snd_shift_ba [NeZero m] {hba_unit : IsUnit ((b - a : �
     given an orbit equivalence Φ with shift properties and a coloring f,
     if f covers all colors at any translate, then f ∘ Φ.symm is polychromatic.
     All four Case 2 subcases use this as their final step. -/
-private lemma orbit_coloring_polychrom
-    (Φ : ZMod d₁ × ZMod e₁ ≃ ZMod m)
+private lemma orbit_coloring_polychrom (Φ : ZMod d₁ × ZMod e₁ ≃ ZMod m)
     (hΦ_add_b : ∀ x : ZMod m, Φ.symm (x + ↑b) = ((Φ.symm x).1, (Φ.symm x).2 + 1))
     (hΦ_cycle_shift : ∀ x : ZMod m, (Φ.symm (x + ↑(b - a))).1 = (Φ.symm x).1 + 1)
     (f : ZMod d₁ × ZMod e₁ → Fin 3) (hcovers : ∀ (n : ZMod m) (k : Fin 3),
@@ -272,7 +268,8 @@ private lemma orbit_coloring_polychrom
   refine ⟨χ, fun n k => ?_⟩
   simp only [zmod_set, Finset.image_insert, Finset.image_singleton,
     Finset.mem_insert, Finset.mem_singleton]
-  set i := (Φ.symm n).1; set j := (Φ.symm n).2
+  set i := (Φ.symm n).1
+  set j := (Φ.symm n).2
   set j' := (Φ.symm (n + ↑(b - a))).2
   have hχ_n : χ n = f (i, j) := rfl
   have hχ_nb : χ (n + ↑b) = f (i, j + 1) := congr_arg f (hΦ_add_b n)
@@ -319,10 +316,10 @@ private def case2b_coloring (d e : ℕ) : ZMod d × ZMod e → Fin 3 := fun ⟨i
 -- Coverage — any 2×2 block covers all 3 colors.
 -- The compatibility says degenerate positions can't coincide:
 -- odd-degenerate at j=0 and even-degenerate at j=e₁-2 are incompatible.
-private lemma case2b_coverage_gen (d e : ℕ) [NeZero d] [NeZero e]
-    (hd_even : Even d) (he_odd : Odd e) (he_ge3 : e ≥ 3) (i : ZMod d) (j₁ j₂ : ZMod e)
-    (h_compat : j₁.val = 0 → j₂.val ≠ e - 2) (h_compat' : j₂.val = 0 → j₁.val ≠ e - 2)
-    (k : Fin 3) :
+private lemma case2b_coverage_gen (d e : ℕ) [NeZero d] [NeZero e] (hd_even : Even d)
+    (he_odd : Odd e) (he_ge3 : e ≥ 3) (i : ZMod d) (j₁ j₂ : ZMod e)
+    (h_compat : j₁.val = 0 → j₂.val ≠ e - 2)
+    (h_compat' : j₂.val = 0 → j₁.val ≠ e - 2) (k : Fin 3) :
     k = case2b_coloring d e (i, j₁) ∨
     k = case2b_coloring d e (i, j₁ + 1) ∨
     k = case2b_coloring d e (i + 1, j₂) ∨
@@ -345,7 +342,8 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d�
     rcases (by grind : e₁ = 1 ∨ e₁ = 2) with he | he
     · have : d₂ ∣ d₁ := by
         have : m = d₁ := by have := hm_eq; rw [he, mul_one] at this; exact this
-        rw [← this]; exact Nat.gcd_dvd_right _ _
+        rw [← this]
+        exact Nat.gcd_dvd_right _ _
       exact absurd (Nat.eq_one_of_dvd_one
         (h_gcd_coprime ▸ Nat.dvd_gcd this (dvd_refl _))) (by grind)
     · grind
@@ -367,10 +365,12 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d�
     intro i j
     change π (orbitMap m a b (i, j)) = _
     simp only [orbitMap, π, map_add, map_mul, map_natCast, map_intCast]
-    rw [(ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mpr hd₂_dvd_ba]; ring
+    rw [(ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mpr hd₂_dvd_ba]
+    ring
   -- π(b) is a unit in ZMod d₂
   have hπ_b_unit : IsUnit (π (↑b)) := by
-    simp only [π, map_intCast]; exact isUnit_intCast_of_natAbs_coprime (by grind)
+    simp only [π, map_intCast]
+    exact isUnit_intCast_of_natAbs_coprime (by grind)
   -- Degenerate positions can't coincide: use d₂ | (j-j') from projection
   -- π(n+(b-a)) = π(n) since π(b-a)=0, combined with π(φ(i,j))=j.val*π(b)
   -- gives d₂ | (j.val - j'.val). Then d₂ | e₁ and d₂ > 1, so e₁-2 and 0
@@ -396,7 +396,8 @@ lemma case_two_d1_even_e1_odd (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d�
     rw [(ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mpr hd₂_dvd_ba, add_zero]
   exact orbit_coloring_polychrom Φ orbitEquiv_shift_b orbitEquiv_cycle_shift
     (case2b_coloring d₁ e₁) (fun n k => by
-      set p := Φ.symm n; set j := p.2
+      set p := Φ.symm n
+      set j := p.2
       set j' := (Φ.symm (n + ↑(b - a))).2
       have hπn : π n = (j.val : ZMod d₂) * π (↑b) := by
         have : n = Φ p := (Equiv.apply_symm_apply Φ n).symm
@@ -501,7 +502,8 @@ private lemma basePattern_consec_pair {e j : ℕ} (he : Odd e) (hge : e ≥ 19) 
     by_cases hsame : whichInterval e j = whichInterval e (j + 1)
     · -- Same interval: both colors present
       have : {basePattern e j, basePattern e (j + 1)} = intervalColors (whichInterval e j) := by
-        simp only [whichInterval, basePattern, intervalColors] at *; grind
+        simp only [whichInterval, basePattern, intervalColors] at *
+        grind
       exact this.ge
     · -- Boundary: last element of interval + first of next
       have : intervalColors (whichInterval e j) ⊆ {basePattern e j, basePattern e (j + 1)} := by
@@ -549,8 +551,7 @@ private lemma rotation_changes_interval {e j : ℕ} (hge : e ≥ 19) (hj : j < e
 private lemma basePattern_rotation_covers {e j : ℕ} (he : Odd e) (hge : e ≥ 19)
     {r : ℕ} (hr_lo : case2d_u e ≤ r) (hr_hi : r ≤ e - case2d_u e) (hj : j < e) :
     ∀ k : Fin 3, k ∈ ({basePattern e j, basePattern e ((j + 1) % e),
-        basePattern e ((j + r) % e),
-        basePattern e ((j + r + 1) % e)} : Finset (Fin 3)) := by
+        basePattern e ((j + r) % e), basePattern e ((j + r + 1) % e)} : Finset (Fin 3)) := by
   intro k
   have he_pos : 0 < e := by grind
   have hI := rotation_changes_interval hge hj hr_lo hr_hi
@@ -591,9 +592,8 @@ private lemma case2d_wrap_shift [NeZero m] (hba_unit : IsUnit ((b - a : ℤ) : Z
 
 private lemma case2d_shift_ba_wrap [NeZero m] (he1_b_zero : e₁ • (b : ZMod m) = 0)
     (k₀ : ZMod e₁) (hk₀ : (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m))
-    (i : ZMod d₁) (hi : i.val = d₁ - 1) :
-    ∀ (j : ZMod e₁), orbitMap m a b (i, j) + ((b - a : ℤ) : ZMod m) =
-        orbitMap m a b ((0 : ZMod d₁), j + k₀) := by
+    (i : ZMod d₁) (hi : i.val = d₁ - 1) : ∀ (j : ZMod e₁),
+    orbitMap m a b (i, j) + ((b - a : ℤ) : ZMod m) = orbitMap m a b ((0 : ZMod d₁), j + k₀) := by
   intro j
   simp only [orbitMap, ZMod.val_zero, Nat.cast_zero, zero_mul, zero_add]
   have hpred : (d₁ - 1 + 1 : ℕ) = d₁ := Nat.succ_pred (NeZero.ne d₁)
@@ -617,15 +617,16 @@ private lemma orbitEquiv_snd_shift_ba_wrap [NeZero m]
     {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)} (he1_b_zero : e₁ • (b : ZMod m) = 0)
     (k₀ : ZMod e₁) (hk₀ : (d₁ : ℕ) • ((b - a : ℤ) : ZMod m) = (k₀.val : ℕ) • (b : ZMod m))
     (n : ZMod m) (hi : (orbitEquiv hba_unit).symm n |>.1.val = d₁ - 1) :
-    ((orbitEquiv hba_unit).symm (n + ↑(b - a))).2 =
-    ((orbitEquiv hba_unit).symm n).2 + k₀ := by
+    ((orbitEquiv hba_unit).symm (n + ↑(b - a))).2 = ((orbitEquiv hba_unit).symm n).2 + k₀ := by
   set Φ := orbitEquiv hba_unit
-  set i := (Φ.symm n).1; set j := (Φ.symm n).2
+  set i := (Φ.symm n).1
+  set j := (Φ.symm n).2
   have hshift := case2d_shift_ba_wrap he1_b_zero k₀ hk₀ i hi
   have hn : Φ (i, j) = n := Prod.eta (Φ.symm n) ▸ Equiv.apply_symm_apply Φ n
   have hΦ : Φ ((0 : ZMod d₁), j + k₀) = n + ↑(b - a) := by
     simp only [Φ, orbitEquiv, Equiv.ofBijective_apply] at hn ⊢
-    rw [← hn]; exact (hshift j).symm
+    rw [← hn]
+    exact (hshift j).symm
   have h : Φ.symm (n + ↑(b - a)) = (0, j + k₀) := by rw [← hΦ, Φ.symm_apply_apply]
   rw [h]
 
@@ -702,7 +703,8 @@ private lemma zmod_filter_sum_succ {n : ℕ} [NeZero n] (f : ZMod n → ℕ) (i 
     (Finset.univ.filter (fun k : ZMod n => k.val < i.val)).sum f + f i := by
   have hsplit : Finset.univ.filter (fun k : ZMod n => k.val < i.val + 1) =
       Finset.univ.filter (fun k : ZMod n => k.val < i.val) ∪ {i} := by
-    ext k; simp only [Finset.mem_filter, Finset.mem_univ, true_and,
+    ext k
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and,
       Finset.mem_union, Finset.mem_singleton]
     grind [ZMod.val_injective]
   grind
@@ -752,7 +754,8 @@ private lemma case2d_coloring_works (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d�
   let f : ZMod d₁ × ZMod e₁ → Fin 3 := fun ⟨i, j⟩ =>
     basePattern e₁ ((j.val + rot i) % e₁)
   exact orbit_coloring_polychrom Φ orbitEquiv_shift_b orbitEquiv_cycle_shift f (fun n k => by
-    set i := (Φ.symm n).1; set j := (Φ.symm n).2
+    set i := (Φ.symm n).1
+    set j := (Φ.symm n).2
     set j' := (Φ.symm (n + ↑(b - a))).2
     set p := (j.val + rot i) % e₁ with hp_def
     have hp_lt : p < e₁ := Nat.mod_lt _ (NeZero.pos e₁)
@@ -811,7 +814,8 @@ lemma case_two_odd_small (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1
   let f : ZMod d₁ × ZMod e₁ → Fin 3 := fun ⟨i, j⟩ =>
     ⟨(j.val + (case2c_pattern d₁ k₀.val i.val).val) % 3, Nat.mod_lt _ (by grind)⟩
   exact orbit_coloring_polychrom Φ orbitEquiv_shift_b orbitEquiv_cycle_shift f (fun n k => by
-    set i := (Φ.symm n).1; set j := (Φ.symm n).2
+    set i := (Φ.symm n).1
+    set j := (Φ.symm n).2
     set j' := (Φ.symm (n + ↑(b - a))).2
     set p := case2c_pattern d₁ k₀.val i.val
     by_cases hi : i.val + 1 < d₁
@@ -898,7 +902,8 @@ lemma main_case_two (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
         by_cases h3 : 3 ∣ d₁
         · -- Swap roles of b and b-a
           rw [← zmod_set_swap m a b]
-          set a' := (-a : ℤ); set b' := (b - a : ℤ)
+          set a' := (-a : ℤ)
+          set b' := (b - a : ℤ)
           have hba_eq : (b' - a').natAbs = b.natAbs := by grind
           have hcop' : (Nat.gcd b'.natAbs m).gcd (Nat.gcd (b' - a').natAbs m) = 1 := by grind
           have hmin' : min (Nat.gcd b'.natAbs m) (Nat.gcd (b' - a').natAbs m) > 1 := by grind
@@ -931,7 +936,8 @@ lemma main_case_two (hm : m ≥ 289) (h_gcd_coprime : Nat.gcd d₁ d₂ = 1)
         · -- 3 ∤ d and 3 ∤ d₂ and e ≤ 17: swap and show new e ≥ 19.
           -- After swap, new e₁' = m/d₂. If e₁' ≤ 17 too, contradiction.
           rw [← zmod_set_swap m a' b']
-          set a'' := (-a' : ℤ); set b'' := (b' - a' : ℤ)
+          set a'' := (-a' : ℤ)
+          set b'' := (b' - a' : ℤ)
           have hba_eq : (b'' - a'').natAbs = b'.natAbs := by grind
           have hcop' : (Nat.gcd b''.natAbs m).gcd (Nat.gcd (b'' - a'').natAbs m) = 1 := by grind
           have hmin' : min (Nat.gcd b''.natAbs m) (Nat.gcd (b'' - a'').natAbs m) > 1 := by grind

--- a/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
+++ b/Lean/Polychromatic/FourThree/Combi/CaseTwo.lean
@@ -241,6 +241,25 @@ private lemma orbitEquiv_cycle_shift [NeZero m] {hm_eq : m = d₁ * e₁}
   congr 1
   exact (hΦ_cycle x).symm
 
+/-- In the non-wrap case, the second coordinate is preserved by the (b-a) shift. -/
+private lemma orbitEquiv_snd_shift_ba [NeZero m] [NeZero d₁]
+    {hm_eq : m = d₁ * e₁} {hb_zero : (b : ZMod d₁) = 0}
+    {hba_unit : IsUnit ((b - a : ℤ) : ZMod d₁)}
+    {hord : addOrderOf (b : ZMod m) = e₁}
+    (n : ZMod m) (hi : (orbitEquiv hm_eq hb_zero hba_unit hord).symm n |>.1.val + 1 < d₁) :
+    ((orbitEquiv hm_eq hb_zero hba_unit hord).symm (n + ↑(b - a))).2 =
+    ((orbitEquiv hm_eq hb_zero hba_unit hord).symm n).2 := by
+  set Φ := orbitEquiv hm_eq hb_zero hba_unit hord
+  set i := (Φ.symm n).1; set j := (Φ.symm n).2
+  have hshift := @orbitMap_shift_ba m a b d₁ e₁ ‹NeZero d₁› i j hi
+  have hn : Φ (i, j) = n := Prod.eta (Φ.symm n) ▸ Equiv.apply_symm_apply Φ n
+  have hΦ : Φ (i + 1, j) = n + ↑(b - a) := by
+    simp only [Φ, orbitEquiv, Equiv.ofBijective_apply] at hn ⊢
+    rw [← hn]; exact hshift.symm
+  have h := congrArg Prod.snd (show Φ.symm (n + ↑(b - a)) = (i + 1, j) by
+    rw [← hΦ, Φ.symm_apply_apply])
+  exact h
+
 /-- **Key infrastructure for Case 2.** Polychromaticity from an orbit coloring:
     given an orbit equivalence Φ with shift properties and a coloring f,
     if f covers all colors at any translate, then f ∘ Φ.symm is polychromatic.
@@ -787,15 +806,7 @@ private lemma case2d_coloring_works (hm : m ≥ 289)
           _ = ((j' + 1 : ZMod e₁).val + rot (i + 1)) % e₁ :=
               (pos_shift_one j' (rot (i + 1))).symm
     by_cases hi : i.val + 1 < d₁
-    · have hj'_eq : j' = j := by
-        have hshift := @orbitMap_shift_ba m a b d₁ e₁ ‹NeZero d₁› i j hi
-        have hn : Φ (i, j) = n := Prod.eta (Φ.symm n) ▸ Equiv.apply_symm_apply Φ n
-        have hΦ : Φ (i + 1, j) = n + ↑(b - a) := by
-          simp only [Φ, orbitEquiv, Equiv.ofBijective_apply] at hn ⊢
-          rw [← hn]; exact hshift.symm
-        have h := congrArg Prod.snd (show Φ.symm (n + ↑(b - a)) = (i + 1, j) by
-          rw [← hΦ, Φ.symm_apply_apply])
-        exact h
+    · have hj'_eq : j' = j := orbitEquiv_snd_shift_ba n hi
       rw [hj'_eq]
       change (j.val + ((Finset.univ.filter
         (fun k : ZMod d₁ => k.val < (i + 1).val)).sum vals) % e₁) % e₁ =
@@ -855,14 +866,7 @@ lemma case_two_odd_small (hm : m ≥ 289)
     set j' := (Φ.symm (n + ↑(b - a))).2
     set p := case2c_pattern d₁ k₀.val i.val
     by_cases hi : i.val + 1 < d₁
-    · have hj'_eq : j' = j := by
-        have hshift := @orbitMap_shift_ba m a b d₁ e₁ ‹NeZero d₁› i j hi
-        have hn : Φ (i, j) = n := Prod.eta (Φ.symm n) ▸ Equiv.apply_symm_apply Φ n
-        have : Φ (i + 1, j) = n + ↑(b - a) := by
-          simp only [Φ, orbitEquiv, Equiv.ofBijective_apply] at hn ⊢; rw [← hn]; exact hshift.symm
-        have h := congrArg Prod.snd (show Φ.symm (n + ↑(b - a)) = (i + 1, j) by
-          rw [← this, Φ.symm_apply_apply])
-        exact h
+    · have hj'_eq : j' = j := orbitEquiv_snd_shift_ba n hi
       rw [hj'_eq]
       set p' := case2c_pattern d₁ k₀.val (i + 1).val
       have hi'_eq : (i + 1).val = i.val + 1 := by


### PR DESCRIPTION
Extract the orbit equivalence construction into `orbitEquiv` with separate lemmas `orbitEquiv_shift_b` and `orbitEquiv_cycle_shift`. Apply to all four Case 2 subcases.

Currently a net +21 lines (37 lines of definitions vs 16 lines saved from the two cases using `orbit_coloring_polychrom`). The other two cases (2c, 2d) use `orbitEquiv` for consistency but don't save lines because they need `he1_b_zero` for forward-direction `orbitMap_shift_b` calls.

Depends on #153.

Prepared by Claude Code.