### PR TITLE
pin lean-action fork with cache-key fix

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -42,7 +42,9 @@ jobs:
         if: github.ref == 'refs/heads/main'
 
       - name: Build Lean files
-        uses: leanprover/lean-action@v1.5.0
+        # b-mehta/lean-action@d489e2d = v1.5.0 + cache-key fix (leanprover/lean-action#167);
+        # revert to leanprover/lean-action once the fix is released.
+        uses: b-mehta/lean-action@d489e2d808dacf725628cc11e07de9f6a875d7e7
         with:
           mk_all-check: true
           lake-package-directory: Lean
@@ -84,7 +86,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Build Lean files
-        uses: leanprover/lean-action@v1.5.0
+        # b-mehta/lean-action@d489e2d = v1.5.0 + cache-key fix (leanprover/lean-action#167);
+        # revert to leanprover/lean-action once the fix is released.
+        uses: b-mehta/lean-action@d489e2d808dacf725628cc11e07de9f6a875d7e7
         with:
           mk_all-check: true
           lake-package-directory: Lean


### PR DESCRIPTION
The make-docs job's GitHub cache key didn't include the toolchain or manifest hash, because lean-action computes them from the repo root while our Lake package lives under `Lean/`. That made the restore-key version-agnostic, so a stale `.lake` from an older Mathlib gets restored and `lake exe cache get` then fails trying to check Mathlib out to the new revision — which is what broke make-docs on the v4.30 bump.

This pins lean-action to a fork carrying the fix (leanprover/lean-action#167) until it's released upstream, at which point we switch back to the official action.
